### PR TITLE
fix: add the kzg feature to the subspace-verification dependency in subspace-farmer

### DIFF
--- a/crates/subspace-farmer/Cargo.toml
+++ b/crates/subspace-farmer/Cargo.toml
@@ -62,7 +62,7 @@ subspace-networking.workspace = true
 subspace-proof-of-space.workspace = true
 subspace-proof-of-space-gpu = { workspace = true, optional = true }
 subspace-rpc-primitives.workspace = true
-subspace-verification.workspace = true
+subspace-verification = { workspace = true, features = ["kzg"] }
 substrate-bip39.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true


### PR DESCRIPTION
@nazar-pc @teor2345  Alright, I’m not sure when this changed, but it was missed—just adding it back now.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
