### PR TITLE
Enforce recursion depth limit when manually decoding runtime calls

### DIFF
--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -3139,7 +3139,7 @@ where
     /// Submits an unsigned extrinsic [`Call::submit_bundle`].
     pub fn submit_bundle_unsigned(opaque_bundle: OpaqueBundleOf<T>) {
         let slot = opaque_bundle.sealed_header.slot_number();
-        let extrincis_count = opaque_bundle.extrinsics.len();
+        let extrinsics_count = opaque_bundle.extrinsics.len();
 
         let call = Call::submit_bundle { opaque_bundle };
         let ext = T::create_unsigned(call.into());
@@ -3148,7 +3148,7 @@ where
             Ok(()) => {
                 log::info!(
                     target: "runtime::domains",
-                    "Submitted bundle from slot {slot}, extrinsics: {extrincis_count}",
+                    "Submitted bundle from slot {slot}, extrinsics: {extrinsics_count}",
                 );
             }
             Err(()) => {

--- a/crates/sp-domains-fraud-proof/src/host_functions.rs
+++ b/crates/sp-domains-fraud-proof/src/host_functions.rs
@@ -364,6 +364,8 @@ where
             domain_runtime_code.into(),
         );
 
+        // These decodes change the opaque extrinsic type to another opaque type, so they don't
+        // need depth limits. (Only runtime code can correctly decode runtime calls.)
         match call {
             StatelessDomainRuntimeCall::IsTxInRange {
                 opaque_extrinsic,

--- a/crates/subspace-runtime-primitives/src/lib.rs
+++ b/crates/subspace-runtime-primitives/src/lib.rs
@@ -57,6 +57,13 @@ pub fn maximum_normal_block_length() -> BlockLength {
     BlockLength::max_with_normal_ratio(MAX_BLOCK_LENGTH, NORMAL_DISPATCH_RATIO)
 }
 
+/// The maximum recursion depth we allow when parsing calls.
+/// This is a safety measure to avoid stack overflows.
+///
+/// Deeper nested calls can result in an error, or, if it is secure, the call is skipped.
+/// (Some code does unlimited heap-based recursion via `nested_utility_call_iter()`.)
+pub const MAX_CALL_RECURSION_DEPTH: u32 = 5;
+
 /// Alias to 512-bit hash when used in the context of a transaction signature on the chain.
 pub type Signature = MultiSignature;
 

--- a/crates/subspace-runtime-primitives/src/lib.rs
+++ b/crates/subspace-runtime-primitives/src/lib.rs
@@ -62,7 +62,7 @@ pub fn maximum_normal_block_length() -> BlockLength {
 ///
 /// Deeper nested calls can result in an error, or, if it is secure, the call is skipped.
 /// (Some code does unlimited heap-based recursion via `nested_utility_call_iter()`.)
-pub const MAX_CALL_RECURSION_DEPTH: u32 = 5;
+pub const MAX_CALL_RECURSION_DEPTH: u32 = 10;
 
 /// Alias to 512-bit hash when used in the context of a transaction signature on the chain.
 pub type Signature = MultiSignature;

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -501,6 +501,16 @@ parameter_types! {
     pub const NoPreimagePostponement: Option<u32> = Some(10);
 }
 
+// Call preimages for the democracy and scheduler pallets can be stored as a binary blob. These
+// blobs are only fetched and decoded in the future block when the call is actually run. This
+// means any member of the council (or sudo) can schedule an invalid subspace runtime call. These
+// calls can cause a stack limit exceeded error in a future block. (Or other kinds of errors.)
+//
+// This risk is acceptable because those accounts are privileged, and those pallets already have
+// to deal with invalid stored calls (for example, stored before an upgrade, but run after).
+//
+// Invalid domain runtime calls will be rejected by the domain runtime extrinsic format checks,
+// even if they are scheduled/democratized in the subspace runtime.
 impl pallet_scheduler::Config for Runtime {
     type MaxScheduledPerBlock = ConstU32<50>;
     type MaximumWeight = MaximumSchedulerWeight;

--- a/crates/subspace-runtime/src/object_mapping.rs
+++ b/crates/subspace-runtime/src/object_mapping.rs
@@ -6,8 +6,7 @@ use parity_scale_codec::{Compact, CompactLen, Encode};
 use sp_std::prelude::*;
 use subspace_core_primitives::hashes;
 use subspace_core_primitives::objects::{BlockObject, BlockObjectMapping};
-
-const MAX_OBJECT_MAPPING_RECURSION_DEPTH: u16 = 5;
+use subspace_runtime_primitives::MAX_CALL_RECURSION_DEPTH;
 
 /// Extract the nested object mappings from `call`.
 // TODO:
@@ -128,7 +127,7 @@ pub(crate) fn extract_block_object_mapping(block: Block) -> BlockObjectMapping {
             base_extrinsic_offset as u32,
             block_object_mapping.objects_mut(),
             &extrinsic.function,
-            MAX_OBJECT_MAPPING_RECURSION_DEPTH,
+            MAX_CALL_RECURSION_DEPTH as u16,
         );
 
         base_offset += extrinsic.encoded_size();

--- a/domains/runtime/auto-id/src/lib.rs
+++ b/domains/runtime/auto-id/src/lib.rs
@@ -36,7 +36,7 @@ use frame_support::{construct_runtime, parameter_types};
 use frame_system::limits::{BlockLength, BlockWeights};
 use pallet_block_fees::fees::OnChargeDomainTransaction;
 use pallet_transporter::EndpointHandler;
-use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
+use parity_scale_codec::{Decode, DecodeLimit, Encode, MaxEncodedLen};
 use sp_api::impl_runtime_apis;
 use sp_core::crypto::KeyTypeId;
 use sp_core::{Get, OpaqueMetadata};
@@ -71,7 +71,7 @@ use static_assertions::const_assert;
 use subspace_runtime_primitives::utility::DefaultNonceProvider;
 use subspace_runtime_primitives::{
     BlockNumber as ConsensusBlockNumber, DomainEventSegmentSize, Hash as ConsensusBlockHash,
-    Moment, SlowAdjustingFeeUpdate, SHANNON, SSC,
+    Moment, SlowAdjustingFeeUpdate, MAX_CALL_RECURSION_DEPTH, SHANNON, SSC,
 };
 
 /// Block type as expected by this runtime.
@@ -592,15 +592,19 @@ fn is_xdm_mmr_proof_valid(ext: &<Block as BlockT>::Extrinsic) -> Option<bool> {
     }
 }
 
-/// Returns `true` if this is a valid Sudo call.
-/// Should extend this function to limit specific calls Sudo can make when needed.
+/// Returns `true` if this is a validly encoded Sudo call.
 fn is_valid_sudo_call(encoded_ext: Vec<u8>) -> bool {
-    UncheckedExtrinsic::decode(&mut encoded_ext.as_slice()).is_ok()
+    UncheckedExtrinsic::decode_with_depth_limit(
+        MAX_CALL_RECURSION_DEPTH,
+        &mut encoded_ext.as_slice(),
+    )
+    .is_ok()
 }
 
 fn construct_sudo_call_extrinsic(encoded_ext: Vec<u8>) -> <Block as BlockT>::Extrinsic {
-    let ext = UncheckedExtrinsic::decode(&mut encoded_ext.as_slice())
-        .expect("must always be an valid extrinsic due to the check above; qed");
+    let ext = UncheckedExtrinsic::decode(&mut encoded_ext.as_slice()).expect(
+        "must always be a valid extrinsic due to the check above and storage proof check; qed",
+    );
     UncheckedExtrinsic::new_bare(
         pallet_domain_sudo::Call::sudo {
             call: Box::new(ext.function),
@@ -927,8 +931,11 @@ impl_runtime_apis! {
             opaque_extrinsic: sp_runtime::OpaqueExtrinsic,
         ) -> Result<<Block as BlockT>::Extrinsic, DecodeExtrinsicError> {
             let encoded = opaque_extrinsic.encode();
-            UncheckedExtrinsic::decode(&mut encoded.as_slice())
-                .map_err(|err| DecodeExtrinsicError(format!("{}", err)))
+
+            UncheckedExtrinsic::decode_with_depth_limit(
+                MAX_CALL_RECURSION_DEPTH,
+                &mut encoded.as_slice(),
+            ).map_err(|err| DecodeExtrinsicError(format!("{}", err)))
         }
 
         fn extrinsic_era(

--- a/domains/runtime/evm/src/lib.rs
+++ b/domains/runtime/evm/src/lib.rs
@@ -52,7 +52,7 @@ use pallet_evm::{
 use pallet_evm_tracker::create_contract::{is_create_contract_allowed, CheckContractCreation};
 use pallet_evm_tracker::traits::{MaybeIntoEthCall, MaybeIntoEvmCall};
 use pallet_transporter::EndpointHandler;
-use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
+use parity_scale_codec::{Decode, DecodeLimit, Encode, MaxEncodedLen};
 use sp_api::impl_runtime_apis;
 use sp_core::crypto::KeyTypeId;
 use sp_core::{Get, OpaqueMetadata, H160, H256, U256};
@@ -96,7 +96,7 @@ use static_assertions::const_assert;
 use subspace_runtime_primitives::utility::MaybeIntoUtilityCall;
 use subspace_runtime_primitives::{
     BlockNumber as ConsensusBlockNumber, DomainEventSegmentSize, Hash as ConsensusBlockHash,
-    Moment, SlowAdjustingFeeUpdate, SHANNON, SSC,
+    Moment, SlowAdjustingFeeUpdate, MAX_CALL_RECURSION_DEPTH, SHANNON, SSC,
 };
 
 /// The address format for describing accounts.
@@ -868,16 +868,20 @@ fn is_xdm_mmr_proof_valid(ext: &<Block as BlockT>::Extrinsic) -> Option<bool> {
     }
 }
 
-/// Returns `true` if this is a valid Sudo call.
-/// Should extend this function to limit specific calls Sudo can make when needed.
+/// Returns `true` if this is a validly encoded Sudo call.
 fn is_valid_sudo_call(encoded_ext: Vec<u8>) -> bool {
-    UncheckedExtrinsic::decode(&mut encoded_ext.as_slice()).is_ok()
+    UncheckedExtrinsic::decode_with_depth_limit(
+        MAX_CALL_RECURSION_DEPTH,
+        &mut encoded_ext.as_slice(),
+    )
+    .is_ok()
 }
 
 /// Constructs a domain-sudo call extrinsic from the given encoded extrinsic.
 fn construct_sudo_call_extrinsic(encoded_ext: Vec<u8>) -> <Block as BlockT>::Extrinsic {
-    let ext = UncheckedExtrinsic::decode(&mut encoded_ext.as_slice())
-        .expect("must always be an valid extrinsic due to the check above; qed");
+    let ext = UncheckedExtrinsic::decode(&mut encoded_ext.as_slice()).expect(
+        "must always be a valid extrinsic due to the check above and storage proof check; qed",
+    );
     UncheckedExtrinsic::new_bare(
         pallet_domain_sudo::Call::sudo {
             call: Box::new(ext.0.function),
@@ -1338,8 +1342,11 @@ impl_runtime_apis! {
             opaque_extrinsic: sp_runtime::OpaqueExtrinsic,
         ) -> Result<<Block as BlockT>::Extrinsic, DecodeExtrinsicError> {
             let encoded = opaque_extrinsic.encode();
-            UncheckedExtrinsic::decode(&mut encoded.as_slice())
-                .map_err(|err| DecodeExtrinsicError(format!("{}", err)))
+
+            UncheckedExtrinsic::decode_with_depth_limit(
+                MAX_CALL_RECURSION_DEPTH,
+                &mut encoded.as_slice(),
+            ).map_err(|err| DecodeExtrinsicError(format!("{}", err)))
         }
 
         fn extrinsic_era(

--- a/domains/test/runtime/auto-id/src/lib.rs
+++ b/domains/test/runtime/auto-id/src/lib.rs
@@ -36,7 +36,7 @@ use frame_support::{construct_runtime, parameter_types};
 use frame_system::limits::{BlockLength, BlockWeights};
 use pallet_block_fees::fees::OnChargeDomainTransaction;
 use pallet_transporter::EndpointHandler;
-use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
+use parity_scale_codec::{Decode, DecodeLimit, Encode, MaxEncodedLen};
 use sp_api::impl_runtime_apis;
 use sp_core::crypto::KeyTypeId;
 use sp_core::{Get, OpaqueMetadata};
@@ -71,7 +71,7 @@ use static_assertions::const_assert;
 use subspace_runtime_primitives::utility::DefaultNonceProvider;
 use subspace_runtime_primitives::{
     BlockNumber as ConsensusBlockNumber, DomainEventSegmentSize, Hash as ConsensusBlockHash,
-    Moment, SlowAdjustingFeeUpdate, SSC,
+    Moment, SlowAdjustingFeeUpdate, MAX_CALL_RECURSION_DEPTH, SSC,
 };
 
 /// Block type as expected by this runtime.
@@ -544,15 +544,19 @@ fn is_xdm_mmr_proof_valid(ext: &<Block as BlockT>::Extrinsic) -> Option<bool> {
     }
 }
 
-/// Returns `true` if this is a valid Sudo call.
-/// Should extend this function to limit specific calls Sudo can make when needed.
+/// Returns `true` if this is a validly encoded Sudo call.
 fn is_valid_sudo_call(encoded_ext: Vec<u8>) -> bool {
-    UncheckedExtrinsic::decode(&mut encoded_ext.as_slice()).is_ok()
+    UncheckedExtrinsic::decode_with_depth_limit(
+        MAX_CALL_RECURSION_DEPTH,
+        &mut encoded_ext.as_slice(),
+    )
+    .is_ok()
 }
 
 fn construct_sudo_call_extrinsic(encoded_ext: Vec<u8>) -> <Block as BlockT>::Extrinsic {
-    let ext = UncheckedExtrinsic::decode(&mut encoded_ext.as_slice())
-        .expect("must always be an valid extrinsic due to the check above; qed");
+    let ext = UncheckedExtrinsic::decode(&mut encoded_ext.as_slice()).expect(
+        "must always be a valid extrinsic due to the check above and storage proof check; qed",
+    );
     UncheckedExtrinsic::new_bare(
         pallet_domain_sudo::Call::sudo {
             call: Box::new(ext.function),
@@ -918,8 +922,11 @@ impl_runtime_apis! {
             opaque_extrinsic: sp_runtime::OpaqueExtrinsic,
         ) -> Result<<Block as BlockT>::Extrinsic, DecodeExtrinsicError> {
             let encoded = opaque_extrinsic.encode();
-            UncheckedExtrinsic::decode(&mut encoded.as_slice())
-                .map_err(|err| DecodeExtrinsicError(format!("{}", err)))
+
+            UncheckedExtrinsic::decode_with_depth_limit(
+                MAX_CALL_RECURSION_DEPTH,
+                &mut encoded.as_slice(),
+            ).map_err(|err| DecodeExtrinsicError(format!("{}", err)))
         }
 
         fn extrinsic_era(

--- a/domains/test/runtime/evm/src/lib.rs
+++ b/domains/test/runtime/evm/src/lib.rs
@@ -50,7 +50,7 @@ use pallet_evm::{
 use pallet_evm_tracker::create_contract::is_create_contract_allowed;
 use pallet_evm_tracker::traits::{MaybeIntoEthCall, MaybeIntoEvmCall};
 use pallet_transporter::EndpointHandler;
-use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
+use parity_scale_codec::{Decode, DecodeLimit, Encode, MaxEncodedLen};
 use sp_api::impl_runtime_apis;
 use sp_core::crypto::KeyTypeId;
 use sp_core::{Get, OpaqueMetadata, H160, H256, U256};
@@ -93,7 +93,7 @@ use static_assertions::const_assert;
 use subspace_runtime_primitives::utility::MaybeIntoUtilityCall;
 use subspace_runtime_primitives::{
     BlockNumber as ConsensusBlockNumber, DomainEventSegmentSize, Hash as ConsensusBlockHash,
-    Moment, SlowAdjustingFeeUpdate, SHANNON, SSC,
+    Moment, SlowAdjustingFeeUpdate, MAX_CALL_RECURSION_DEPTH, SHANNON, SSC,
 };
 
 /// The address format for describing accounts.
@@ -944,16 +944,20 @@ fn is_xdm_mmr_proof_valid(ext: &<Block as BlockT>::Extrinsic) -> Option<bool> {
     }
 }
 
-/// Returns a valid Sudo call.
-/// Should extend this function to limit specific calls Sudo can make when needed.
+/// Returns `true`` if this is a validly encoded Sudo call.
 fn is_valid_sudo_call(encoded_ext: Vec<u8>) -> bool {
-    UncheckedExtrinsic::decode(&mut encoded_ext.as_slice()).is_ok()
+    UncheckedExtrinsic::decode_with_depth_limit(
+        MAX_CALL_RECURSION_DEPTH,
+        &mut encoded_ext.as_slice(),
+    )
+    .is_ok()
 }
 
 /// Constructs a domain-sudo call extrinsic from the given encoded extrinsic.
 fn construct_sudo_call_extrinsic(encoded_ext: Vec<u8>) -> <Block as BlockT>::Extrinsic {
-    let ext = UncheckedExtrinsic::decode(&mut encoded_ext.as_slice())
-        .expect("must always be an valid extrinsic due to the check above; qed");
+    let ext = UncheckedExtrinsic::decode(&mut encoded_ext.as_slice()).expect(
+        "must always be a valid extrinsic due to the check above and storage proof check; qed",
+    );
     UncheckedExtrinsic::new_bare(
         pallet_domain_sudo::Call::sudo {
             call: Box::new(ext.0.function),
@@ -1365,8 +1369,11 @@ impl_runtime_apis! {
             opaque_extrinsic: sp_runtime::OpaqueExtrinsic,
         ) -> Result<<Block as BlockT>::Extrinsic, DecodeExtrinsicError> {
             let encoded = opaque_extrinsic.encode();
-            UncheckedExtrinsic::decode(&mut encoded.as_slice())
-                .map_err(|err| DecodeExtrinsicError(format!("{}", err)))
+
+            UncheckedExtrinsic::decode_with_depth_limit(
+                MAX_CALL_RECURSION_DEPTH,
+                &mut encoded.as_slice(),
+            ).map_err(|err| DecodeExtrinsicError(format!("{}", err)))
         }
 
         fn extrinsic_era(

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -110,7 +110,8 @@ use subspace_core_primitives::{hashes, PublicKey, Randomness, SlotNumber, U256};
 use subspace_runtime_primitives::utility::DefaultNonceProvider;
 use subspace_runtime_primitives::{
     AccountId, Balance, BlockNumber, ConsensusEventSegmentSize, FindBlockRewardAddress, Hash,
-    HoldIdentifier, Moment, Nonce, Signature, MIN_REPLICATION_FACTOR, SHANNON, SSC,
+    HoldIdentifier, Moment, Nonce, Signature, MAX_CALL_RECURSION_DEPTH, MIN_REPLICATION_FACTOR,
+    SHANNON, SSC,
 };
 use subspace_test_primitives::DOMAINS_BLOCK_PRUNING_DEPTH;
 
@@ -203,8 +204,6 @@ const BLOCK_WEIGHT_FOR_2_SEC: Weight =
 
 /// Maximum block length for non-`Normal` extrinsic is 5 MiB.
 const MAX_BLOCK_LENGTH: u32 = 5 * 1024 * 1024;
-
-const MAX_OBJECT_MAPPING_RECURSION_DEPTH: u16 = 5;
 
 parameter_types! {
     pub const Version: RuntimeVersion = VERSION;
@@ -1129,7 +1128,7 @@ fn extract_block_object_mapping(block: Block) -> BlockObjectMapping {
             base_extrinsic_offset as u32,
             block_object_mapping.objects_mut(),
             &extrinsic.function,
-            MAX_OBJECT_MAPPING_RECURSION_DEPTH,
+            MAX_CALL_RECURSION_DEPTH as u16,
         );
 
         base_offset += extrinsic.encoded_size();


### PR DESCRIPTION
### Issue

In a few cases, the domain runtimes receive a binary blob, and decode that into a runtime calls. A number of pallets (7) can wrap other runtime calls, leading to stack recursion during decoding.

### Solution

This PR limits that manual decoding to 10 levels, which should be enough for a multisig domain sudo call, with a reasonable amount of inner utility/structure nesting.

Other decoding is protected by consensus checks, domain checks, or fraud proof storage verification, so we don't need to implement a limit for it.

### TODO

- [ ] Add tests for these to this PR. (The existing tests pass with these limits.)

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
