### PR TITLE
include multisig calls while checking for balance transfers, extensibly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13932,6 +13932,7 @@ dependencies = [
  "pallet-domains",
  "pallet-messenger",
  "pallet-mmr",
+ "pallet-multisig",
  "pallet-rewards",
  "pallet-runtime-configs",
  "pallet-subspace",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8018,7 +8018,6 @@ dependencies = [
  "pallet-ethereum",
  "pallet-evm",
  "pallet-transaction-payment",
- "pallet-utility",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
@@ -13773,6 +13772,7 @@ version = "0.1.0"
 dependencies = [
  "frame-support",
  "frame-system",
+ "pallet-multisig",
  "pallet-transaction-payment",
  "pallet-utility",
  "parity-scale-codec",

--- a/crates/subspace-runtime-primitives/Cargo.toml
+++ b/crates/subspace-runtime-primitives/Cargo.toml
@@ -19,6 +19,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 parity-scale-codec = { workspace = true, features = ["derive"] }
 frame-support.workspace = true
 frame-system.workspace = true
+pallet-multisig.workspace = true
 pallet-transaction-payment.workspace = true
 pallet-utility.workspace = true
 scale-info = { workspace = true, features = ["derive"] }
@@ -34,6 +35,7 @@ std = [
     "parity-scale-codec/std",
     "frame-support/std",
     "frame-system/std",
+    "pallet-multisig/std",
     "pallet-transaction-payment/std",
     "pallet-utility/std",
     "scale-info/std",

--- a/crates/subspace-runtime-primitives/src/utility.rs
+++ b/crates/subspace-runtime-primitives/src/utility.rs
@@ -4,52 +4,108 @@ use core::marker::PhantomData;
 use frame_support::pallet_prelude::TypeInfo;
 use frame_system::pallet_prelude::RuntimeCallFor;
 use scale_info::prelude::collections::VecDeque;
+use scale_info::prelude::vec;
 use sp_runtime::traits::{BlockNumberProvider, Get};
+use sp_runtime::Vec;
 
 /// Trait used to convert from a generated `RuntimeCall` type to `pallet_utility::Call<Runtime>`.
-pub trait MaybeIntoUtilityCall<Runtime>
+pub trait MaybeUtilityCall<Runtime>
 where
     Runtime: pallet_utility::Config,
+    for<'call> &'call RuntimeCallFor<Runtime>:
+        From<&'call <Runtime as pallet_utility::Config>::RuntimeCall>,
 {
-    /// If this call is a `pallet_utility::Call<Runtime>` call, returns the inner call.
-    fn maybe_into_utility_call(&self) -> Option<&pallet_utility::Call<Runtime>>;
+    /// If this call is a `pallet_utility::Call<Runtime>` call, returns the inner `pallet_utility::Call`.
+    fn maybe_utility_call(&self) -> Option<&pallet_utility::Call<Runtime>>;
+
+    /// If this call is a `pallet_utility::Call<Runtime>` call, returns the inner `RuntimeCall`.
+    ///
+    /// Runtimes can override this default implementation if they want to ignore (or not ignore)
+    /// certain utility calls. For example, a stack limit check shouldn't ignore `Call::__Ignore`.
+    fn maybe_nested_utility_calls(&self) -> Option<Vec<&RuntimeCallFor<Runtime>>> {
+        if let Some(call) = self.maybe_utility_call() {
+            match call {
+                pallet_utility::Call::batch { calls }
+                | pallet_utility::Call::batch_all { calls }
+                | pallet_utility::Call::force_batch { calls } => {
+                    Some(calls.iter().map(Into::into).collect())
+                }
+                pallet_utility::Call::as_derivative { call, .. }
+                | pallet_utility::Call::dispatch_as { call, .. }
+                | pallet_utility::Call::with_weight { call, .. } => {
+                    Some(vec![call.as_ref().into()])
+                }
+                pallet_utility::Call::__Ignore(..) => None,
+            }
+        } else {
+            None
+        }
+    }
 }
 
-/// Returns an interator over `call`, and any calls nested within it using `pallet-utility`.
+/// Trait used to convert from a generated `RuntimeCall` type to `pallet_multisig::Call<Runtime>`.
+pub trait MaybeMultisigCall<Runtime>
+where
+    Runtime: pallet_multisig::Config,
+    for<'call> &'call RuntimeCallFor<Runtime>:
+        From<&'call <Runtime as pallet_multisig::Config>::RuntimeCall>,
+{
+    /// If this call is a `pallet_multisig::Call<Runtime>` call, returns the inner `pallet_multisig::Call`.
+    fn maybe_multisig_call(&self) -> Option<&pallet_multisig::Call<Runtime>>;
+
+    /// If this call is a `pallet_multisig::Call<Runtime>` call, returns the inner `RuntimeCall`.
+    ///
+    /// Runtimes can override this default implementation if they want to ignore (or not ignore)
+    /// certain multisig calls.
+    fn maybe_nested_multisig_calls(&self) -> Option<Vec<&RuntimeCallFor<Runtime>>> {
+        if let Some(call) = self.maybe_multisig_call() {
+            match call {
+                pallet_multisig::Call::as_multi { call, .. }
+                | pallet_multisig::Call::as_multi_threshold_1 { call, .. } => Some(vec![call.as_ref().into()]),
+                // Doesn't contain any actual calls
+                pallet_multisig::Call::approve_as_multi {  .. }
+                | pallet_multisig::Call::cancel_as_multi { .. }
+                // Ignored calls
+                | pallet_multisig::Call::__Ignore(..) => None,
+            }
+        } else {
+            None
+        }
+    }
+}
+
+/// Trait used to extract nested `RuntimeCall`s from a `RuntimeCall` type.
+/// Each runtime has a different set of pallets which can nest calls.
+pub trait MaybeNestedCall<Runtime: frame_system::Config> {
+    /// If this call is a nested runtime call, returns the inner call(s).
+    ///
+    /// Ignored calls (such as `pallet_utility::Call::__Ignore`) should be yielded themsevles, but
+    /// their contents should not be yielded.
+    fn maybe_nested_call(&self) -> Option<Vec<&RuntimeCallFor<Runtime>>>;
+}
+
+/// Returns an interator over `call`, and any calls nested within it.
 ///
 /// The iterator yields all calls in depth-first order, including calls which contain other calls.
-/// `pallet_utility::Call::__Ignore` calls are yielded themsevles, but their contents are not.
-// This function doesn't use stack recursion, so there's no need to check the recursion depth.
-pub fn nested_utility_call_iter<Runtime>(
+/// Ignored calls (such as `pallet_utility::Call::__Ignore`) are yielded themsevles, but their
+/// contents are not.
+///
+/// This function doesn't use stack recursion, so there's no need to check the recursion depth.
+pub fn nested_call_iter<Runtime>(
     call: &RuntimeCallFor<Runtime>,
 ) -> impl Iterator<Item = &RuntimeCallFor<Runtime>>
 where
-    Runtime: frame_system::Config + pallet_utility::Config,
-    RuntimeCallFor<Runtime>: MaybeIntoUtilityCall<Runtime>,
-    for<'block> &'block RuntimeCallFor<Runtime>:
-        From<&'block <Runtime as pallet_utility::Config>::RuntimeCall>,
+    Runtime: frame_system::Config,
+    RuntimeCallFor<Runtime>: MaybeNestedCall<Runtime>,
 {
     // Instead of using recursion, we allocate references to each call on the heap.
-    // TODO: re-use the same memory with an enum for a call ref, a boxed call, or a vec of calls
     let mut new_calls = VecDeque::from([call]);
 
     core::iter::from_fn(move || {
         let call = new_calls.pop_front()?;
 
-        if let Some(call) = call.maybe_into_utility_call() {
-            match call {
-                pallet_utility::Call::batch { calls }
-                | pallet_utility::Call::batch_all { calls }
-                | pallet_utility::Call::force_batch { calls } => calls.iter().for_each(|call| {
-                    new_calls.push_front(call.into());
-                }),
-                pallet_utility::Call::as_derivative { call, .. }
-                | pallet_utility::Call::dispatch_as { call, .. }
-                | pallet_utility::Call::with_weight { call, .. } => {
-                    new_calls.push_front(call.as_ref().into())
-                }
-                pallet_utility::Call::__Ignore(..) => {}
-            }
+        for call in call.maybe_nested_call().into_iter().flatten() {
+            new_calls.push_front(call);
         }
 
         Some(call)

--- a/crates/subspace-runtime/src/object_mapping.rs
+++ b/crates/subspace-runtime/src/object_mapping.rs
@@ -9,7 +9,10 @@ use subspace_core_primitives::objects::{BlockObject, BlockObjectMapping};
 
 const MAX_OBJECT_MAPPING_RECURSION_DEPTH: u16 = 5;
 
-/// Extract the nested object mappings from `call`.
+/// Extract the nested `pallet-utility` object mappings from `call`.
+///
+/// Object mappings are currently ignored if nested within unprivileged multisig `RuntimeCalls`,
+/// privileged sudo, collective, and scheduler `RuntimeCall`s, and democracy nested `BoundedCall`s.
 // TODO:
 // - add start and end nesting closures to nested_call_iter(), so we can modify and restore
 //   the base offset

--- a/crates/subspace-runtime/src/object_mapping.rs
+++ b/crates/subspace-runtime/src/object_mapping.rs
@@ -11,9 +11,10 @@ const MAX_OBJECT_MAPPING_RECURSION_DEPTH: u16 = 5;
 
 /// Extract the nested object mappings from `call`.
 // TODO:
-// - add start and end nesting closures to nested_utility_call_iter(), so we can modify and restore
+// - add start and end nesting closures to nested_call_iter(), so we can modify and restore
 //   the base offset
-// - convert this code to use nested_utility_call_iter(), and remove the recursion depth limit
+// - convert this code to use nested_call_iter(), and remove the recursion depth limit
+// - extract other nested calls: sudo, collective, multisig, scheduler, democracy (BoundedCall)
 pub(crate) fn extract_utility_block_object_mapping(
     mut base_offset: u32,
     objects: &mut Vec<BlockObject>,

--- a/crates/subspace-runtime/src/signed_extensions.rs
+++ b/crates/subspace-runtime/src/signed_extensions.rs
@@ -12,7 +12,7 @@ use sp_runtime::transaction_validity::{
     ValidTransaction,
 };
 use sp_std::prelude::*;
-use subspace_runtime_primitives::utility::nested_utility_call_iter;
+use subspace_runtime_primitives::utility::nested_call_iter;
 
 /// Disable balance transfers, if configured in the runtime.
 #[derive(Debug, Encode, Decode, Clone, Eq, PartialEq, Default, TypeInfo)]
@@ -89,8 +89,9 @@ impl TransactionExtension<RuntimeCall> for DisablePallets {
 }
 
 fn contains_balance_transfer(call: &RuntimeCall) -> bool {
-    for call in nested_utility_call_iter::<Runtime>(call) {
-        // Other calls are inconclusive, they might contain nested calls
+    for call in nested_call_iter::<Runtime>(call) {
+        // Any other calls might contain nested calls, so we can only return early if we find a
+        // balance transfer call.
         if let RuntimeCall::Balances(
             pallet_balances::Call::transfer_allow_death { .. }
             | pallet_balances::Call::transfer_keep_alive { .. }

--- a/domains/pallets/evm-tracker/Cargo.toml
+++ b/domains/pallets/evm-tracker/Cargo.toml
@@ -21,7 +21,6 @@ pallet-ethereum.workspace = true
 pallet-evm.workspace = true
 pallet-block-fees.workspace = true
 pallet-transaction-payment.workspace = true
-pallet-utility.workspace = true
 scale-info = { workspace = true, features = ["derive"] }
 sp-core.workspace = true
 sp-domains.workspace = true
@@ -41,7 +40,6 @@ std = [
     "pallet-evm/std",
     "pallet-block-fees/std",
     "pallet-transaction-payment/std",
-    "pallet-utility/std",
     "scale-info/std",
     "sp-core/std",
     "sp-domains/std",

--- a/domains/pallets/evm-tracker/src/create_contract.rs
+++ b/domains/pallets/evm-tracker/src/create_contract.rs
@@ -17,7 +17,7 @@ use sp_runtime::transaction_validity::{
     ValidTransaction,
 };
 use sp_weights::Weight;
-use subspace_runtime_primitives::utility::{nested_utility_call_iter, MaybeIntoUtilityCall};
+use subspace_runtime_primitives::utility::{nested_call_iter, MaybeNestedCall};
 
 /// Rejects contracts that can't be created under the current allow list.
 /// Returns false if the call is a contract call, and the account is *not* allowed to call it.
@@ -30,12 +30,9 @@ where
     Runtime: frame_system::Config<AccountId = EthereumAccountId>
         + pallet_ethereum::Config
         + pallet_evm::Config
-        + pallet_utility::Config
         + crate::Config,
     RuntimeCallFor<Runtime>:
-        MaybeIntoEthCall<Runtime> + MaybeIntoEvmCall<Runtime> + MaybeIntoUtilityCall<Runtime>,
-    for<'block> &'block RuntimeCallFor<Runtime>:
-        From<&'block <Runtime as pallet_utility::Config>::RuntimeCall>,
+        MaybeIntoEthCall<Runtime> + MaybeIntoEvmCall<Runtime> + MaybeNestedCall<Runtime>,
     Result<pallet_ethereum::RawOrigin, OriginFor<Runtime>>: From<OriginFor<Runtime>>,
 {
     // If the account is allowed to create contracts, or it's not a contract call, return true.
@@ -49,15 +46,9 @@ where
 /// list. Otherwise, returns true.
 pub fn is_create_unsigned_contract_allowed<Runtime>(call: &RuntimeCallFor<Runtime>) -> bool
 where
-    Runtime: frame_system::Config
-        + pallet_ethereum::Config
-        + pallet_evm::Config
-        + pallet_utility::Config
-        + crate::Config,
+    Runtime: frame_system::Config + pallet_ethereum::Config + pallet_evm::Config + crate::Config,
     RuntimeCallFor<Runtime>:
-        MaybeIntoEthCall<Runtime> + MaybeIntoEvmCall<Runtime> + MaybeIntoUtilityCall<Runtime>,
-    for<'block> &'block RuntimeCallFor<Runtime>:
-        From<&'block <Runtime as pallet_utility::Config>::RuntimeCall>,
+        MaybeIntoEthCall<Runtime> + MaybeIntoEvmCall<Runtime> + MaybeNestedCall<Runtime>,
     Result<pallet_ethereum::RawOrigin, OriginFor<Runtime>>: From<OriginFor<Runtime>>,
 {
     // If any account is allowed to create contracts, or it's not a contract call, return true.
@@ -69,17 +60,12 @@ where
 /// Returns true if the call is a contract creation call.
 pub fn is_create_contract<Runtime>(call: &RuntimeCallFor<Runtime>) -> bool
 where
-    Runtime: frame_system::Config
-        + pallet_ethereum::Config
-        + pallet_evm::Config
-        + pallet_utility::Config,
+    Runtime: frame_system::Config + pallet_ethereum::Config + pallet_evm::Config,
     RuntimeCallFor<Runtime>:
-        MaybeIntoEthCall<Runtime> + MaybeIntoEvmCall<Runtime> + MaybeIntoUtilityCall<Runtime>,
-    for<'block> &'block RuntimeCallFor<Runtime>:
-        From<&'block <Runtime as pallet_utility::Config>::RuntimeCall>,
+        MaybeIntoEthCall<Runtime> + MaybeIntoEvmCall<Runtime> + MaybeNestedCall<Runtime>,
     Result<pallet_ethereum::RawOrigin, OriginFor<Runtime>>: From<OriginFor<Runtime>>,
 {
-    for call in nested_utility_call_iter::<Runtime>(call) {
+    for call in nested_call_iter::<Runtime>(call) {
         if let Some(call) = call.maybe_into_eth_call() {
             match call {
                 pallet_ethereum::Call::transact {
@@ -142,16 +128,13 @@ where
     Runtime: frame_system::Config<AccountId = EthereumAccountId>
         + pallet_ethereum::Config
         + pallet_evm::Config
-        + pallet_utility::Config
         + crate::Config
         + scale_info::TypeInfo
         + fmt::Debug
         + Send
         + Sync,
     RuntimeCallFor<Runtime>:
-        MaybeIntoEthCall<Runtime> + MaybeIntoEvmCall<Runtime> + MaybeIntoUtilityCall<Runtime>,
-    for<'block> &'block RuntimeCallFor<Runtime>:
-        From<&'block <Runtime as pallet_utility::Config>::RuntimeCall>,
+        MaybeIntoEthCall<Runtime> + MaybeIntoEvmCall<Runtime> + MaybeNestedCall<Runtime>,
     Result<pallet_ethereum::RawOrigin, OriginFor<Runtime>>: From<OriginFor<Runtime>>,
     <RuntimeCallFor<Runtime> as Dispatchable>::RuntimeOrigin:
         AsSystemOriginSigner<AccountIdFor<Runtime>> + Clone,
@@ -189,16 +172,13 @@ where
     Runtime: frame_system::Config<AccountId = EthereumAccountId>
         + pallet_ethereum::Config
         + pallet_evm::Config
-        + pallet_utility::Config
         + crate::Config
         + scale_info::TypeInfo
         + fmt::Debug
         + Send
         + Sync,
     RuntimeCallFor<Runtime>:
-        MaybeIntoEthCall<Runtime> + MaybeIntoEvmCall<Runtime> + MaybeIntoUtilityCall<Runtime>,
-    for<'block> &'block RuntimeCallFor<Runtime>:
-        From<&'block <Runtime as pallet_utility::Config>::RuntimeCall>,
+        MaybeIntoEthCall<Runtime> + MaybeIntoEvmCall<Runtime> + MaybeNestedCall<Runtime>,
     Result<pallet_ethereum::RawOrigin, OriginFor<Runtime>>: From<OriginFor<Runtime>>,
     <RuntimeCallFor<Runtime> as Dispatchable>::RuntimeOrigin:
         AsSystemOriginSigner<AccountIdFor<Runtime>> + Clone,

--- a/domains/runtime/evm/src/lib.rs
+++ b/domains/runtime/evm/src/lib.rs
@@ -40,6 +40,7 @@ use frame_support::weights::constants::ParityDbWeight;
 use frame_support::weights::{ConstantMultiplier, Weight};
 use frame_support::{construct_runtime, parameter_types};
 use frame_system::limits::{BlockLength, BlockWeights};
+use frame_system::pallet_prelude::RuntimeCallFor;
 use pallet_block_fees::fees::OnChargeDomainTransaction;
 use pallet_ethereum::{
     PostLogContent, Transaction as EthereumTransaction, TransactionAction, TransactionData,
@@ -93,7 +94,7 @@ use sp_subspace_mmr::domain_mmr_runtime_interface::{
 use sp_subspace_mmr::{ConsensusChainMmrLeafProof, MmrLeaf};
 use sp_version::RuntimeVersion;
 use static_assertions::const_assert;
-use subspace_runtime_primitives::utility::MaybeIntoUtilityCall;
+use subspace_runtime_primitives::utility::{MaybeNestedCall, MaybeUtilityCall};
 use subspace_runtime_primitives::{
     BlockNumber as ConsensusBlockNumber, DomainEventSegmentSize, Hash as ConsensusBlockHash,
     Moment, SlowAdjustingFeeUpdate, SHANNON, SSC,
@@ -774,13 +775,25 @@ impl pallet_utility::Config for Runtime {
     type WeightInfo = pallet_utility::weights::SubstrateWeight<Runtime>;
 }
 
-impl MaybeIntoUtilityCall<Runtime> for RuntimeCall {
+impl MaybeUtilityCall<Runtime> for RuntimeCall {
     /// If this call is a `pallet_utility::Call<Runtime>` call, returns the inner call.
-    fn maybe_into_utility_call(&self) -> Option<&pallet_utility::Call<Runtime>> {
+    fn maybe_utility_call(&self) -> Option<&pallet_utility::Call<Runtime>> {
         match self {
             RuntimeCall::Utility(call) => Some(call),
             _ => None,
         }
+    }
+}
+
+impl MaybeNestedCall<Runtime> for RuntimeCall {
+    /// If this call is a nested runtime call, returns the inner call(s).
+    ///
+    /// Ignored calls (such as `pallet_utility::Call::__Ignore`) should be yielded themsevles, but
+    /// their contents should not be yielded.
+    fn maybe_nested_call(&self) -> Option<Vec<&RuntimeCallFor<Runtime>>> {
+        // We currently ignore privileged calls, because privileged users can already change
+        // runtime code. Domain sudo `RuntimeCall`s also have to pass inherent validation.
+        self.maybe_nested_utility_calls()
     }
 }
 

--- a/test/subspace-test-runtime/Cargo.toml
+++ b/test/subspace-test-runtime/Cargo.toml
@@ -25,6 +25,7 @@ pallet-balances.workspace = true
 pallet-domains.workspace = true
 pallet-messenger.workspace = true
 pallet-mmr.workspace = true
+pallet-multisig.workspace = true
 pallet-rewards.workspace = true
 pallet-runtime-configs.workspace = true
 pallet-subspace = { workspace = true, features = ["serde"] }
@@ -79,6 +80,7 @@ std = [
     "pallet-domains/std",
     "pallet-messenger/std",
     "pallet-mmr/std",
+    "pallet-multisig/std",
     "pallet-rewards/std",
     "pallet-runtime-configs/std",
     "pallet-subspace/std",
@@ -122,8 +124,9 @@ runtime-benchmarks = [
     "frame-system/runtime-benchmarks",
     "pallet-balances/runtime-benchmarks",
     "pallet-domains/runtime-benchmarks",
-    "pallet-mmr/runtime-benchmarks",
     "pallet-messenger/runtime-benchmarks",
+    "pallet-mmr/runtime-benchmarks",
+    "pallet-multisig/runtime-benchmarks",
     "pallet-rewards/runtime-benchmarks",
     "pallet-runtime-configs/runtime-benchmarks",
     "pallet-subspace/runtime-benchmarks",

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -48,13 +48,14 @@ use frame_support::inherent::ProvideInherent;
 use frame_support::traits::fungible::Inspect;
 use frame_support::traits::tokens::WithdrawConsequence;
 use frame_support::traits::{
-    ConstU128, ConstU16, ConstU32, ConstU64, ConstU8, Currency, ExistenceRequirement, Get,
-    Imbalance, Time, VariantCount, WithdrawReasons,
+    ConstU128, ConstU16, ConstU32, ConstU64, ConstU8, Currency, Everything, ExistenceRequirement,
+    Get, Imbalance, Time, VariantCount, WithdrawReasons,
 };
 use frame_support::weights::constants::{ParityDbWeight, WEIGHT_REF_TIME_PER_SECOND};
 use frame_support::weights::{ConstantMultiplier, Weight};
 use frame_support::{construct_runtime, parameter_types, PalletId};
 use frame_system::limits::{BlockLength, BlockWeights};
+use frame_system::pallet_prelude::{OriginFor, RuntimeCallFor};
 use pallet_balances::NegativeImbalance;
 pub use pallet_rewards::RewardPoint;
 pub use pallet_subspace::{AllowAuthoringBy, EnableRewardsAt};
@@ -85,14 +86,19 @@ use sp_messenger::{ChannelNonce, XdmId};
 use sp_messenger_host_functions::{get_storage_key, StorageKeyRequest};
 use sp_mmr_primitives::EncodableOpaqueLeaf;
 use sp_runtime::traits::{
-    AccountIdConversion, AccountIdLookup, BlakeTwo256, Block as BlockT, ConstBool, DispatchInfoOf,
-    Keccak256, NumberFor, PostDispatchInfoOf, Zero,
+    AccountIdConversion, AccountIdLookup, AsSystemOriginSigner, BlakeTwo256, Block as BlockT,
+    ConstBool, DispatchInfoOf, Keccak256, NumberFor, PostDispatchInfoOf, TransactionExtension,
+    ValidateResult, Zero,
 };
 use sp_runtime::transaction_validity::{
     InvalidTransaction, TransactionSource, TransactionValidity, TransactionValidityError,
+    ValidTransaction,
 };
 use sp_runtime::type_with_default::TypeWithDefault;
-use sp_runtime::{generic, AccountId32, ApplyExtrinsicResult, ExtrinsicInclusionMode, Perbill};
+use sp_runtime::{
+    generic, impl_tx_ext_default, AccountId32, ApplyExtrinsicResult, ExtrinsicInclusionMode,
+    Perbill,
+};
 use sp_std::collections::btree_map::BTreeMap;
 use sp_std::collections::btree_set::BTreeSet;
 use sp_std::marker::PhantomData;
@@ -107,7 +113,9 @@ use subspace_core_primitives::segments::{
 };
 use subspace_core_primitives::solutions::SolutionRange;
 use subspace_core_primitives::{hashes, PublicKey, Randomness, SlotNumber, U256};
-use subspace_runtime_primitives::utility::DefaultNonceProvider;
+use subspace_runtime_primitives::utility::{
+    nested_call_iter, DefaultNonceProvider, MaybeMultisigCall, MaybeNestedCall, MaybeUtilityCall,
+};
 use subspace_runtime_primitives::{
     AccountId, Balance, BlockNumber, ConsensusEventSegmentSize, FindBlockRewardAddress, Hash,
     HoldIdentifier, Moment, Nonce, Signature, MIN_REPLICATION_FACTOR, SHANNON, SSC,
@@ -221,7 +229,10 @@ pub type SS58Prefix = ConstU16<6094>;
 
 impl frame_system::Config for Runtime {
     /// The basic call filter to use in dispatchable.
-    type BaseCallFilter = frame_support::traits::Everything;
+    ///
+    /// `Everything` is used here as we use the signed extension
+    /// `DisablePallets` as the actual call filter.
+    type BaseCallFilter = Everything;
     /// Block & extrinsics weights: base values and limits.
     type BlockWeights = SubspaceBlockWeights;
     /// The maximum length of a block (in bytes).
@@ -544,6 +555,51 @@ impl pallet_utility::Config for Runtime {
     type RuntimeCall = RuntimeCall;
     type PalletsOrigin = OriginCaller;
     type WeightInfo = pallet_utility::weights::SubstrateWeight<Runtime>;
+}
+
+impl MaybeMultisigCall<Runtime> for RuntimeCall {
+    /// If this call is a `pallet_multisig::Call<Runtime>` call, returns the inner call.
+    fn maybe_multisig_call(&self) -> Option<&pallet_multisig::Call<Runtime>> {
+        match self {
+            RuntimeCall::Multisig(call) => Some(call),
+            _ => None,
+        }
+    }
+}
+
+impl MaybeUtilityCall<Runtime> for RuntimeCall {
+    /// If this call is a `pallet_utility::Call<Runtime>` call, returns the inner call.
+    fn maybe_utility_call(&self) -> Option<&pallet_utility::Call<Runtime>> {
+        match self {
+            RuntimeCall::Utility(call) => Some(call),
+            _ => None,
+        }
+    }
+}
+
+impl MaybeNestedCall<Runtime> for RuntimeCall {
+    /// If this call is a nested runtime call, returns the inner call(s).
+    ///
+    /// Ignored calls (such as `pallet_utility::Call::__Ignore`) should be yielded themsevles, but
+    /// their contents should not be yielded.
+    fn maybe_nested_call(&self) -> Option<Vec<&RuntimeCallFor<Runtime>>> {
+        // We currently ignore privileged calls, because privileged users can already change
+        // runtime code. This includes sudo, collective, and scheduler nested `RuntimeCall`s,
+        // and democracy nested `BoundedCall`s.
+
+        // It is ok to return early, because each call can only belong to one pallet.
+        let calls = self.maybe_nested_utility_calls();
+        if calls.is_some() {
+            return calls;
+        }
+
+        let calls = self.maybe_nested_multisig_calls();
+        if calls.is_some() {
+            return calls;
+        }
+
+        None
+    }
 }
 
 impl pallet_sudo::Config for Runtime {
@@ -889,6 +945,41 @@ impl pallet_runtime_configs::Config for Runtime {
     type WeightInfo = pallet_runtime_configs::weights::SubstrateWeight<Runtime>;
 }
 
+parameter_types! {
+    pub const MaxSignatories: u32 = 100;
+}
+
+macro_rules! deposit {
+    ($name:ident, $item_fee:expr, $items:expr, $bytes:expr) => {
+        pub struct $name;
+
+        impl Get<Balance> for $name {
+            fn get() -> Balance {
+                $item_fee.saturating_mul($items.into()).saturating_add(
+                    TransactionFees::transaction_byte_fee().saturating_mul($bytes.into()),
+                )
+            }
+        }
+    };
+}
+
+// One storage item; key size is 32; value is size 4+4+16+32 bytes = 56 bytes.
+// Each multisig costs 20 SSC + bytes_of_storge * TransactionByteFee
+deposit!(DepositBaseFee, 20 * SSC, 1u32, 88u32);
+
+// Additional storage item size of 32 bytes.
+deposit!(DepositFactor, 0u128, 0u32, 32u32);
+
+impl pallet_multisig::Config for Runtime {
+    type RuntimeEvent = RuntimeEvent;
+    type RuntimeCall = RuntimeCall;
+    type Currency = Balances;
+    type DepositBase = DepositBaseFee;
+    type DepositFactor = DepositFactor;
+    type MaxSignatories = MaxSignatories;
+    type WeightInfo = pallet_multisig::weights::SubstrateWeight<Runtime>;
+}
+
 construct_runtime!(
     pub struct Runtime {
         System: frame_system = 0,
@@ -913,6 +1004,9 @@ construct_runtime!(
         Messenger: pallet_messenger exclude_parts { Inherent } = 60,
         Transporter: pallet_transporter = 61,
 
+        // Multisig
+        Multisig: pallet_multisig = 90,
+
         // Reserve some room for other pallets as we'll remove sudo pallet eventually.
         Sudo: pallet_sudo = 100,
     }
@@ -934,6 +1028,7 @@ pub type SignedExtra = (
     frame_system::CheckNonce<Runtime>,
     frame_system::CheckWeight<Runtime>,
     pallet_transaction_payment::ChargeTransactionPayment<Runtime>,
+    DisablePallets,
     pallet_subspace::extensions::SubspaceExtension<Runtime>,
     pallet_domains::extensions::DomainsExtension<Runtime>,
     pallet_messenger::extensions::MessengerExtension<Runtime>,
@@ -1171,6 +1266,7 @@ fn create_unsigned_general_extrinsic(call: RuntimeCall) -> UncheckedExtrinsic {
         // for unsigned extrinsic, transaction fee check will be skipped
         // so set a default value
         pallet_transaction_payment::ChargeTransactionPayment::<Runtime>::from(0u128),
+        DisablePallets,
         pallet_subspace::extensions::SubspaceExtension::<Runtime>::new(),
         pallet_domains::extensions::DomainsExtension::<Runtime>::new(),
         pallet_messenger::extensions::MessengerExtension::<Runtime>::new(),
@@ -1729,4 +1825,95 @@ impl_runtime_apis! {
             vec![]
         }
     }
+}
+
+/// Disable balance transfers, if configured in the runtime.
+#[derive(Debug, Encode, Decode, Clone, Eq, PartialEq, Default, TypeInfo)]
+pub struct DisablePallets;
+
+impl DisablePallets {
+    fn do_validate_unsigned(call: &RuntimeCall) -> TransactionValidity {
+        if matches!(call, RuntimeCall::Domains(_)) && !RuntimeConfigs::enable_domains() {
+            InvalidTransaction::Call.into()
+        } else {
+            Ok(ValidTransaction::default())
+        }
+    }
+
+    fn do_validate_signed(call: &RuntimeCall) -> TransactionValidity {
+        // Disable normal balance transfers.
+        if !RuntimeConfigs::enable_balance_transfers() && contains_balance_transfer(call) {
+            Err(InvalidTransaction::Call.into())
+        } else {
+            Ok(ValidTransaction::default())
+        }
+    }
+}
+
+impl TransactionExtension<RuntimeCall> for DisablePallets {
+    const IDENTIFIER: &'static str = "DisablePallets";
+    type Implicit = ();
+    type Val = ();
+    type Pre = ();
+
+    // TODO: calculate weight for extension
+    fn weight(&self, _call: &RuntimeCall) -> Weight {
+        // there is always one storage read
+        <Runtime as frame_system::Config>::DbWeight::get().reads(1)
+    }
+
+    fn validate(
+        &self,
+        origin: OriginFor<Runtime>,
+        call: &RuntimeCallFor<Runtime>,
+        _info: &DispatchInfoOf<RuntimeCallFor<Runtime>>,
+        _len: usize,
+        _self_implicit: Self::Implicit,
+        _inherited_implication: &impl Encode,
+        _source: TransactionSource,
+    ) -> ValidateResult<Self::Val, RuntimeCallFor<Runtime>> {
+        let validity = if origin.as_system_origin_signer().is_some() {
+            Self::do_validate_signed(call)?
+        } else {
+            ValidTransaction::default()
+        };
+
+        Ok((validity, (), origin))
+    }
+
+    impl_tx_ext_default!(RuntimeCallFor<Runtime>; prepare);
+
+    fn bare_validate(
+        call: &RuntimeCallFor<Runtime>,
+        _info: &DispatchInfoOf<RuntimeCallFor<Runtime>>,
+        _len: usize,
+    ) -> TransactionValidity {
+        Self::do_validate_unsigned(call)
+    }
+
+    fn bare_validate_and_prepare(
+        call: &RuntimeCallFor<Runtime>,
+        _info: &DispatchInfoOf<RuntimeCallFor<Runtime>>,
+        _len: usize,
+    ) -> Result<(), TransactionValidityError> {
+        Self::do_validate_unsigned(call)?;
+        Ok(())
+    }
+}
+
+fn contains_balance_transfer(call: &RuntimeCall) -> bool {
+    for call in nested_call_iter::<Runtime>(call) {
+        // Any other calls might contain nested calls, so we can only return early if we find a
+        // balance transfer call.
+        if let RuntimeCall::Balances(
+            pallet_balances::Call::transfer_allow_death { .. }
+            | pallet_balances::Call::transfer_keep_alive { .. }
+            | pallet_balances::Call::transfer_all { .. },
+        ) = call
+        {
+            return true;
+        }
+    }
+
+    false
 }

--- a/test/subspace-test-service/src/lib.rs
+++ b/test/subspace-test-service/src/lib.rs
@@ -96,7 +96,8 @@ use subspace_service::{FullSelectChain, RuntimeExecutor};
 use subspace_test_client::{chain_spec, Backend, Client};
 use subspace_test_primitives::OnchainStateApi;
 use subspace_test_runtime::{
-    Runtime, RuntimeApi, RuntimeCall, SignedExtra, UncheckedExtrinsic, SLOT_DURATION,
+    DisablePallets, Runtime, RuntimeApi, RuntimeCall, SignedExtra, UncheckedExtrinsic,
+    SLOT_DURATION,
 };
 use substrate_frame_rpc_system::AccountNonceApi;
 use substrate_test_client::{RpcHandlersExt, RpcTransactionError, RpcTransactionOutput};
@@ -1382,6 +1383,7 @@ fn get_signed_extra(
         frame_system::CheckNonce::<Runtime>::from(nonce.into()),
         frame_system::CheckWeight::<Runtime>::new(),
         pallet_transaction_payment::ChargeTransactionPayment::<Runtime>::from(tip),
+        DisablePallets,
         pallet_subspace::extensions::SubspaceExtension::<Runtime>::new(),
         pallet_domains::extensions::DomainsExtension::<Runtime>::new(),
         pallet_messenger::extensions::MessengerExtension::<Runtime>::new(),
@@ -1414,7 +1416,7 @@ where
         >::from_raw(
             function,
             extra.clone(),
-            ((), 100, 1, genesis_block, current_block_hash, (), (), (), (), (),()),
+            ((), 100, 1, genesis_block, current_block_hash, (), (), (), (), (), (),()),
         ),
         extra,
     )


### PR DESCRIPTION
This PR is based on PR #3440.

Multisig calls can contain balance transfers, so this PR includes them during the Extension check.

This PR adds a default implementation of `MaybeUtilityCall::maybe_nested_utility_calls()` in `subspace-runtime-primitives`, but keeps the runtime-specific extractors. The new `MaybeNestedCall` extractors can call the shared utility and multisig implementations as needed.

This allows runtimes to override the default nested call extraction code for each pallet, and extract from the pallets used in that specific runtime.

Since we currently only care about unprivileged utility and multisig nested calls, the runtime implementations only extract those calls. If in future there are more pallets with nested calls, or we need to check privileged calls, we can add those calls to the runtime extractor implementations.

This keeps code duplication to a minimum across the 4 relevant runtimes: subspace, evm, and their test runtimes.

### Discarded Alternatives

We cannot use chaining iterators here since multisig calls can contain utility calls as well. (We can't even `flat_map()` each extraction function's outputs into the next extraction function, because that wouldn't find `B in A` or `A in B in A`.)

~~This PR moves the runtime-specific call extraction logic into each runtime, so that runtimes that use the multisig pallet can extract its nested calls, but runtimes that don't use multisig can still use the same iterator function. This also has the advantage of simplifying dependencies and trait bounds.~~

~~This involves a small amount of code duplication across some runtimes, but that duplication is only limited to the utility pallet.~~

### TODO

- [ ] Add tests for these to this PR. (The existing tests pass with these limits.)

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
