### PR TITLE
Check crates without dependents individually, and run clippy on them

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -313,9 +313,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-
 
+      # Pruning the target directory is only required if we're using a build cache or running locally
       - name: check all crates individually
         run: |
-          for crate in $(grep 'path =' Cargo.toml | sed 's/.*path *= *"\([^"]*\).*/\1/' | sort); do
+          for crate in $(find . -name Cargo.toml -o -path ./target -prune | xargs -n 1 dirname | grep -v '^[.]$' | sort); do
               echo "$crate";
               pushd "$crate";
               if ! cargo -Zgitoxide -Zgit check --locked --all-targets; then

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -319,7 +319,7 @@ jobs:
           for crate in $(find . -name Cargo.toml -o -path ./target -prune | xargs -n 1 dirname | grep -v '^[.]$' | sort); do
               echo "$crate";
               pushd "$crate";
-              if ! cargo -Zgitoxide -Zgit check --locked --all-targets; then
+              if ! cargo -Zgitoxide -Zgit clippy --locked --all-targets -- -D warnings; then
                   pwd;
                   popd;
                   exit 1;

--- a/crates/subspace-gateway/Cargo.toml
+++ b/crates/subspace-gateway/Cargo.toml
@@ -40,6 +40,6 @@ subspace-kzg.workspace = true
 subspace-logging.workspace = true
 subspace-networking.workspace = true
 subspace-rpc-primitives.workspace = true
-subspace-verification.workspace = true
+subspace-verification = { workspace = true, features = ["kzg"] }
 tokio = { workspace = true, features = ["rt-multi-thread", "signal", "macros"] }
 tracing.workspace = true

--- a/domains/pallets/executive/src/migrations.rs
+++ b/domains/pallets/executive/src/migrations.rs
@@ -5,8 +5,6 @@ use frame_support::traits::{Get, OnRuntimeUpgrade};
 use frame_support::weights::Weight;
 use frame_system::pallet::Config;
 use frame_system::{EventRecord, Pallet as System};
-#[cfg(not(feature = "std"))]
-use sp_std::vec::Vec;
 
 pub struct StorageCheckedMigrateToEventSegments<T>(sp_std::marker::PhantomData<T>);
 


### PR DESCRIPTION
This PR checks all crates individually, and checks them using clippy (not just `cargo check`).

In the original PR #3427 I missed some crates - it was only checking crates that were depended on by other crates. PR #3441 fixed one missing dependency feature, here is another missed feature, and a missed clippy warning.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
