### PR TITLE
Fix self-hosted runner linux builds OOM

### DIFF
--- a/.github/runs-on.yml
+++ b/.github/runs-on.yml
@@ -1,7 +1,7 @@
 runners:
   self-hosted-ubuntu-22.04-x86-64:
     cpu: [16, 32, 64]
-    ram: [64, 128]
+    ram: [32, 64, 128]
     disk: default
     family: ["c7a", "c7i", "m7a", "m7i"]
     spot: capacity-optimized

--- a/.github/workflows/snapshot-build.yml
+++ b/.github/workflows/snapshot-build.yml
@@ -59,6 +59,16 @@ jobs:
               max-parallelism = 1
         if: github.repository_owner != 'autonomys'
 
+      # This is to manage the concurrency of the builds and prevent self-hosted runners from running out of memory
+      - name: Set up Docker Buildx (self-hosted runner)
+        uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.7.1
+        with:
+          # Limit concurrency so it can reduce the likelihood of running out of memory
+          buildkitd-config-inline: |
+            [worker.oci]
+              max-parallelism = 3
+        if: github.repository_owner == 'autonomys'
+
       - name: Log into registry
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
         with:


### PR DESCRIPTION
This reverts the changes done in #3413 and adds a section for self-hosted runners explicitly to limit the parallelism/concurrency of builds for different architectures. It will result in slower build time, but we won't be wasting runners resources.

### Code contributor checklist:
* [X] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
