### PR TITLE
Remove unnecessary CI platforms for runtime build job

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -163,16 +163,9 @@ jobs:
         if: runner.os == 'Windows'
 
   cargo-runtime-build:
-    strategy:
-      matrix:
-        os: ${{ fromJson(github.repository_owner == 'autonomys' &&
-          '[
-            "runs-on=${{ github.run_id }}/runner=self-hosted-ubuntu-22.04-x86-64",
-            ["self-hosted", "windows-server-2022-x86-64"],
-            ["self-hosted", "macos-14-arm64"]
-          ]' ||
-          '["ubuntu-22.04", "windows-2022", "macos-14"]') }}
-    runs-on: ${{ matrix.os }}
+    # If clippy and tests pass on all OSes, it is unlikely that a runtime build will pass on Linux, but fail on other OSes.
+    runs-on: ${{ fromJson(github.repository_owner == 'autonomys' &&
+      '"runs-on=${{ github.run_id }}/runner=self-hosted-ubuntu-22.04-x86-64"' || '"ubuntu-22.04"') }}
 
     steps:
       - name: Checkout
@@ -297,15 +290,9 @@ jobs:
   # We need to check crates individually for missing features, because cargo does feature
   # unification, which hides missing features when crates are built together.
   cargo-check-individually:
-    strategy:
-      matrix:
-        # We only want to run these slower checks on the fastest runner
-        os: ${{ fromJson(github.repository_owner == 'autonomys' &&
-          '[
-            "runs-on=${{ github.run_id }}/runner=self-hosted-ubuntu-22.04-x86-64",
-          ]' ||
-          '["ubuntu-22.04"]') }}
-    runs-on: ${{ matrix.os }}
+    # If clippy and tests pass on all OSes, it is unlikely that a crate build will pass on Linux but fail on other OSes.
+    runs-on: ${{ fromJson(github.repository_owner == 'autonomys' &&
+      '"runs-on=${{ github.run_id }}/runner=self-hosted-ubuntu-22.04-x86-64"' || '"ubuntu-22.04"') }}
 
     steps:
       - name: Checkout


### PR DESCRIPTION
If clippy and tests pass on all OSes, and the runtime builds pass on one OS, it is unlikely the runtime builds will fail on any other OS. So this PR just builds runtimes on Linux (typically the fastest and cheapest runner).

~~When we build the subspace runtime in Docker, we use the production profile. There's no need for LTO in CI, but building in release mode can sometimes discover more errors (due to release optimisation passes). So I switched the runtime builds to release. (There's no need to build the std library because we're not cross-compiling, and we aren't doing LTO.)~~

I also cleaned up a matrix with only one entry. 

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
