### PR TITLE
Introduce new fee calculator for evm domain and refactor eth constants to primitives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3482,7 +3482,6 @@ dependencies = [
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
  "pallet-balances",
- "pallet-base-fee",
  "pallet-block-fees",
  "pallet-domain-id",
  "pallet-domain-sudo",
@@ -3540,7 +3539,6 @@ dependencies = [
  "frame-system",
  "frame-system-rpc-runtime-api",
  "pallet-balances",
- "pallet-base-fee",
  "pallet-block-fees",
  "pallet-domain-id",
  "pallet-domain-sudo",
@@ -8234,20 +8232,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pallet-base-fee"
-version = "1.0.0"
-source = "git+https://github.com/autonomys/frontier?rev=986eb1ad6ec69c16d05d142b7e731b4b69e3b409#986eb1ad6ec69c16d05d142b7e731b4b69e3b409"
-dependencies = [
- "fp-evm",
- "frame-support",
- "frame-system",
- "parity-scale-codec",
- "scale-info",
- "sp-core",
- "sp-runtime",
-]
-
-[[package]]
 name = "pallet-block-fees"
 version = "0.1.0"
 dependencies = [
@@ -8447,8 +8431,10 @@ dependencies = [
  "domain-runtime-primitives",
  "frame-support",
  "frame-system",
+ "pallet-block-fees",
  "pallet-ethereum",
  "pallet-evm",
+ "pallet-transaction-payment",
  "pallet-utility",
  "parity-scale-codec",
  "scale-info",
@@ -12975,10 +12961,12 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "domain-runtime-primitives",
+ "frame-support",
  "parity-scale-codec",
  "sp-api",
  "sp-domains",
  "sp-inherents",
+ "sp-weights",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,7 +108,6 @@ num_cpus = "1.16.0"
 ouroboros = "0.18.4"
 pallet-auto-id = { version = "0.1.0", path = "domains/pallets/auto-id", default-features = false }
 pallet-balances = { git = "https://github.com/subspace/polkadot-sdk", rev = "949bb3cfb64ab974e4fc49328fb3e81c96bc0fbe", default-features = false }
-pallet-base-fee = { version = "1.0.0-dev", git = "https://github.com/autonomys/frontier", rev = "986eb1ad6ec69c16d05d142b7e731b4b69e3b409", default-features = false }
 pallet-block-fees = { version = "0.1.0", path = "domains/pallets/block-fees", default-features = false }
 pallet-collective = { git = "https://github.com/subspace/polkadot-sdk", rev = "949bb3cfb64ab974e4fc49328fb3e81c96bc0fbe", default-features = false }
 pallet-democracy = { git = "https://github.com/subspace/polkadot-sdk", rev = "949bb3cfb64ab974e4fc49328fb3e81c96bc0fbe", default-features = false }

--- a/crates/subspace-runtime-primitives/src/lib.rs
+++ b/crates/subspace-runtime-primitives/src/lib.rs
@@ -218,7 +218,7 @@ parameter_types! {
 
 /// Parameterized slow adjusting fee updated based on
 /// <https://research.web3.foundation/Polkadot/overview/token-economics#2-slow-adjusting-mechanism>
-pub type SlowAdjustingFeeUpdate<R> = TargetedFeeAdjustment<
+pub type SlowAdjustingFeeUpdate<R, TargetBlockFullness> = TargetedFeeAdjustment<
     R,
     TargetBlockFullness,
     AdjustmentVariable,

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -102,9 +102,9 @@ use subspace_core_primitives::{PublicKey, Randomness, SlotNumber, U256};
 use subspace_runtime_primitives::utility::{DefaultNonceProvider, MaybeIntoUtilityCall};
 use subspace_runtime_primitives::{
     maximum_normal_block_length, AccountId, Balance, BlockNumber, FindBlockRewardAddress, Hash,
-    HoldIdentifier, Moment, Nonce, Signature, SlowAdjustingFeeUpdate, BLOCK_WEIGHT_FOR_2_SEC,
-    DOMAINS_BLOCK_PRUNING_DEPTH, MAX_BLOCK_LENGTH, MIN_REPLICATION_FACTOR, NORMAL_DISPATCH_RATIO,
-    SHANNON, SLOT_PROBABILITY, SSC,
+    HoldIdentifier, Moment, Nonce, Signature, SlowAdjustingFeeUpdate, TargetBlockFullness,
+    BLOCK_WEIGHT_FOR_2_SEC, DOMAINS_BLOCK_PRUNING_DEPTH, MAX_BLOCK_LENGTH, MIN_REPLICATION_FACTOR,
+    NORMAL_DISPATCH_RATIO, SHANNON, SLOT_PROBABILITY, SSC,
 };
 
 sp_runtime::impl_opaque_keys! {
@@ -399,7 +399,7 @@ impl pallet_transaction_payment::Config for Runtime {
     type OperationalFeeMultiplier = ConstU8<5>;
     type WeightToFee = ConstantMultiplier<Balance, TransactionWeightFee>;
     type LengthToFee = ConstantMultiplier<Balance, TransactionByteFee>;
-    type FeeMultiplierUpdate = SlowAdjustingFeeUpdate<Runtime>;
+    type FeeMultiplierUpdate = SlowAdjustingFeeUpdate<Runtime, TargetBlockFullness>;
     type WeightInfo = pallet_transaction_payment::weights::SubstrateWeight<Runtime>;
 }
 

--- a/domains/client/domain-operator/src/tests.rs
+++ b/domains/client/domain-operator/src/tests.rs
@@ -1308,7 +1308,7 @@ async fn test_evm_domain_gas_estimates() {
                         create_info.used_gas.effective,
                     ),
                     // The exact estimate is not important, but we want to know if it changes
-                    (4_326_280.into(), 4_326_280.into()),
+                    (53_408.into(), 53_408.into()),
                     "Incorrect EVM Create gas estimate: {:?} {:?}",
                     evm_call,
                     create_info,
@@ -1363,7 +1363,6 @@ async fn test_evm_domain_gas_estimates() {
         .runtime_api()
         .gas_price(alice.client.info().best_hash)
         .unwrap();
-
     // Estimates
     let evm_nonce = alice
         .client
@@ -1473,7 +1472,7 @@ async fn test_evm_domain_gas_estimates() {
         // Check the actual block fees for an EVM contract create
         BlockFees {
             consensus_storage_fee: 789,
-            domain_execution_fee: 10_815_700_000_631,
+            domain_execution_fee: 10_813_273_629_579_568,
             burned_balance: 0,
             chain_rewards: [].into(),
         }
@@ -1520,7 +1519,7 @@ async fn test_evm_domain_gas_estimates() {
         // Check the actual block fees for an EVM contract call
         BlockFees {
             consensus_storage_fee: 849,
-            domain_execution_fee: 10_815_700_000_651,
+            domain_execution_fee: 10_812_720_677_240_620,
             burned_balance: 0,
             chain_rewards: [].into(),
         }
@@ -8040,6 +8039,8 @@ async fn test_xdm_transfer_to_wrong_format_address() {
     .unwrap();
 }
 
+// TODO: ignore test until we bring back the best block number as starting nonce instead of 0.
+#[ignore]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_current_block_number_used_as_new_account_nonce() {
     let directory = TempDir::new().expect("Must be able to create temporary directory");

--- a/domains/pallets/evm-tracker/Cargo.toml
+++ b/domains/pallets/evm-tracker/Cargo.toml
@@ -19,6 +19,8 @@ frame-support.workspace = true
 frame-system.workspace = true
 pallet-ethereum.workspace = true
 pallet-evm.workspace = true
+pallet-block-fees.workspace = true
+pallet-transaction-payment.workspace = true
 pallet-utility.workspace = true
 scale-info = { workspace = true, features = ["derive"] }
 sp-core.workspace = true
@@ -37,6 +39,8 @@ std = [
     "frame-system/std",
     "pallet-ethereum/std",
     "pallet-evm/std",
+    "pallet-block-fees/std",
+    "pallet-transaction-payment/std",
     "pallet-utility/std",
     "scale-info/std",
     "sp-core/std",

--- a/domains/pallets/evm-tracker/src/fees.rs
+++ b/domains/pallets/evm-tracker/src/fees.rs
@@ -32,7 +32,7 @@ where
     fn min_gas_price() -> (U256, Weight) {
         // spread the storage fee across the gas price based on the Gas Per Byte.
         let storage_fee_per_gas =
-            BlockFees::<T>::final_domain_transaction_byte_fee().saturating_div(GasPerByte::get());
+            BlockFees::<T>::final_domain_transaction_byte_fee().div_ceil(GasPerByte::get());
         // adjust the fee per weight using the multiplier
         let weight_fee = TransactionWeightFee::get().saturating_mul(WEIGHT_PER_GAS.into());
         let adjusted_weight_fee =

--- a/domains/pallets/evm-tracker/src/fees.rs
+++ b/domains/pallets/evm-tracker/src/fees.rs
@@ -1,0 +1,61 @@
+//! Fees module for EVM domain
+
+use crate::Config;
+use core::marker::PhantomData;
+use domain_runtime_primitives::Balance;
+use pallet_block_fees::Pallet as BlockFees;
+use pallet_evm::FeeCalculator;
+use pallet_transaction_payment::Pallet as TransactionPayment;
+use sp_core::U256;
+use sp_evm_tracker::WEIGHT_PER_GAS;
+use sp_runtime::traits::Get;
+use sp_runtime::{FixedPointNumber, Perbill};
+use sp_weights::Weight;
+
+/// Evm gas price calculator for EVM domains.
+/// TransactionWeightFee is the fee for 1 unit of Weight.
+/// GasPerByte is the gas for 1 byte
+pub struct EvmGasPriceCalculator<T, TransactionWeightFee, GasPerByte, StorageFeePercent>(
+    PhantomData<(T, TransactionWeightFee, GasPerByte, StorageFeePercent)>,
+);
+
+impl<T, TransactionWeightFee, GasPerByte, StorageFeePercent> FeeCalculator
+    for EvmGasPriceCalculator<T, TransactionWeightFee, GasPerByte, StorageFeePercent>
+where
+    T: Config
+        + frame_system::Config
+        + pallet_transaction_payment::Config
+        + pallet_block_fees::Config<Balance = Balance>,
+    TransactionWeightFee: Get<T::Balance>,
+    GasPerByte: Get<T::Balance>,
+{
+    fn min_gas_price() -> (U256, Weight) {
+        // spread the storage fee across the gas price based on the Gas Per Byte.
+        let storage_fee_per_gas =
+            BlockFees::<T>::final_domain_transaction_byte_fee().saturating_div(GasPerByte::get());
+        // adjust the fee per weight using the multiplier
+        let weight_fee = TransactionWeightFee::get().saturating_mul(WEIGHT_PER_GAS.into());
+        let adjusted_weight_fee =
+            TransactionPayment::<T>::next_fee_multiplier().saturating_mul_int(weight_fee);
+
+        // finally add the storage_fee_per_gas and adjusted_weight_fee to calculate the final
+        // min_gas_price.
+        let min_gas_price = adjusted_weight_fee.saturating_add(storage_fee_per_gas);
+        (
+            min_gas_price.into(),
+            <T as frame_system::Config>::DbWeight::get().reads(2),
+        )
+    }
+}
+
+impl<T, TransactionWeightFee, BytePerFee, StorageFeePercent>
+    EvmGasPriceCalculator<T, TransactionWeightFee, BytePerFee, StorageFeePercent>
+where
+    StorageFeePercent: Get<Perbill>,
+{
+    pub fn split_fee_into_storage_and_execution(fee: Balance) -> (Balance, Balance) {
+        let ratio = StorageFeePercent::get();
+        let storage_fee = ratio.mul_ceil(fee);
+        (storage_fee, fee.saturating_sub(storage_fee))
+    }
+}

--- a/domains/pallets/evm-tracker/src/lib.rs
+++ b/domains/pallets/evm-tracker/src/lib.rs
@@ -22,6 +22,7 @@ extern crate alloc;
 
 pub mod check_nonce;
 pub mod create_contract;
+pub mod fees;
 pub mod traits;
 
 pub use check_nonce::CheckNonce;

--- a/domains/primitives/evm-tracker/Cargo.toml
+++ b/domains/primitives/evm-tracker/Cargo.toml
@@ -14,19 +14,23 @@ include = [
 
 [dependencies]
 async-trait = { workspace = true, optional = true }
-parity-scale-codec = { workspace = true, features = ["derive"] }
 domain-runtime-primitives.workspace = true
+frame-support.workspace = true
+parity-scale-codec = { workspace = true, features = ["derive"] }
 sp-api.workspace = true
 sp-domains.workspace = true
 sp-inherents.workspace = true
+sp-weights.workspace = true
 
 [features]
 default = ["std"]
 std = [
     "async-trait",
-    "parity-scale-codec/std",
     "domain-runtime-primitives/std",
+    "frame-support/std",
+    "parity-scale-codec/std",
     "sp-api/std",
     "sp-domains/std",
     "sp-inherents/std",
+    "sp-weights/std"
 ]

--- a/domains/primitives/evm-tracker/src/lib.rs
+++ b/domains/primitives/evm-tracker/src/lib.rs
@@ -1,12 +1,40 @@
 //! Inherents for EVM tracker
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use domain_runtime_primitives::EthereumAccountId;
+use domain_runtime_primitives::{maximum_domain_block_weight, Balance, EthereumAccountId};
+use frame_support::parameter_types;
+use frame_support::sp_runtime::app_crypto::sp_core::U256;
+use frame_support::sp_runtime::Perbill;
 use parity_scale_codec::{Decode, Encode};
 use sp_domains::PermissionedActionAllowedBy;
 #[cfg(feature = "std")]
 use sp_inherents::{Error, InherentData};
 use sp_inherents::{InherentIdentifier, IsFatalError};
+use sp_weights::constants::WEIGHT_REF_TIME_PER_SECOND;
+use sp_weights::Weight;
+
+/// Current approximation of the gas/s consumption considering
+/// EVM execution over compiled WASM (on 4.4Ghz CPU).
+pub const GAS_PER_SECOND: u64 = 40_000_000;
+
+/// Approximate ratio of the amount of Weight per Gas.
+/// u64 works for approximations because Weight is a very small unit compared to gas.
+pub const WEIGHT_PER_GAS: u64 = WEIGHT_REF_TIME_PER_SECOND.saturating_div(GAS_PER_SECOND);
+
+parameter_types! {
+    pub const GasLimitPovSizeRatio: u64 = 4;
+    /// Gas per byte
+    /// Ethereum’s Yellow Paper states that it costs 20,000 gas to store one 256-bit word.
+    /// 1 Byte costs 20_000/32 = 625
+    pub const GasPerByte: Balance = 625;
+    /// Proportion of final (gas_price * gas_used) given as storage fee.
+    pub const StorageFeeRatio: Perbill = Perbill::from_percent(30);
+    /// EVM block gas limit is set to maximum to allow all the transaction stored on Consensus chain.
+    pub BlockGasLimit: U256 = U256::from(
+        maximum_domain_block_weight().ref_time() / WEIGHT_PER_GAS
+    );
+    pub WeightPerGas: Weight = Weight::from_parts(WEIGHT_PER_GAS, 0);
+}
 
 /// Executive inherent identifier.
 pub const INHERENT_IDENTIFIER: InherentIdentifier = *b"dmnevmtr";

--- a/domains/primitives/evm-tracker/src/lib.rs
+++ b/domains/primitives/evm-tracker/src/lib.rs
@@ -19,7 +19,7 @@ pub const GAS_PER_SECOND: u64 = 40_000_000;
 
 /// Approximate ratio of the amount of Weight per Gas.
 /// u64 works for approximations because Weight is a very small unit compared to gas.
-pub const WEIGHT_PER_GAS: u64 = WEIGHT_REF_TIME_PER_SECOND.saturating_div(GAS_PER_SECOND);
+pub const WEIGHT_PER_GAS: u64 = WEIGHT_REF_TIME_PER_SECOND.div_ceil(GAS_PER_SECOND);
 
 parameter_types! {
     pub const GasLimitPovSizeRatio: u64 = 4;

--- a/domains/primitives/runtime/src/lib.rs
+++ b/domains/primitives/runtime/src/lib.rs
@@ -31,11 +31,12 @@ use frame_system::limits::{BlockLength, BlockWeights};
 use parity_scale_codec::{Decode, Encode};
 use scale_info::TypeInfo;
 use serde::{Deserialize, Serialize};
+use sp_core::parameter_types;
 use sp_runtime::generic::{ExtensionVersion, Preamble, UncheckedExtrinsic};
 use sp_runtime::traits::transaction_extension::TransactionExtension;
 use sp_runtime::traits::{Convert, Dispatchable, IdentifyAccount, Verify};
 use sp_runtime::transaction_validity::TransactionValidityError;
-use sp_runtime::{MultiAddress, MultiSignature, Perbill};
+use sp_runtime::{MultiAddress, MultiSignature, Perbill, Perquintill};
 use sp_weights::constants::WEIGHT_REF_TIME_PER_SECOND;
 use sp_weights::Weight;
 pub use subspace_runtime_primitives::HoldIdentifier;
@@ -128,6 +129,12 @@ pub const DEFAULT_EXTENSION_VERSION: ExtensionVersion = 0;
 /// Storage duration (1 year) - It is theoretically unlimited, accounts will stay around while the chain is alive.
 /// Storage cost per year of (12 * 1e-9 * 0.1 ) - SSD storage on cloud hosting costs about 0.1 USD per Gb per month
 pub const EXISTENTIAL_DEPOSIT: Balance = 1_000_000_000_000 * SHANNON;
+
+parameter_types! {
+    /// The portion of the `NORMAL_DISPATCH_RATIO` that we adjust the fees with. Blocks filled less
+    /// than this will decrease the weight and more will increase.
+    pub const TargetBlockFullness: Perquintill = Perquintill::from_percent(25);
+}
 
 /// We assume that ~5% of the block weight is consumed by `on_initialize` handlers. This is
 /// used to limit the maximal weight of a single extrinsic.

--- a/domains/runtime/auto-id/src/lib.rs
+++ b/domains/runtime/auto-id/src/lib.rs
@@ -20,7 +20,7 @@ pub use domain_runtime_primitives::{
 };
 use domain_runtime_primitives::{
     AccountId, Address, CheckExtrinsicsValidityError, DecodeExtrinsicError, HoldIdentifier,
-    Signature, ERR_BALANCE_OVERFLOW, SLOT_DURATION,
+    Signature, TargetBlockFullness, ERR_BALANCE_OVERFLOW, SLOT_DURATION,
 };
 use frame_support::dispatch::{DispatchClass, DispatchInfo, GetDispatchInfo};
 use frame_support::genesis_builder_helper::{build_state, get_preset};
@@ -260,7 +260,7 @@ impl pallet_transaction_payment::Config for Runtime {
     type OnChargeTransaction = OnChargeDomainTransaction<Balances>;
     type WeightToFee = ConstantMultiplier<Balance, TransactionWeightFee>;
     type LengthToFee = ConstantMultiplier<Balance, FinalDomainTransactionByteFee>;
-    type FeeMultiplierUpdate = SlowAdjustingFeeUpdate<Runtime>;
+    type FeeMultiplierUpdate = SlowAdjustingFeeUpdate<Runtime, TargetBlockFullness>;
     type OperationalFeeMultiplier = OperationalFeeMultiplier;
     type WeightInfo = pallet_transaction_payment::weights::SubstrateWeight<Runtime>;
 }

--- a/domains/runtime/evm/Cargo.toml
+++ b/domains/runtime/evm/Cargo.toml
@@ -29,7 +29,6 @@ frame-system.workspace = true
 frame-system-benchmarking = { workspace = true, optional = true }
 frame-system-rpc-runtime-api.workspace = true
 pallet-balances.workspace = true
-pallet-base-fee.workspace = true
 pallet-block-fees.workspace = true
 pallet-domain-id.workspace = true
 pallet-domain-sudo.workspace = true
@@ -92,7 +91,6 @@ std = [
     "frame-system/std",
     "frame-system-rpc-runtime-api/std",
     "pallet-balances/std",
-    "pallet-base-fee/std",
     "pallet-domain-id/std",
     "pallet-domain-sudo/std",
     "pallet-block-fees/std",

--- a/domains/runtime/evm/src/lib.rs
+++ b/domains/runtime/evm/src/lib.rs
@@ -23,8 +23,8 @@ pub use domain_runtime_primitives::{
 };
 use domain_runtime_primitives::{
     AccountId20, CheckExtrinsicsValidityError, DecodeExtrinsicError, HoldIdentifier,
-    DEFAULT_EXTENSION_VERSION, ERR_BALANCE_OVERFLOW, ERR_CONTRACT_CREATION_NOT_ALLOWED,
-    ERR_NONCE_OVERFLOW, MAX_OUTGOING_MESSAGES, SLOT_DURATION,
+    TargetBlockFullness, DEFAULT_EXTENSION_VERSION, ERR_BALANCE_OVERFLOW,
+    ERR_CONTRACT_CREATION_NOT_ALLOWED, ERR_NONCE_OVERFLOW, MAX_OUTGOING_MESSAGES, SLOT_DURATION,
 };
 use fp_self_contained::{CheckedSignature, SelfContainedCall};
 use frame_support::dispatch::{DispatchClass, DispatchInfo, GetDispatchInfo};
@@ -36,7 +36,7 @@ use frame_support::traits::{
     ConstU16, ConstU32, ConstU64, Currency, Everything, FindAuthor, Imbalance, OnFinalize,
     OnUnbalanced, VariantCount,
 };
-use frame_support::weights::constants::{ParityDbWeight, WEIGHT_REF_TIME_PER_SECOND};
+use frame_support::weights::constants::ParityDbWeight;
 use frame_support::weights::{ConstantMultiplier, Weight};
 use frame_support::{construct_runtime, parameter_types};
 use frame_system::limits::{BlockLength, BlockWeights};
@@ -59,6 +59,9 @@ use sp_core::{Get, OpaqueMetadata, H160, H256, U256};
 use sp_domains::{
     ChannelId, DomainAllowlistUpdates, DomainId, PermissionedActionAllowedBy, Transfers,
 };
+use sp_evm_tracker::{
+    BlockGasLimit, GasLimitPovSizeRatio, GasPerByte, StorageFeeRatio, WeightPerGas,
+};
 use sp_messenger::endpoint::{Endpoint, EndpointHandler as EndpointHandlerT, EndpointId};
 use sp_messenger::messages::{
     BlockMessagesWithStorageKey, ChainId, CrossDomainMessage, FeeModel, MessageId, MessageKey,
@@ -75,7 +78,6 @@ use sp_runtime::traits::{
 use sp_runtime::transaction_validity::{
     InvalidTransaction, TransactionSource, TransactionValidity, TransactionValidityError,
 };
-use sp_runtime::type_with_default::TypeWithDefault;
 use sp_runtime::{
     generic, impl_opaque_keys, ApplyExtrinsicResult, ConsensusEngineId, Digest,
     ExtrinsicInclusionMode,
@@ -91,7 +93,7 @@ use sp_subspace_mmr::domain_mmr_runtime_interface::{
 use sp_subspace_mmr::{ConsensusChainMmrLeafProof, MmrLeaf};
 use sp_version::RuntimeVersion;
 use static_assertions::const_assert;
-use subspace_runtime_primitives::utility::{DefaultNonceProvider, MaybeIntoUtilityCall};
+use subspace_runtime_primitives::utility::MaybeIntoUtilityCall;
 use subspace_runtime_primitives::{
     BlockNumber as ConsensusBlockNumber, Hash as ConsensusBlockHash, Moment,
     SlowAdjustingFeeUpdate, SHANNON, SSC,
@@ -202,24 +204,8 @@ impl fp_self_contained::SelfContainedCall for RuntimeCall {
             .into()));
         }
 
-        // TODO: move this code into pallet-block-fees, so it can be used from the production and
-        // test runtimes.
         match self {
-            RuntimeCall::Ethereum(call) => {
-                // Ensure the caller can pay for the consensus chain storage fee
-                let consensus_storage_fee = match consensus_storage_fee(len) {
-                    Ok(fee) => fee,
-                    Err(err) => return Some(Err(err)),
-                };
-                let withdraw_res = <InnerEVMCurrencyAdapter as pallet_evm::OnChargeEVMTransaction<
-                    Runtime,
-                >>::withdraw_fee(info, consensus_storage_fee.into());
-                if withdraw_res.is_err() {
-                    return Some(Err(InvalidTransaction::Payment.into()));
-                }
-
-                call.validate_self_contained(info, dispatch_info, len)
-            }
+            RuntimeCall::Ethereum(call) => call.validate_self_contained(info, dispatch_info, len),
             _ => None,
         }
     }
@@ -241,23 +227,6 @@ impl fp_self_contained::SelfContainedCall for RuntimeCall {
         // test runtimes.
         match self {
             RuntimeCall::Ethereum(call) => {
-                // Withdraw the consensus chain storage fee from the caller and record
-                // it in the `BlockFees`
-                let consensus_storage_fee = match consensus_storage_fee(len) {
-                    Ok(fee) => fee,
-                    Err(err) => return Some(Err(err)),
-                };
-                match <InnerEVMCurrencyAdapter as pallet_evm::OnChargeEVMTransaction<Runtime>>::withdraw_fee(
-                    info,
-                    consensus_storage_fee.into(),
-                ) {
-                    Ok(None) => {}
-                    Ok(Some(paid_consensus_storage_fee)) => {
-                        BlockFees::note_consensus_storage_fee(paid_consensus_storage_fee.peek())
-                    }
-                    Err(_) => return Some(Err(InvalidTransaction::Payment.into())),
-                }
-
                 // Copied from [`pallet_ethereum::Call::pre_dispatch_self_contained`] with `frame_system::CheckWeight`
                 // replaced with `domain_check_weight::CheckWeight`
                 if let pallet_ethereum::Call::transact { transaction } = call {
@@ -343,7 +312,7 @@ impl frame_system::Config for Runtime {
     /// The lookup mechanism to get account ID from whatever is passed in dispatchers.
     type Lookup = IdentityLookup<AccountId>;
     /// The type for storing how many extrinsics an account has signed.
-    type Nonce = TypeWithDefault<Nonce, DefaultNonceProvider<System, Nonce>>;
+    type Nonce = Nonce;
     /// The type for hashing blocks and tries.
     type Hash = Hash;
     /// The hashing algorithm used.
@@ -432,7 +401,7 @@ impl pallet_balances::Config for Runtime {
 
 parameter_types! {
     pub const OperationalFeeMultiplier: u8 = 5;
-    pub const DomainChainByteFee: Balance = 1;
+    pub const DomainChainByteFee: Balance = 100_000 * SHANNON;
     pub TransactionWeightFee: Balance = 100_000 * SHANNON;
 }
 
@@ -456,7 +425,7 @@ impl pallet_transaction_payment::Config for Runtime {
     type OnChargeTransaction = OnChargeDomainTransaction<Balances>;
     type WeightToFee = ConstantMultiplier<Balance, TransactionWeightFee>;
     type LengthToFee = ConstantMultiplier<Balance, FinalDomainTransactionByteFee>;
-    type FeeMultiplierUpdate = SlowAdjustingFeeUpdate<Runtime>;
+    type FeeMultiplierUpdate = SlowAdjustingFeeUpdate<Runtime, TargetBlockFullness>;
     type OperationalFeeMultiplier = OperationalFeeMultiplier;
     type WeightInfo = pallet_transaction_payment::weights::SubstrateWeight<Runtime>;
 }
@@ -666,21 +635,8 @@ impl FindAuthor<H160> for FindAuthorTruncated {
     }
 }
 
-/// Current approximation of the gas/s consumption considering
-/// EVM execution over compiled WASM (on 4.4Ghz CPU).
-pub const GAS_PER_SECOND: u64 = 40_000_000;
-
-/// Approximate ratio of the amount of Weight per Gas.
-/// u64 works for approximations because Weight is a very small unit compared to gas.
-pub const WEIGHT_PER_GAS: u64 = WEIGHT_REF_TIME_PER_SECOND.saturating_div(GAS_PER_SECOND);
-
 parameter_types! {
-    /// EVM block gas limit is set to maximum to allow all the transaction stored on Consensus chain.
-    pub BlockGasLimit: U256 = U256::from(
-        maximum_domain_block_weight().ref_time() / WEIGHT_PER_GAS
-    );
     pub PrecompilesValue: Precompiles = Precompiles::default();
-    pub WeightPerGas: Weight = Weight::from_parts(WEIGHT_PER_GAS, 0);
 }
 
 type InnerEVMCurrencyAdapter = pallet_evm::EVMCurrencyAdapter<Balances, ()>;
@@ -707,8 +663,13 @@ impl pallet_evm::OnChargeEVMTransaction<Runtime> for EVMCurrencyAdapter {
         already_withdrawn: Self::LiquidityInfo,
     ) -> Self::LiquidityInfo {
         if already_withdrawn.is_some() {
-            // Record the evm actual transaction fee
-            BlockFees::note_domain_execution_fee(corrected_fee.as_u128());
+            // Record the evm actual transaction fee and storage fee
+            let (storage_fee, execution_fee) =
+                EvmGasPriceCalculator::split_fee_into_storage_and_execution(
+                    corrected_fee.as_u128(),
+                );
+            BlockFees::note_consensus_storage_fee(storage_fee);
+            BlockFees::note_domain_execution_fee(execution_fee);
         }
 
         <InnerEVMCurrencyAdapter as pallet_evm::OnChargeEVMTransaction<
@@ -723,12 +684,16 @@ impl pallet_evm::OnChargeEVMTransaction<Runtime> for EVMCurrencyAdapter {
     }
 }
 
-parameter_types! {
-    pub const GasLimitPovSizeRatio: u64 = 4;
-}
+pub type EvmGasPriceCalculator = pallet_evm_tracker::fees::EvmGasPriceCalculator<
+    Runtime,
+    TransactionWeightFee,
+    GasPerByte,
+    StorageFeeRatio,
+>;
 
 impl pallet_evm::Config for Runtime {
-    type FeeCalculator = BaseFee;
+    type AccountProvider = pallet_evm::FrameSystemAccountProvider<Self>;
+    type FeeCalculator = EvmGasPriceCalculator;
     type GasWeightMapping = pallet_evm::FixedGasWeightMapping<Self>;
     type WeightPerGas = WeightPerGas;
     type BlockHashMapping = pallet_ethereum::EthereumBlockHashMapping<Self>;
@@ -746,11 +711,10 @@ impl pallet_evm::Config for Runtime {
     type OnCreate = ();
     type FindAuthor = FindAuthorTruncated;
     type GasLimitPovSizeRatio = GasLimitPovSizeRatio;
-    type Timestamp = Timestamp;
-    type WeightInfo = pallet_evm::weights::SubstrateWeight<Self>;
-    type AccountProvider = pallet_evm::FrameSystemAccountProvider<Self>;
     // TODO: re-check this value mostly from moonbeam
     type GasLimitStorageGrowthRatio = ();
+    type Timestamp = Timestamp;
+    type WeightInfo = pallet_evm::weights::SubstrateWeight<Self>;
 }
 
 impl MaybeIntoEvmCall<Runtime> for RuntimeCall {
@@ -784,37 +748,6 @@ impl MaybeIntoEthCall<Runtime> for RuntimeCall {
             _ => None,
         }
     }
-}
-
-parameter_types! {
-    pub BoundDivision: U256 = U256::from(1024);
-}
-
-parameter_types! {
-    pub DefaultBaseFeePerGas: U256 = U256::from(1_000_000_000);
-    // mark it to 5% increments on beyond target weight.
-    pub DefaultElasticity: Permill = Permill::from_parts(50_000);
-}
-
-pub struct BaseFeeThreshold;
-
-impl pallet_base_fee::BaseFeeThreshold for BaseFeeThreshold {
-    fn lower() -> Permill {
-        Permill::zero()
-    }
-    fn ideal() -> Permill {
-        Permill::from_parts(500_000)
-    }
-    fn upper() -> Permill {
-        Permill::from_parts(1_000_000)
-    }
-}
-
-impl pallet_base_fee::Config for Runtime {
-    type RuntimeEvent = RuntimeEvent;
-    type Threshold = BaseFeeThreshold;
-    type DefaultBaseFeePerGas = DefaultBaseFeePerGas;
-    type DefaultElasticity = DefaultElasticity;
 }
 
 impl pallet_domain_id::Config for Runtime {}
@@ -880,7 +813,6 @@ construct_runtime!(
         Ethereum: pallet_ethereum = 80,
         EVM: pallet_evm = 81,
         EVMChainId: pallet_evm_chain_id = 82,
-        BaseFee: pallet_base_fee = 83,
         EVMNoncetracker: pallet_evm_tracker = 84,
 
         // domain instance stuff
@@ -1035,20 +967,6 @@ fn pre_dispatch_evm_transaction(
 ) -> Result<(), TransactionValidityError> {
     match call {
         RuntimeCall::Ethereum(call) => {
-            // Withdraw the consensus chain storage fee from the caller and record
-            // it in the `BlockFees`
-            let consensus_storage_fee = consensus_storage_fee(len)?;
-            match <InnerEVMCurrencyAdapter as pallet_evm::OnChargeEVMTransaction<Runtime>>::withdraw_fee(
-                &account_id,
-                consensus_storage_fee.into(),
-            ) {
-                Ok(None) => {}
-                Ok(Some(paid_consensus_storage_fee)) => {
-                    BlockFees::note_consensus_storage_fee(paid_consensus_storage_fee.peek())
-                }
-                Err(_) => return Err(InvalidTransaction::Payment.into()),
-            }
-
             if let Some(transaction_validity) =
                 call.validate_self_contained(&account_id, dispatch_info, len)
             {
@@ -1270,7 +1188,7 @@ impl_runtime_apis! {
 
     impl frame_system_rpc_runtime_api::AccountNonceApi<Block, AccountId, Nonce> for Runtime {
         fn account_nonce(account: AccountId) -> Nonce {
-            *System::account_nonce(account)
+            System::account_nonce(account)
         }
     }
 
@@ -1686,7 +1604,7 @@ impl_runtime_apis! {
         }
 
         fn elasticity() -> Option<Permill> {
-            Some(pallet_base_fee::Elasticity::<Runtime>::get())
+            None
         }
 
         fn gas_limit_multiplier_support() {}

--- a/domains/test/runtime/auto-id/src/lib.rs
+++ b/domains/test/runtime/auto-id/src/lib.rs
@@ -19,8 +19,8 @@ pub use domain_runtime_primitives::{
     Nonce, Signature, EXISTENTIAL_DEPOSIT, MAX_OUTGOING_MESSAGES,
 };
 use domain_runtime_primitives::{
-    CheckExtrinsicsValidityError, DecodeExtrinsicError, HoldIdentifier, ERR_BALANCE_OVERFLOW,
-    SLOT_DURATION,
+    CheckExtrinsicsValidityError, DecodeExtrinsicError, HoldIdentifier, TargetBlockFullness,
+    ERR_BALANCE_OVERFLOW, SLOT_DURATION,
 };
 use frame_support::dispatch::{DispatchClass, DispatchInfo, GetDispatchInfo};
 use frame_support::genesis_builder_helper::{build_state, get_preset};
@@ -256,7 +256,7 @@ impl pallet_transaction_payment::Config for Runtime {
     type OnChargeTransaction = OnChargeDomainTransaction<Balances>;
     type WeightToFee = IdentityFee<Balance>;
     type LengthToFee = ConstantMultiplier<Balance, FinalDomainTransactionByteFee>;
-    type FeeMultiplierUpdate = SlowAdjustingFeeUpdate<Runtime>;
+    type FeeMultiplierUpdate = SlowAdjustingFeeUpdate<Runtime, TargetBlockFullness>;
     type OperationalFeeMultiplier = OperationalFeeMultiplier;
     type WeightInfo = pallet_transaction_payment::weights::SubstrateWeight<Runtime>;
 }

--- a/domains/test/runtime/evm/Cargo.toml
+++ b/domains/test/runtime/evm/Cargo.toml
@@ -28,7 +28,6 @@ frame-support.workspace = true
 frame-system.workspace = true
 frame-system-rpc-runtime-api.workspace = true
 pallet-balances.workspace = true
-pallet-base-fee.workspace = true
 pallet-block-fees.workspace = true
 pallet-domain-id.workspace = true
 pallet-domain-sudo.workspace = true
@@ -89,7 +88,6 @@ std = [
     "frame-system/std",
     "frame-system-rpc-runtime-api/std",
     "pallet-balances/std",
-    "pallet-base-fee/std",
     "pallet-domain-id/std",
     "pallet-domain-sudo/std",
     "pallet-block-fees/std",

--- a/domains/test/runtime/evm/src/lib.rs
+++ b/domains/test/runtime/evm/src/lib.rs
@@ -17,10 +17,9 @@ use alloc::format;
 use core::mem;
 pub use domain_runtime_primitives::opaque::Header;
 use domain_runtime_primitives::{
-    block_weights, maximum_block_length, maximum_domain_block_weight, AccountId20,
-    EthereumAccountId, DEFAULT_EXTENSION_VERSION, ERR_BALANCE_OVERFLOW,
-    ERR_CONTRACT_CREATION_NOT_ALLOWED, ERR_NONCE_OVERFLOW, EXISTENTIAL_DEPOSIT,
-    MAX_OUTGOING_MESSAGES, SLOT_DURATION,
+    block_weights, maximum_block_length, AccountId20, EthereumAccountId, TargetBlockFullness,
+    DEFAULT_EXTENSION_VERSION, ERR_BALANCE_OVERFLOW, ERR_CONTRACT_CREATION_NOT_ALLOWED,
+    ERR_NONCE_OVERFLOW, EXISTENTIAL_DEPOSIT, MAX_OUTGOING_MESSAGES, SLOT_DURATION,
 };
 pub use domain_runtime_primitives::{
     opaque, Balance, BlockNumber, CheckExtrinsicsValidityError, DecodeExtrinsicError,
@@ -32,10 +31,9 @@ use frame_support::genesis_builder_helper::{build_state, get_preset};
 use frame_support::inherent::ProvideInherent;
 use frame_support::pallet_prelude::TypeInfo;
 use frame_support::traits::{
-    ConstU16, ConstU32, ConstU64, Currency, Everything, FindAuthor, Imbalance, OnFinalize, Time,
-    VariantCount,
+    ConstU16, ConstU32, ConstU64, Currency, Everything, FindAuthor, OnFinalize, Time, VariantCount,
 };
-use frame_support::weights::constants::{ParityDbWeight, WEIGHT_REF_TIME_PER_SECOND};
+use frame_support::weights::constants::ParityDbWeight;
 use frame_support::weights::{ConstantMultiplier, Weight};
 use frame_support::{construct_runtime, parameter_types};
 use frame_system::limits::{BlockLength, BlockWeights};
@@ -57,6 +55,9 @@ use sp_api::impl_runtime_apis;
 use sp_core::crypto::KeyTypeId;
 use sp_core::{Get, OpaqueMetadata, H160, H256, U256};
 use sp_domains::{DomainAllowlistUpdates, DomainId, PermissionedActionAllowedBy, Transfers};
+use sp_evm_tracker::{
+    BlockGasLimit, GasLimitPovSizeRatio, GasPerByte, StorageFeeRatio, WeightPerGas,
+};
 use sp_messenger::endpoint::{Endpoint, EndpointHandler as EndpointHandlerT, EndpointId};
 use sp_messenger::messages::{
     BlockMessagesWithStorageKey, ChainId, ChannelId, CrossDomainMessage, FeeModel, MessageId,
@@ -74,7 +75,6 @@ use sp_runtime::traits::{
 use sp_runtime::transaction_validity::{
     InvalidTransaction, TransactionSource, TransactionValidity, TransactionValidityError,
 };
-use sp_runtime::type_with_default::TypeWithDefault;
 use sp_runtime::{
     generic, impl_opaque_keys, ApplyExtrinsicResult, ConsensusEngineId, Digest,
     ExtrinsicInclusionMode, SaturatedConversion,
@@ -90,9 +90,10 @@ use sp_subspace_mmr::domain_mmr_runtime_interface::{
 use sp_subspace_mmr::{ConsensusChainMmrLeafProof, MmrLeaf};
 use sp_version::RuntimeVersion;
 use static_assertions::const_assert;
-use subspace_runtime_primitives::utility::{DefaultNonceProvider, MaybeIntoUtilityCall};
+use subspace_runtime_primitives::utility::MaybeIntoUtilityCall;
 use subspace_runtime_primitives::{
-    BlockNumber as ConsensusBlockNumber, Hash as ConsensusBlockHash, Moment, SHANNON, SSC,
+    BlockNumber as ConsensusBlockNumber, Hash as ConsensusBlockHash, Moment,
+    SlowAdjustingFeeUpdate, SHANNON, SSC,
 };
 
 /// The address format for describing accounts.
@@ -174,7 +175,7 @@ pub fn construct_extrinsic_raw_payload(
         } else {
             generic::Era::mortal(period, current_block)
         }),
-        frame_system::CheckNonce::<Runtime>::from(nonce.into()),
+        frame_system::CheckNonce::<Runtime>::from(nonce),
         domain_check_weight::CheckWeight::<Runtime>::new(),
         pallet_transaction_payment::ChargeTransactionPayment::<Runtime>::from(tip),
         pallet_evm_tracker::create_contract::CheckContractCreation::<Runtime>::new(),
@@ -252,24 +253,8 @@ impl fp_self_contained::SelfContainedCall for RuntimeCall {
             .into()));
         }
 
-        // TODO: move this code into pallet-block-fees, so it can be used from the production and
-        // test runtimes.
         match self {
-            RuntimeCall::Ethereum(call) => {
-                // Ensure the caller can pay for the consensus chain storage fee
-                let consensus_storage_fee = match consensus_storage_fee(len) {
-                    Ok(fee) => fee,
-                    Err(err) => return Some(Err(err)),
-                };
-                let withdraw_res = <InnerEVMCurrencyAdapter as pallet_evm::OnChargeEVMTransaction<
-                    Runtime,
-                >>::withdraw_fee(info, consensus_storage_fee.into());
-                if withdraw_res.is_err() {
-                    return Some(Err(InvalidTransaction::Payment.into()));
-                }
-
-                call.validate_self_contained(info, dispatch_info, len)
-            }
+            RuntimeCall::Ethereum(call) => call.validate_self_contained(info, dispatch_info, len),
             _ => None,
         }
     }
@@ -291,23 +276,6 @@ impl fp_self_contained::SelfContainedCall for RuntimeCall {
         // test runtimes.
         match self {
             RuntimeCall::Ethereum(call) => {
-                // Withdraw the consensus chain storage fee from the caller and record
-                // it in the `BlockFees`
-                let consensus_storage_fee = match consensus_storage_fee(len) {
-                    Ok(fee) => fee,
-                    Err(err) => return Some(Err(err)),
-                };
-                match <InnerEVMCurrencyAdapter as pallet_evm::OnChargeEVMTransaction<Runtime>>::withdraw_fee(
-                    info,
-                    consensus_storage_fee.into(),
-                ) {
-                    Ok(None) => {}
-                    Ok(Some(paid_consensus_storage_fee)) => {
-                        BlockFees::note_consensus_storage_fee(paid_consensus_storage_fee.peek())
-                    }
-                    Err(_) => return Some(Err(InvalidTransaction::Payment.into())),
-                }
-
                 // Copied from [`pallet_ethereum::Call::pre_dispatch_self_contained`] with `frame_system::CheckWeight`
                 // replaced with `domain_check_weight::CheckWeight`
                 if let pallet_ethereum::Call::transact { transaction } = call {
@@ -398,7 +366,7 @@ impl frame_system::Config for Runtime {
     /// The aggregated `RuntimeTask` type.
     type RuntimeTask = RuntimeTask;
     /// The type for storing how many extrinsics an account has signed.
-    type Nonce = TypeWithDefault<Nonce, DefaultNonceProvider<System, Nonce>>;
+    type Nonce = Nonce;
     /// The type for hashing blocks and tries.
     type Hash = Hash;
     /// The hashing algorithm used.
@@ -472,7 +440,7 @@ impl pallet_balances::Config for Runtime {
 
 parameter_types! {
     pub const OperationalFeeMultiplier: u8 = 5;
-    pub const DomainChainByteFee: Balance = 1;
+    pub const DomainChainByteFee: Balance = 100_000 * SHANNON;
     pub TransactionWeightFee: Balance = 100_000 * SHANNON;
 }
 
@@ -494,7 +462,7 @@ impl pallet_transaction_payment::Config for Runtime {
     type OnChargeTransaction = OnChargeDomainTransaction<Balances>;
     type WeightToFee = ConstantMultiplier<Balance, TransactionWeightFee>;
     type LengthToFee = ConstantMultiplier<Balance, FinalDomainTransactionByteFee>;
-    type FeeMultiplierUpdate = ();
+    type FeeMultiplierUpdate = SlowAdjustingFeeUpdate<Runtime, TargetBlockFullness>;
     type OperationalFeeMultiplier = OperationalFeeMultiplier;
     type WeightInfo = pallet_transaction_payment::weights::SubstrateWeight<Runtime>;
 }
@@ -702,21 +670,8 @@ impl FindAuthor<H160> for FindAuthorTruncated {
     }
 }
 
-/// Current approximation of the gas/s consumption considering
-/// EVM execution over compiled WASM (on 4.4Ghz CPU).
-pub const GAS_PER_SECOND: u64 = 40_000_000;
-
-/// Approximate ratio of the amount of Weight per Gas.
-/// u64 works for approximations because Weight is a very small unit compared to gas.
-pub const WEIGHT_PER_GAS: u64 = WEIGHT_REF_TIME_PER_SECOND.saturating_div(GAS_PER_SECOND);
-
 parameter_types! {
-    /// EVM block gas limit is set to maximum to allow all the transaction stored on Consensus chain.
-    pub BlockGasLimit: U256 = U256::from(
-        maximum_domain_block_weight().ref_time() / WEIGHT_PER_GAS
-    );
     pub PrecompilesValue: Precompiles = Precompiles::default();
-    pub WeightPerGas: Weight = Weight::from_parts(WEIGHT_PER_GAS, 0);
 }
 
 type NegativeImbalance = <Balances as Currency<AccountId>>::NegativeImbalance;
@@ -745,8 +700,13 @@ impl pallet_evm::OnChargeEVMTransaction<Runtime> for EVMCurrencyAdapter {
         already_withdrawn: Self::LiquidityInfo,
     ) -> Self::LiquidityInfo {
         if already_withdrawn.is_some() {
-            // Record the evm actual transaction fee
-            BlockFees::note_domain_execution_fee(corrected_fee.as_u128());
+            // Record the evm actual transaction fee and storage fee
+            let (storage_fee, execution_fee) =
+                EvmGasPriceCalculator::split_fee_into_storage_and_execution(
+                    corrected_fee.as_u128(),
+                );
+            BlockFees::note_consensus_storage_fee(storage_fee);
+            BlockFees::note_domain_execution_fee(execution_fee);
         }
 
         <InnerEVMCurrencyAdapter as pallet_evm::OnChargeEVMTransaction<
@@ -763,9 +723,16 @@ impl pallet_evm::OnChargeEVMTransaction<Runtime> for EVMCurrencyAdapter {
 
 impl pallet_evm_tracker::Config for Runtime {}
 
+pub type EvmGasPriceCalculator = pallet_evm_tracker::fees::EvmGasPriceCalculator<
+    Runtime,
+    TransactionWeightFee,
+    GasPerByte,
+    StorageFeeRatio,
+>;
+
 impl pallet_evm::Config for Runtime {
     type AccountProvider = pallet_evm::FrameSystemAccountProvider<Self>;
-    type FeeCalculator = BaseFee;
+    type FeeCalculator = EvmGasPriceCalculator;
     type GasWeightMapping = pallet_evm::FixedGasWeightMapping<Self>;
     type WeightPerGas = WeightPerGas;
     type BlockHashMapping = pallet_ethereum::EthereumBlockHashMapping<Self>;
@@ -782,7 +749,7 @@ impl pallet_evm::Config for Runtime {
     type OnChargeTransaction = EVMCurrencyAdapter;
     type OnCreate = ();
     type FindAuthor = FindAuthorTruncated;
-    type GasLimitPovSizeRatio = ();
+    type GasLimitPovSizeRatio = GasLimitPovSizeRatio;
     type GasLimitStorageGrowthRatio = ();
     type Timestamp = Timestamp;
     type WeightInfo = pallet_evm::weights::SubstrateWeight<Self>;
@@ -817,37 +784,6 @@ impl MaybeIntoEthCall<Runtime> for RuntimeCall {
             _ => None,
         }
     }
-}
-
-parameter_types! {
-    pub BoundDivision: U256 = U256::from(1024);
-}
-
-parameter_types! {
-    pub DefaultBaseFeePerGas: U256 = U256::from(1_000_000_000);
-    // mark it to 5% increments on beyond target weight.
-    pub DefaultElasticity: Permill = Permill::from_parts(50_000);
-}
-
-pub struct BaseFeeThreshold;
-
-impl pallet_base_fee::BaseFeeThreshold for BaseFeeThreshold {
-    fn lower() -> Permill {
-        Permill::zero()
-    }
-    fn ideal() -> Permill {
-        Permill::from_parts(500_000)
-    }
-    fn upper() -> Permill {
-        Permill::from_parts(1_000_000)
-    }
-}
-
-impl pallet_base_fee::Config for Runtime {
-    type RuntimeEvent = RuntimeEvent;
-    type Threshold = BaseFeeThreshold;
-    type DefaultBaseFeePerGas = DefaultBaseFeePerGas;
-    type DefaultElasticity = DefaultElasticity;
 }
 
 impl pallet_domain_id::Config for Runtime {}
@@ -912,7 +848,6 @@ construct_runtime!(
         Ethereum: pallet_ethereum = 80,
         EVM: pallet_evm = 81,
         EVMChainId: pallet_evm_chain_id = 82,
-        BaseFee: pallet_base_fee = 83,
         EVMNoncetracker: pallet_evm_tracker = 84,
 
         // domain instance stuff
@@ -1060,21 +995,6 @@ fn pre_dispatch_evm_transaction(
 ) -> Result<(), TransactionValidityError> {
     match call {
         RuntimeCall::Ethereum(call) => {
-            // Withdraw the consensus chain storage fee from the caller and record
-            // it in the `BlockFees`
-            let consensus_storage_fee = consensus_storage_fee(len)?;
-
-            match <InnerEVMCurrencyAdapter as pallet_evm::OnChargeEVMTransaction<Runtime>>::withdraw_fee(
-                &account_id,
-                consensus_storage_fee.into(),
-            ) {
-                Ok(None) => {}
-                Ok(Some(paid_consensus_storage_fee)) => {
-                    BlockFees::note_consensus_storage_fee(paid_consensus_storage_fee.peek())
-                }
-                Err(_) => return Err(InvalidTransaction::Payment.into()),
-            }
-
             if let Some(transaction_validity) =
                 call.validate_self_contained(&account_id, dispatch_info, len)
             {
@@ -1290,7 +1210,7 @@ impl_runtime_apis! {
 
     impl frame_system_rpc_runtime_api::AccountNonceApi<Block, AccountId, Nonce> for Runtime {
         fn account_nonce(account: AccountId) -> Nonce {
-            *System::account_nonce(account)
+            System::account_nonce(account)
         }
     }
 
@@ -1689,7 +1609,7 @@ impl_runtime_apis! {
         }
 
         fn elasticity() -> Option<Permill> {
-            Some(pallet_base_fee::Elasticity::<Runtime>::get())
+            None
         }
 
         fn gas_limit_multiplier_support() {}


### PR DESCRIPTION
## Notable changes
- New FeeCalculator for EVM domains.
	- Removed BaseFee and rather use TransactionPayment multiper that is common between Substrate and EVM transactions
	- Since the gas_price includes the storage_fee, I have for now use 30% of final fee deducted to storage fee and 70% to execution fee. Since StorageFee is scaled to 3 times the actual storage fee on consensus for Domains, this seems like a reasonable percent after running some tests before and after this change

- TargettedBlockFullness for domains is set to 25% but for consensus it remains same at 50%
- Reverted DefaultNonce from current block number to simple Nonce, which defaults to zero, since contract creation fails with `Collision` error. This is because contract address uses the nonce and it needs to be deterministic for the user to ensure correct address is derived before and after execution
- Moved common eth specific params to primitives as these are common across runtimes.

## Gas Price
Previously, and even on Taurus, the gas_price does not move big and actually remained at 0.5 Gwei. This is due multipler is different from substrate. 

With the common multiplier and adjusted storage_fee_per_gas, the gas_price from local calculations on taurus will be around 2.8 Gwei. This Will be adjusted by following factors
- Block fullness which is at 25%. As the blocks are full, it slowly adjust the multiplier.
- Storage Fee. As the storage_fee on consensus changes the same will be reflected on gas_price

cc: @jfrank-summit 

Closes: #3418
### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
