### PR TITLE
include multisig calls while checking for balance transfers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13773,6 +13773,7 @@ version = "0.1.0"
 dependencies = [
  "frame-support",
  "frame-system",
+ "pallet-multisig",
  "pallet-transaction-payment",
  "pallet-utility",
  "parity-scale-codec",

--- a/crates/subspace-runtime-primitives/Cargo.toml
+++ b/crates/subspace-runtime-primitives/Cargo.toml
@@ -19,6 +19,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 parity-scale-codec = { workspace = true, features = ["derive"] }
 frame-support.workspace = true
 frame-system.workspace = true
+pallet-multisig.workspace = true
 pallet-transaction-payment.workspace = true
 pallet-utility.workspace = true
 scale-info = { workspace = true, features = ["derive"] }
@@ -34,6 +35,7 @@ std = [
     "parity-scale-codec/std",
     "frame-support/std",
     "frame-system/std",
+    "pallet-multisig/std",
     "pallet-transaction-payment/std",
     "pallet-utility/std",
     "scale-info/std",

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -99,7 +99,9 @@ use subspace_core_primitives::solutions::{
     pieces_to_solution_range, solution_range_to_pieces, SolutionRange,
 };
 use subspace_core_primitives::{PublicKey, Randomness, SlotNumber, U256};
-use subspace_runtime_primitives::utility::{DefaultNonceProvider, MaybeIntoUtilityCall};
+use subspace_runtime_primitives::utility::{
+    DefaultNonceProvider, MaybeIntoUtilityCall, MaybeMultisigCall,
+};
 use subspace_runtime_primitives::{
     maximum_normal_block_length, AccountId, Balance, BlockNumber, ConsensusEventSegmentSize,
     FindBlockRewardAddress, Hash, HoldIdentifier, Moment, Nonce, Signature, SlowAdjustingFeeUpdate,
@@ -416,6 +418,15 @@ impl MaybeIntoUtilityCall<Runtime> for RuntimeCall {
     fn maybe_into_utility_call(&self) -> Option<&pallet_utility::Call<Runtime>> {
         match self {
             RuntimeCall::Utility(call) => Some(call),
+            _ => None,
+        }
+    }
+}
+
+impl MaybeMultisigCall<Runtime> for RuntimeCall {
+    fn maybe_multisig_call(&self) -> Option<&pallet_multisig::Call<Runtime>> {
+        match self {
+            RuntimeCall::Multisig(call) => Some(call),
             _ => None,
         }
     }

--- a/crates/subspace-runtime/src/signed_extensions.rs
+++ b/crates/subspace-runtime/src/signed_extensions.rs
@@ -12,7 +12,7 @@ use sp_runtime::transaction_validity::{
     ValidTransaction,
 };
 use sp_std::prelude::*;
-use subspace_runtime_primitives::utility::nested_utility_call_iter;
+use subspace_runtime_primitives::utility::nested_call_iter;
 
 /// Disable balance transfers, if configured in the runtime.
 #[derive(Debug, Encode, Decode, Clone, Eq, PartialEq, Default, TypeInfo)]
@@ -89,7 +89,7 @@ impl TransactionExtension<RuntimeCall> for DisablePallets {
 }
 
 fn contains_balance_transfer(call: &RuntimeCall) -> bool {
-    for call in nested_utility_call_iter::<Runtime>(call) {
+    for call in nested_call_iter::<Runtime>(call) {
         // Other calls are inconclusive, they might contain nested calls
         if let RuntimeCall::Balances(
             pallet_balances::Call::transfer_allow_death { .. }


### PR DESCRIPTION
Multisig calls can contain balance transfers and this PR includes them during the Extension check.

Unfortunately due to how tightly connected the function that iterates the calls, we cannot use it across all runtimes since some runtimes doe not yet bring the multisig pallet unlike consensus.

I have created a new function that includes the multisig along with utility call checks. We cannot use chaining iterators here since multisig call can contain utility call as well.

Since currently only utility and multisig are the one containing the nested call, i'm leaning to simpler approach of having another function that covers the both.

If in future there are more pallets that bring nested calls and need this balance check, we would have to make the call iterator generic over any runtime that may or may not impl all the kinds of pallets.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
