### PR TITLE
Migrate pallet-messenger to General Unsigned extrinsics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8467,6 +8467,7 @@ dependencies = [
  "sp-state-machine",
  "sp-subspace-mmr",
  "sp-trie",
+ "subspace-runtime-primitives",
 ]
 
 [[package]]
@@ -13923,6 +13924,7 @@ dependencies = [
  "log",
  "mimalloc",
  "pallet-domains",
+ "pallet-messenger",
  "pallet-subspace",
  "pallet-sudo",
  "pallet-transaction-payment",
@@ -14423,6 +14425,7 @@ dependencies = [
  "jsonrpsee 0.24.8",
  "mmr-gadget",
  "pallet-domains",
+ "pallet-messenger",
  "pallet-subspace",
  "pallet-transaction-payment",
  "parity-scale-codec",

--- a/crates/subspace-malicious-operator/Cargo.toml
+++ b/crates/subspace-malicious-operator/Cargo.toml
@@ -36,6 +36,7 @@ hex-literal.workspace = true
 log.workspace = true
 mimalloc.workspace = true
 pallet-domains.workspace = true
+pallet-messenger.workspace = true
 pallet-transaction-payment.workspace = true
 parity-scale-codec.workspace = true
 pallet-subspace.workspace = true

--- a/crates/subspace-malicious-operator/src/malicious_bundle_producer.rs
+++ b/crates/subspace-malicious-operator/src/malicious_bundle_producer.rs
@@ -418,6 +418,7 @@ fn get_singed_extra(best_number: u64, immortal: bool, nonce: Nonce) -> SignedExt
         DisablePallets,
         pallet_subspace::extensions::SubspaceExtension::<Runtime>::new(),
         pallet_domains::extensions::DomainsExtension::<Runtime>::new(),
+        pallet_messenger::extensions::MessengerExtension::<Runtime>::new(),
     )
 }
 
@@ -438,6 +439,7 @@ pub fn construct_signed_extrinsic(
             subspace_runtime::VERSION.transaction_version,
             consensus_chain_info.genesis_hash,
             consensus_chain_info.best_hash,
+            (),
             (),
             (),
             (),

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -712,6 +712,7 @@ impl pallet_messenger::Config for Runtime {
     type DomainRegistration = DomainRegistration;
     type ChannelFeeModel = ChannelFeeModel;
     type MaxOutgoingMessages = MaxOutgoingMessages;
+    type MessengerOrigin = pallet_messenger::EnsureMessengerOrigin;
 }
 
 impl<C> frame_system::offchain::CreateTransactionBase<C> for Runtime
@@ -1037,6 +1038,7 @@ pub type SignedExtra = (
     DisablePallets,
     pallet_subspace::extensions::SubspaceExtension<Runtime>,
     pallet_domains::extensions::DomainsExtension<Runtime>,
+    pallet_messenger::extensions::MessengerExtension<Runtime>,
 );
 /// Unchecked extrinsic type as expected by this runtime.
 pub type UncheckedExtrinsic =
@@ -1070,6 +1072,15 @@ impl pallet_domains::extensions::MaybeDomainsCall<Runtime> for RuntimeCall {
     fn maybe_domains_call(&self) -> Option<&pallet_domains::Call<Runtime>> {
         match self {
             RuntimeCall::Domains(call) => Some(call),
+            _ => None,
+        }
+    }
+}
+
+impl pallet_messenger::extensions::MaybeMessengerCall<Runtime> for RuntimeCall {
+    fn maybe_messenger_call(&self) -> Option<&pallet_messenger::Call<Runtime>> {
+        match self {
+            RuntimeCall::Messenger(call) => Some(call),
             _ => None,
         }
     }
@@ -1129,6 +1140,7 @@ fn create_unsigned_general_extrinsic(call: RuntimeCall) -> UncheckedExtrinsic {
         DisablePallets,
         pallet_subspace::extensions::SubspaceExtension::<Runtime>::new(),
         pallet_domains::extensions::DomainsExtension::<Runtime>::new(),
+        pallet_messenger::extensions::MessengerExtension::<Runtime>::new(),
     );
 
     UncheckedExtrinsic::new_transaction(call, extra)

--- a/domains/pallets/messenger/Cargo.toml
+++ b/domains/pallets/messenger/Cargo.toml
@@ -27,6 +27,7 @@ sp-mmr-primitives.workspace = true
 sp-runtime.workspace = true
 sp-trie.workspace = true
 sp-subspace-mmr.workspace = true
+subspace-runtime-primitives.workspace = true
 
 [dev-dependencies]
 domain-runtime-primitives.workspace = true
@@ -50,6 +51,7 @@ std = [
     "sp-runtime/std",
     "sp-trie/std",
     "sp-subspace-mmr/std",
+    "subspace-runtime-primitives/std",
 ]
 runtime-benchmarks = [
     "frame-benchmarking",

--- a/domains/pallets/messenger/src/benchmarking.rs
+++ b/domains/pallets/messenger/src/benchmarking.rs
@@ -25,9 +25,11 @@ use sp_trie::StorageProof;
 #[cfg(feature = "std")]
 use std::collections::BTreeSet;
 
-#[benchmarks]
+#[benchmarks(where <RuntimeCallFor<T> as sp_runtime::traits::Dispatchable>::RuntimeOrigin: From<crate::RawOrigin>)]
 mod benchmarks {
     use super::*;
+    use crate::RawOrigin as MessengerOrigin;
+    use frame_system::pallet_prelude::RuntimeCallFor;
 
     #[benchmark]
     fn initiate_channel() {
@@ -152,7 +154,7 @@ mod benchmarks {
         };
 
         #[extrinsic_call]
-        _(RawOrigin::None, xdm);
+        _(MessengerOrigin::ValidatedUnsigned, xdm);
 
         let post_channel =
             Channels::<T>::get(dst_chain_id, channel_id).expect("channel should exist");
@@ -222,7 +224,7 @@ mod benchmarks {
         };
 
         #[extrinsic_call]
-        _(RawOrigin::None, xdm);
+        _(MessengerOrigin::ValidatedUnsigned, xdm);
 
         let post_channel =
             Channels::<T>::get(dst_chain_id, channel_id).expect("channel should exist");

--- a/domains/pallets/messenger/src/extensions.rs
+++ b/domains/pallets/messenger/src/extensions.rs
@@ -1,0 +1,269 @@
+//! Extensions for unsigned general extrinsics
+
+use crate::pallet::Call as MessengerCall;
+use crate::{
+    Call, Config, Origin, Pallet as Messenger, ValidatedRelayMessage, XDM_TRANSACTION_LONGEVITY,
+};
+use core::cmp::Ordering;
+use frame_support::pallet_prelude::{PhantomData, TypeInfo};
+use frame_support::RuntimeDebugNoBound;
+use frame_system::pallet_prelude::RuntimeCallFor;
+use parity_scale_codec::{Decode, Encode};
+use scale_info::prelude::fmt;
+use sp_messenger::messages::{Message, Nonce};
+use sp_messenger::MAX_FUTURE_ALLOWED_NONCES;
+use sp_runtime::impl_tx_ext_default;
+use sp_runtime::traits::{
+    AsSystemOriginSigner, DispatchInfoOf, DispatchOriginOf, Dispatchable, Implication,
+    TransactionExtension, ValidateResult,
+};
+use sp_runtime::transaction_validity::{
+    InvalidTransaction, TransactionSource, TransactionValidityError, ValidTransaction,
+    ValidTransactionBuilder,
+};
+use sp_subspace_mmr::MmrProofVerifier;
+
+/// Trait to convert Runtime call to possible Messenger call.
+pub trait MaybeMessengerCall<Runtime>
+where
+    Runtime: Config,
+{
+    fn maybe_messenger_call(&self) -> Option<&MessengerCall<Runtime>>;
+}
+
+/// Data passed from validate to prepare.
+#[derive(RuntimeDebugNoBound)]
+pub enum Val<T: Config + fmt::Debug> {
+    /// No validation data
+    None,
+    /// Validated data
+    ValidatedRelayMessage(ValidatedRelayMessage<T>),
+}
+
+/// Extensions for pallet-messenger unsigned extrinsics.
+#[derive(Encode, Decode, Clone, Eq, PartialEq, TypeInfo)]
+pub struct MessengerExtension<Runtime>(PhantomData<Runtime>);
+
+impl<Runtime> MessengerExtension<Runtime> {
+    pub fn new() -> Self {
+        Self(PhantomData)
+    }
+}
+
+impl<Runtime> Default for MessengerExtension<Runtime> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<T: Config> fmt::Debug for MessengerExtension<T> {
+    #[cfg(feature = "std")]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "MessengerExtension",)
+    }
+
+    #[cfg(not(feature = "std"))]
+    fn fmt(&self, _: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Ok(())
+    }
+}
+
+impl<Runtime> MessengerExtension<Runtime>
+where
+    Runtime: Config + scale_info::TypeInfo + fmt::Debug + Send + Sync,
+{
+    fn check_future_nonce_and_add_requires(
+        mut valid_tx_builder: ValidTransactionBuilder,
+        validated_relay_message: &ValidatedRelayMessage<Runtime>,
+    ) -> Result<ValidTransactionBuilder, TransactionValidityError> {
+        let Message {
+            dst_chain_id,
+            channel_id,
+            nonce: msg_nonce,
+            ..
+        } = &validated_relay_message.message;
+
+        let next_nonce = validated_relay_message.next_nonce;
+        // Only add the requires tag if the msg nonce is in future
+        if *msg_nonce > next_nonce {
+            let max_future_nonce = next_nonce.saturating_add(MAX_FUTURE_ALLOWED_NONCES.into());
+            if *msg_nonce > max_future_nonce {
+                return Err(InvalidTransaction::Custom(
+                    crate::verification_errors::IN_FUTURE_NONCE,
+                )
+                .into());
+            }
+
+            valid_tx_builder =
+                valid_tx_builder.and_requires((dst_chain_id, channel_id, msg_nonce - Nonce::one()));
+        };
+
+        Ok(valid_tx_builder)
+    }
+
+    fn do_validate(
+        call: &MessengerCall<Runtime>,
+    ) -> Result<(ValidTransaction, ValidatedRelayMessage<Runtime>), TransactionValidityError> {
+        match call {
+            Call::relay_message { msg: xdm } => {
+                let consensus_state_root =
+                    Runtime::MmrProofVerifier::verify_proof_and_extract_leaf(
+                        xdm.proof.consensus_mmr_proof(),
+                    )
+                    .ok_or(InvalidTransaction::BadProof)?
+                    .state_root();
+
+                let validated_message =
+                    Messenger::<Runtime>::validate_relay_message(xdm, consensus_state_root)?;
+
+                let Message {
+                    dst_chain_id,
+                    channel_id,
+                    nonce: msg_nonce,
+                    ..
+                } = &validated_message.message;
+
+                let valid_tx_builder = Self::check_future_nonce_and_add_requires(
+                    ValidTransaction::with_tag_prefix("MessengerInbox"),
+                    &validated_message,
+                )?;
+
+                let validity = valid_tx_builder
+                    // XDM have a bit higher priority than normal extrinsic but must less than
+                    // fraud proof
+                    .priority(1)
+                    .longevity(XDM_TRANSACTION_LONGEVITY)
+                    .and_provides((dst_chain_id, channel_id, msg_nonce))
+                    .propagate(true)
+                    .build()?;
+
+                Ok((validity, validated_message))
+            }
+            Call::relay_message_response { msg: xdm } => {
+                let consensus_state_root =
+                    Runtime::MmrProofVerifier::verify_proof_and_extract_leaf(
+                        xdm.proof.consensus_mmr_proof(),
+                    )
+                    .ok_or(InvalidTransaction::BadProof)?
+                    .state_root();
+
+                let validated_message = Messenger::<Runtime>::validate_relay_message_response(
+                    xdm,
+                    consensus_state_root,
+                )?;
+
+                let Message {
+                    dst_chain_id,
+                    channel_id,
+                    nonce: msg_nonce,
+                    ..
+                } = &validated_message.message;
+
+                let valid_tx_builder = Self::check_future_nonce_and_add_requires(
+                    ValidTransaction::with_tag_prefix("MessengerOutboxResponse"),
+                    &validated_message,
+                )?;
+
+                let validity = valid_tx_builder
+                    // XDM have a bit higher priority than normal extrinsic but must less than
+                    // fraud proof
+                    .priority(1)
+                    .longevity(XDM_TRANSACTION_LONGEVITY)
+                    .and_provides((dst_chain_id, channel_id, msg_nonce))
+                    .propagate(true)
+                    .build()?;
+
+                Ok((validity, validated_message))
+            }
+            _ => Err(InvalidTransaction::Call.into()),
+        }
+    }
+
+    fn do_prepare(
+        call: &MessengerCall<Runtime>,
+        val: ValidatedRelayMessage<Runtime>,
+    ) -> Result<(), TransactionValidityError> {
+        let ValidatedRelayMessage {
+            message,
+            should_init_channel,
+            next_nonce,
+        } = val;
+
+        // Reject in future message
+        if message.nonce.cmp(&next_nonce) == Ordering::Greater {
+            return Err(InvalidTransaction::Future.into());
+        }
+
+        match call {
+            Call::relay_message { .. } => {
+                Messenger::<Runtime>::pre_dispatch_relay_message(message, should_init_channel)
+            }
+            Call::relay_message_response { .. } => {
+                Messenger::<Runtime>::pre_dispatch_relay_message_response(message)
+            }
+            _ => Err(InvalidTransaction::Call.into()),
+        }
+    }
+}
+
+impl<Runtime> TransactionExtension<RuntimeCallFor<Runtime>> for MessengerExtension<Runtime>
+where
+    Runtime: Config + scale_info::TypeInfo + fmt::Debug + Send + Sync,
+    <RuntimeCallFor<Runtime> as Dispatchable>::RuntimeOrigin:
+        AsSystemOriginSigner<<Runtime as frame_system::Config>::AccountId> + From<Origin> + Clone,
+    RuntimeCallFor<Runtime>: MaybeMessengerCall<Runtime>,
+{
+    const IDENTIFIER: &'static str = "MessengerExtension";
+    type Implicit = ();
+    type Val = Val<Runtime>;
+    type Pre = ();
+
+    fn validate(
+        &self,
+        origin: DispatchOriginOf<RuntimeCallFor<Runtime>>,
+        call: &RuntimeCallFor<Runtime>,
+        _info: &DispatchInfoOf<RuntimeCallFor<Runtime>>,
+        _len: usize,
+        _self_implicit: Self::Implicit,
+        _inherited_implication: &impl Implication,
+        _source: TransactionSource,
+    ) -> ValidateResult<Self::Val, RuntimeCallFor<Runtime>> {
+        // we only care about unsigned calls
+        if origin.as_system_origin_signer().is_some() {
+            return Ok((ValidTransaction::default(), Val::None, origin));
+        };
+
+        let messenger_call = match call.maybe_messenger_call() {
+            Some(messenger_call) => messenger_call,
+            None => return Ok((ValidTransaction::default(), Val::None, origin)),
+        };
+
+        let (validity, validated_relay_message) = Self::do_validate(messenger_call)?;
+        Ok((
+            validity,
+            Val::ValidatedRelayMessage(validated_relay_message),
+            Origin::ValidatedUnsigned.into(),
+        ))
+    }
+
+    fn prepare(
+        self,
+        val: Self::Val,
+        _origin: &DispatchOriginOf<RuntimeCallFor<Runtime>>,
+        call: &RuntimeCallFor<Runtime>,
+        _info: &DispatchInfoOf<RuntimeCallFor<Runtime>>,
+        _len: usize,
+    ) -> Result<Self::Pre, TransactionValidityError> {
+        match (call.maybe_messenger_call(), val) {
+            // prepare if this is a messenger call and has been validated
+            (Some(messenger_call), Val::ValidatedRelayMessage(validated_relay_message)) => {
+                Self::do_prepare(messenger_call, validated_relay_message)
+            }
+            // return Ok for the rest of the call types
+            (_, _) => Ok(()),
+        }
+    }
+
+    // TODO: need benchmarking for this extension.
+    impl_tx_ext_default!(RuntimeCallFor<Runtime>; weight);
+}

--- a/domains/pallets/messenger/src/mock.rs
+++ b/domains/pallets/messenger/src/mock.rs
@@ -104,6 +104,7 @@ macro_rules! impl_runtime {
             type DomainRegistration = DomainRegistration;
             type ChannelFeeModel = ChannelFeeModel;
             type MaxOutgoingMessages = MaxOutgoingMessages;
+            type MessengerOrigin = crate::EnsureMessengerOrigin;
             /// function to fetch endpoint response handler by Endpoint.
             fn get_endpoint_handler(
                 #[allow(unused_variables)] endpoint: &Endpoint,

--- a/domains/pallets/messenger/src/tests.rs
+++ b/domains/pallets/messenger/src/tests.rs
@@ -592,7 +592,8 @@ fn channel_relay_request_and_response(
         Inbox::<chain_b::Runtime>::set(Some(msg));
 
         // process inbox message
-        let result = chain_b::Messenger::relay_message(chain_b::RuntimeOrigin::none(), xdm);
+        let result =
+            chain_b::Messenger::relay_message(crate::RawOrigin::ValidatedUnsigned.into(), xdm);
         assert_ok!(result);
 
         chain_b::System::assert_has_event(chain_b::RuntimeEvent::Messenger(crate::Event::<
@@ -649,8 +650,10 @@ fn channel_relay_request_and_response(
         OutboxResponses::<chain_a::Runtime>::set(Some(msg));
 
         // process outbox message response
-        let result =
-            chain_a::Messenger::relay_message_response(chain_a::RuntimeOrigin::none(), xdm);
+        let result = chain_a::Messenger::relay_message_response(
+            crate::RawOrigin::ValidatedUnsigned.into(),
+            xdm,
+        );
         assert_ok!(result);
 
         // outbox message and message response should not exists

--- a/domains/pallets/transporter/src/mock.rs
+++ b/domains/pallets/transporter/src/mock.rs
@@ -109,6 +109,8 @@ impl pallet_messenger::Config for MockRuntime {
         #[cfg(not(feature = "runtime-benchmarks"))]
         None
     }
+
+    type MessengerOrigin = pallet_messenger::EnsureMessengerOrigin;
 }
 
 #[derive(Debug)]

--- a/domains/runtime/auto-id/src/lib.rs
+++ b/domains/runtime/auto-id/src/lib.rs
@@ -96,6 +96,19 @@ pub type SignedExtra = (
     pallet_messenger::extensions::MessengerExtension<Runtime>,
 );
 
+/// The Custom SignedExtension used for pre_dispatch checks for bundle extrinsic verification
+pub type CustomSignedExtra = (
+    frame_system::CheckNonZeroSender<Runtime>,
+    frame_system::CheckSpecVersion<Runtime>,
+    frame_system::CheckTxVersion<Runtime>,
+    frame_system::CheckGenesis<Runtime>,
+    frame_system::CheckMortality<Runtime>,
+    frame_system::CheckNonce<Runtime>,
+    domain_check_weight::CheckWeight<Runtime>,
+    pallet_transaction_payment::ChargeTransactionPayment<Runtime>,
+    pallet_messenger::extensions::MessengerTrustedMmrExtension<Runtime>,
+);
+
 /// Unchecked extrinsic type as expected by this runtime.
 pub type UncheckedExtrinsic =
     generic::UncheckedExtrinsic<Address, RuntimeCall, Signature, SignedExtra>;
@@ -661,9 +674,21 @@ fn check_transaction_and_do_pre_dispatch_inner(
     // runtime instance.
     match xt.format {
         ExtrinsicFormat::General(extension_version, extra) => {
+            let custom_extra: CustomSignedExtra = (
+                extra.0,
+                extra.1,
+                extra.2,
+                extra.3,
+                extra.4,
+                extra.5,
+                extra.6.clone(),
+                extra.7,
+                pallet_messenger::extensions::MessengerTrustedMmrExtension::<Runtime>::new(),
+            );
+
             let origin = RuntimeOrigin::none();
-            <SignedExtra as DispatchTransaction<RuntimeCall>>::validate_and_prepare(
-                extra,
+            <CustomSignedExtra as DispatchTransaction<RuntimeCall>>::validate_and_prepare(
+                custom_extra,
                 origin,
                 &xt.function,
                 &dispatch_info,
@@ -689,11 +714,7 @@ fn check_transaction_and_do_pre_dispatch_inner(
         }
         // unsigned transaction
         ExtrinsicFormat::Bare => {
-            if let RuntimeCall::Messenger(call) = &xt.function {
-                Messenger::pre_dispatch_with_trusted_mmr_proof(call)?;
-            } else {
-                Runtime::pre_dispatch(&xt.function).map(|_| ())?;
-            }
+            Runtime::pre_dispatch(&xt.function).map(|_| ())?;
             <SignedExtra as TransactionExtension<RuntimeCall>>::bare_validate_and_prepare(
                 &xt.function,
                 &dispatch_info,

--- a/domains/test/runtime/auto-id/src/lib.rs
+++ b/domains/test/runtime/auto-id/src/lib.rs
@@ -93,6 +93,7 @@ pub type SignedExtra = (
     frame_system::CheckNonce<Runtime>,
     domain_check_weight::CheckWeight<Runtime>,
     pallet_transaction_payment::ChargeTransactionPayment<Runtime>,
+    pallet_messenger::extensions::MessengerExtension<Runtime>,
 );
 
 /// Unchecked extrinsic type as expected by this runtime.
@@ -426,6 +427,7 @@ impl pallet_messenger::Config for Runtime {
     type DomainRegistration = ();
     type ChannelFeeModel = ChannelFeeModel;
     type MaxOutgoingMessages = MaxOutgoingMessages;
+    type MessengerOrigin = pallet_messenger::EnsureMessengerOrigin;
 }
 
 impl<C> frame_system::offchain::CreateTransactionBase<C> for Runtime
@@ -434,15 +436,6 @@ where
 {
     type Extrinsic = UncheckedExtrinsic;
     type RuntimeCall = RuntimeCall;
-}
-
-impl<C> frame_system::offchain::CreateInherent<C> for Runtime
-where
-    RuntimeCall: From<C>,
-{
-    fn create_inherent(call: Self::RuntimeCall) -> Self::Extrinsic {
-        UncheckedExtrinsic::new_bare(call)
-    }
 }
 
 parameter_types! {
@@ -591,6 +584,44 @@ fn extrinsic_era(extrinsic: &<Block as BlockT>::Extrinsic) -> Option<Era> {
         Preamble::Bare(_) | Preamble::General(_, _) => None,
         Preamble::Signed(_, _, extra) => Some(extra.4 .0),
     }
+}
+
+impl pallet_messenger::extensions::MaybeMessengerCall<Runtime> for RuntimeCall {
+    fn maybe_messenger_call(&self) -> Option<&pallet_messenger::Call<Runtime>> {
+        match self {
+            RuntimeCall::Messenger(call) => Some(call),
+            _ => None,
+        }
+    }
+}
+
+impl<C> subspace_runtime_primitives::CreateUnsigned<C> for Runtime
+where
+    RuntimeCall: From<C>,
+{
+    fn create_unsigned(call: Self::RuntimeCall) -> Self::Extrinsic {
+        create_unsigned_general_extrinsic(call)
+    }
+}
+
+fn create_unsigned_general_extrinsic(call: RuntimeCall) -> UncheckedExtrinsic {
+    let extra: SignedExtra = (
+        frame_system::CheckNonZeroSender::<Runtime>::new(),
+        frame_system::CheckSpecVersion::<Runtime>::new(),
+        frame_system::CheckTxVersion::<Runtime>::new(),
+        frame_system::CheckGenesis::<Runtime>::new(),
+        frame_system::CheckMortality::<Runtime>::from(generic::Era::Immortal),
+        // for unsigned extrinsic, nonce check will be skipped
+        // so set a default value
+        frame_system::CheckNonce::<Runtime>::from(0u32.into()),
+        domain_check_weight::CheckWeight::<Runtime>::new(),
+        // for unsigned extrinsic, transaction fee check will be skipped
+        // so set a default value
+        pallet_transaction_payment::ChargeTransactionPayment::<Runtime>::from(0u128),
+        pallet_messenger::extensions::MessengerExtension::<Runtime>::new(),
+    );
+
+    UncheckedExtrinsic::new_transaction(call, extra)
 }
 
 #[cfg(feature = "runtime-benchmarks")]

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -673,6 +673,7 @@ impl pallet_messenger::Config for Runtime {
     type DomainRegistration = DomainRegistration;
     type ChannelFeeModel = ChannelFeeModel;
     type MaxOutgoingMessages = MaxOutgoingMessages;
+    type MessengerOrigin = pallet_messenger::EnsureMessengerOrigin;
 }
 
 impl<C> frame_system::offchain::CreateTransactionBase<C> for Runtime
@@ -681,15 +682,6 @@ where
 {
     type Extrinsic = UncheckedExtrinsic;
     type RuntimeCall = RuntimeCall;
-}
-
-impl<C> frame_system::offchain::CreateInherent<C> for Runtime
-where
-    RuntimeCall: From<C>,
-{
-    fn create_inherent(call: Self::RuntimeCall) -> Self::Extrinsic {
-        UncheckedExtrinsic::new_bare(call)
-    }
 }
 
 impl<C> subspace_runtime_primitives::CreateUnsigned<C> for Runtime
@@ -943,6 +935,7 @@ pub type SignedExtra = (
     pallet_transaction_payment::ChargeTransactionPayment<Runtime>,
     pallet_subspace::extensions::SubspaceExtension<Runtime>,
     pallet_domains::extensions::DomainsExtension<Runtime>,
+    pallet_messenger::extensions::MessengerExtension<Runtime>,
 );
 /// Unchecked extrinsic type as expected by this runtime.
 pub type UncheckedExtrinsic =
@@ -971,6 +964,15 @@ impl pallet_domains::extensions::MaybeDomainsCall<Runtime> for RuntimeCall {
     fn maybe_domains_call(&self) -> Option<&pallet_domains::Call<Runtime>> {
         match self {
             RuntimeCall::Domains(call) => Some(call),
+            _ => None,
+        }
+    }
+}
+
+impl pallet_messenger::extensions::MaybeMessengerCall<Runtime> for RuntimeCall {
+    fn maybe_messenger_call(&self) -> Option<&pallet_messenger::Call<Runtime>> {
+        match self {
+            RuntimeCall::Messenger(call) => Some(call),
             _ => None,
         }
     }
@@ -1170,6 +1172,7 @@ fn create_unsigned_general_extrinsic(call: RuntimeCall) -> UncheckedExtrinsic {
         pallet_transaction_payment::ChargeTransactionPayment::<Runtime>::from(0u128),
         pallet_subspace::extensions::SubspaceExtension::<Runtime>::new(),
         pallet_domains::extensions::DomainsExtension::<Runtime>::new(),
+        pallet_messenger::extensions::MessengerExtension::<Runtime>::new(),
     );
 
     UncheckedExtrinsic::new_transaction(call, extra)

--- a/test/subspace-test-service/Cargo.toml
+++ b/test/subspace-test-service/Cargo.toml
@@ -27,6 +27,7 @@ pallet-transaction-payment.workspace = true
 mmr-gadget.workspace = true
 rand.workspace = true
 pallet-domains.workspace = true
+pallet-messenger.workspace = true
 pallet-subspace.workspace = true
 parking_lot.workspace = true
 sc-block-builder.workspace = true

--- a/test/subspace-test-service/src/lib.rs
+++ b/test/subspace-test-service/src/lib.rs
@@ -1384,6 +1384,7 @@ fn get_signed_extra(
         pallet_transaction_payment::ChargeTransactionPayment::<Runtime>::from(tip),
         pallet_subspace::extensions::SubspaceExtension::<Runtime>::new(),
         pallet_domains::extensions::DomainsExtension::<Runtime>::new(),
+        pallet_messenger::extensions::MessengerExtension::<Runtime>::new(),
     )
 }
 
@@ -1413,7 +1414,7 @@ where
         >::from_raw(
             function,
             extra.clone(),
-            ((), 100, 1, genesis_block, current_block_hash, (), (), (), (), ()),
+            ((), 100, 1, genesis_block, current_block_hash, (), (), (), (), (),()),
         ),
         extra,
     )


### PR DESCRIPTION
PR migrates the pallet-messenger Unsigned Bare calls into General Unsigned extrinsics. This is the last of the migration post our recent substrate upgrade from our code base.

Only remaining thing is the frontier itself. Either we let them handle it before next substrate upgrade or we jump into doing such migration by ourselves. Time will tell.

## Notable changes
- I introduced 2 extensions
	- Regular Messenger extension that also validates the MMR proof, used for calls when executing extrinsics that are in Block
	- Trusted MMR extension that is used to validate the our extrinsics during the Bundle verification before sending to Consensus chain.

- Refactored validation and pre_dispatch logic since we should not run them twice and pass the inputs from the validation to prepare through extension's `Val` config.


## Note
This PR introduces more similar/same runtime impls and other things. I will handling on de-duplicating these common things soon in a different PR.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
