### PR TITLE
Ignore RUSTSEC-2025-0009 which doesn't impact us in production

### DIFF
--- a/.github/workflows/rustsec-audit.yml
+++ b/.github/workflows/rustsec-audit.yml
@@ -21,4 +21,5 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           # TODO: Remove first once Substrate upgrades litep2p and we no longer have rustls 0.20.9 in our dependencies
-          ignore: RUSTSEC-2024-0336
+          # TODO: Remove second once Substrate upgrades litep2p and sc-network and we no longer have ring 0.16 in our dependencies
+          ignore: RUSTSEC-2024-0336, RUSTSEC-2025-0009


### PR DESCRIPTION
Our CI is currently failing due to RUSTSEC-2025-0009, which impacts users of `ring` with overflow checks on. We have overflow checks off in production and release builds (the default), so this doesn't impact us.

https://github.com/autonomys/subspace/pull/3420/checks?check_run_id=38349684685

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
