### PR TITLE
Introduce V1 message format for XDM

### DIFF
--- a/crates/subspace-runtime-primitives/src/lib.rs
+++ b/crates/subspace-runtime-primitives/src/lib.rs
@@ -10,13 +10,17 @@ extern crate alloc;
 use crate::time::{BLOCKS_IN_AN_MINUTE, BLOCKS_IN_A_DAY};
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
+use core::marker::PhantomData;
 use frame_support::pallet_prelude::Weight;
 use frame_support::traits::tokens;
 use frame_support::weights::constants::WEIGHT_REF_TIME_PER_SECOND;
+use frame_support::weights::WeightToFee;
 use frame_support::{Deserialize, Serialize};
 use frame_system::limits::BlockLength;
 use frame_system::offchain::CreateTransactionBase;
-use pallet_transaction_payment::{Multiplier, TargetedFeeAdjustment};
+use pallet_transaction_payment::{
+    Multiplier, NextFeeMultiplier, OnChargeTransaction, TargetedFeeAdjustment,
+};
 use parity_scale_codec::{Codec, Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
 use sp_core::parameter_types;
@@ -247,6 +251,29 @@ impl<Balance: Codec + tokens::Balance> Default for BlockTransactionByteFee<Balan
             current: Balance::max_value(),
             next: Balance::max_value(),
         }
+    }
+}
+
+parameter_types! {
+    pub const XdmFeeMultipler: u32 = 5;
+}
+
+/// Balance type pointing to the OnChargeTransaction trait.
+pub type OnChargeTransactionBalance<T> = <<T as pallet_transaction_payment::Config>::OnChargeTransaction as OnChargeTransaction<
+    T,
+>>::Balance;
+
+/// Adjusted XDM Weight to fee Conversion.
+pub struct XdmAdjustedWeightToFee<T>(PhantomData<T>);
+impl<T: pallet_transaction_payment::Config> WeightToFee for XdmAdjustedWeightToFee<T> {
+    type Balance = OnChargeTransactionBalance<T>;
+
+    fn weight_to_fee(weight: &Weight) -> Self::Balance {
+        // the adjustable part of the fee.
+        let unadjusted_weight_fee = pallet_transaction_payment::Pallet::<T>::weight_to_fee(*weight);
+        let multiplier = NextFeeMultiplier::<T>::get();
+        // final adjusted weight fee.
+        multiplier.saturating_mul_int(unadjusted_weight_fee)
     }
 }
 

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -103,8 +103,9 @@ use subspace_runtime_primitives::utility::{DefaultNonceProvider, MaybeIntoUtilit
 use subspace_runtime_primitives::{
     maximum_normal_block_length, AccountId, Balance, BlockNumber, ConsensusEventSegmentSize,
     FindBlockRewardAddress, Hash, HoldIdentifier, Moment, Nonce, Signature, SlowAdjustingFeeUpdate,
-    TargetBlockFullness, BLOCK_WEIGHT_FOR_2_SEC, DOMAINS_BLOCK_PRUNING_DEPTH, MAX_BLOCK_LENGTH,
-    MIN_REPLICATION_FACTOR, NORMAL_DISPATCH_RATIO, SHANNON, SLOT_PROBABILITY, SSC,
+    TargetBlockFullness, XdmAdjustedWeightToFee, XdmFeeMultipler, BLOCK_WEIGHT_FOR_2_SEC,
+    DOMAINS_BLOCK_PRUNING_DEPTH, MAX_BLOCK_LENGTH, MIN_REPLICATION_FACTOR, NORMAL_DISPATCH_RATIO,
+    SHANNON, SLOT_PROBABILITY, SSC,
 };
 
 sp_runtime::impl_opaque_keys! {
@@ -702,6 +703,8 @@ impl pallet_messenger::Config for Runtime {
     type Currency = Balances;
     type WeightInfo = pallet_messenger::weights::SubstrateWeight<Runtime>;
     type WeightToFee = ConstantMultiplier<Balance, TransactionWeightFee>;
+    type AdjustedWeightToFee = XdmAdjustedWeightToFee<Runtime>;
+    type FeeMultiplier = XdmFeeMultipler;
     type OnXDMRewards = OnXDMRewards;
     type MmrHash = mmr::Hash;
     type MmrProofVerifier = MmrProofVerifier;

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -676,6 +676,7 @@ parameter_types! {
     // TODO update the fee model
     pub const ChannelFeeModel: FeeModel<Balance> = FeeModel{relay_fee: SSC};
     pub const MaxOutgoingMessages: u32 = MAX_OUTGOING_MESSAGES;
+    pub const MessageVersion: pallet_messenger::MessageVersion = pallet_messenger::MessageVersion::V0;
 }
 
 // ensure the max outgoing messages is not 0.
@@ -717,6 +718,7 @@ impl pallet_messenger::Config for Runtime {
     type ChannelFeeModel = ChannelFeeModel;
     type MaxOutgoingMessages = MaxOutgoingMessages;
     type MessengerOrigin = pallet_messenger::EnsureMessengerOrigin;
+    type MessageVersion = MessageVersion;
 }
 
 impl<C> frame_system::offchain::CreateTransactionBase<C> for Runtime

--- a/domains/pallets/messenger/src/lib.rs
+++ b/domains/pallets/messenger/src/lib.rs
@@ -526,6 +526,9 @@ mod pallet {
 
         /// Message count underflow
         MessageCountUnderflow,
+
+        /// Incorrect message version
+        MessageVersionMismatch,
     }
 
     #[pallet::call]

--- a/domains/pallets/messenger/src/lib.rs
+++ b/domains/pallets/messenger/src/lib.rs
@@ -212,6 +212,7 @@ mod pallet {
         type AdjustedWeightToFee: WeightToFee<Balance = BalanceOf<Self>>;
         /// Fee Multiper for XDM
         /// Final fee calculated will fee_multiplier * adjusted_weight_to_fee.
+        #[pallet::constant]
         type FeeMultiplier: Get<u32>;
         /// Handle XDM rewards.
         type OnXDMRewards: OnXDMRewards<BalanceOf<Self>>;
@@ -241,10 +242,12 @@ mod pallet {
         /// Channels fee model
         type ChannelFeeModel: Get<FeeModel<BalanceOf<Self>>>;
         /// Maximum outgoing messages from a given channel
+        #[pallet::constant]
         type MaxOutgoingMessages: Get<u32>;
         /// Origin for messenger call.
         type MessengerOrigin: EnsureOrigin<Self::RuntimeOrigin, Success = ()>;
         /// Message version to use.
+        #[pallet::constant]
         type MessageVersion: Get<crate::MessageVersion>;
     }
 

--- a/domains/pallets/messenger/src/lib.rs
+++ b/domains/pallets/messenger/src/lib.rs
@@ -197,6 +197,12 @@ mod pallet {
         type WeightInfo: WeightInfo;
         /// Weight to fee conversion.
         type WeightToFee: WeightToFee<Balance = BalanceOf<Self>>;
+        /// Adjusted Weight to fee conversion.
+        /// This includes the TransactionPayment Multiper at the time of fee deduction.
+        type AdjustedWeightToFee: WeightToFee<Balance = BalanceOf<Self>>;
+        /// Fee Multiper for XDM
+        /// Final fee calculated will fee_multiplier * adjusted_weight_to_fee.
+        type FeeMultiplier: Get<u32>;
         /// Handle XDM rewards.
         type OnXDMRewards: OnXDMRewards<BalanceOf<Self>>;
         /// Hash type of MMR

--- a/domains/pallets/messenger/src/messages.rs
+++ b/domains/pallets/messenger/src/messages.rs
@@ -1,7 +1,7 @@
 #[cfg(not(feature = "std"))]
 extern crate alloc;
 
-use crate::pallet::{ChainAllowlist, OutboxMessageCount, UpdatedChannels};
+use crate::pallet::{ChainAllowlist, InboxFee, OutboxMessageCount, UpdatedChannels};
 use crate::{
     BalanceOf, ChannelId, ChannelState, Channels, CloseChannelBy, Config, Error, Event,
     InboxResponses, MessageWeightTags as MessageWeightTagStore, Nonce, Outbox, OutboxMessageResult,
@@ -16,9 +16,9 @@ use parity_scale_codec::{Decode, Encode};
 use scale_info::TypeInfo;
 use sp_messenger::endpoint::{EndpointHandler, EndpointRequest, EndpointResponse};
 use sp_messenger::messages::{
-    BlockMessageWithStorageKey, BlockMessagesWithStorageKey, ChainId, Message, MessageId,
-    MessageWeightTag, Payload, ProtocolMessageRequest, ProtocolMessageResponse, RequestResponse,
-    VersionedPayload,
+    BlockMessageWithStorageKey, BlockMessagesWithStorageKey, ChainId, ChannelOpenParams,
+    ConvertedPayload, Message, MessageId, MessageWeightTag, Payload, ProtocolMessageRequest,
+    ProtocolMessageResponse, RequestResponse, VersionedPayload,
 };
 use sp_runtime::traits::Get;
 use sp_runtime::{ArithmeticError, DispatchError, DispatchResult};
@@ -121,29 +121,41 @@ impl<T: Config> Pallet<T> {
             "The message nonce and the channel next inbox nonce must be the same as checked in pre_dispatch; qed"
         );
 
-        let response = match msg.payload {
+        let maybe_collected_fee = msg.payload.maybe_collected_fee();
+        let ConvertedPayload { payload, is_v1 } = msg.payload.into_payload_v0();
+        let response = match payload {
             // process incoming protocol message.
-            VersionedPayload::V0(Payload::Protocol(RequestResponse::Request(req))) => {
-                Payload::Protocol(RequestResponse::Response(
-                    Self::process_incoming_protocol_message_req(
-                        dst_chain_id,
-                        channel_id,
-                        req,
-                        &msg_weight_tag,
-                    ),
-                ))
-            }
+            Payload::Protocol(RequestResponse::Request(req)) => Payload::Protocol(
+                RequestResponse::Response(Self::process_incoming_protocol_message_req(
+                    dst_chain_id,
+                    channel_id,
+                    req,
+                    &msg_weight_tag,
+                )),
+            ),
 
             // process incoming endpoint message.
-            VersionedPayload::V0(Payload::Endpoint(RequestResponse::Request(req))) => {
+            Payload::Endpoint(RequestResponse::Request(req)) => {
                 // Firstly, store fees for inbox message execution regardless what the execution result is,
                 // since the fee is already charged from the sender of the src chain and processing of the
                 // XDM in this end is finished.
-                Self::store_fees_for_inbox_message(
-                    (dst_chain_id, (channel_id, nonce)),
-                    &channel.fee,
-                    &req.src_endpoint,
-                );
+                if let Some(collected_fee) = maybe_collected_fee {
+                    // since v1 collects fee on behalf of dst_chain, this chain,
+                    // so we do not recalculate the fee but instead use the collected fee as is
+                    InboxFee::<T>::insert(
+                        (dst_chain_id, (channel_id, nonce)),
+                        collected_fee.dst_chain_fee,
+                    );
+                } else {
+                    // for v0, use the weight to fee conversion to calculate the fee
+                    // and store the fee
+                    Self::store_fees_for_inbox_message(
+                        (dst_chain_id, (channel_id, nonce)),
+                        &channel.fee,
+                        &req.src_endpoint,
+                    );
+                }
+
                 let response =
                     if let Some(endpoint_handler) = T::get_endpoint_handler(&req.dst_endpoint) {
                         Self::process_incoming_endpoint_message_req(
@@ -162,17 +174,20 @@ impl<T: Config> Pallet<T> {
             }
 
             // return error for all the remaining branches
-            VersionedPayload::V0(payload) => match payload {
-                Payload::Protocol(_) => Payload::Protocol(RequestResponse::Response(Err(
-                    Error::<T>::InvalidMessagePayload.into(),
-                ))),
-                Payload::Endpoint(_) => Payload::Endpoint(RequestResponse::Response(Err(
-                    Error::<T>::InvalidMessagePayload.into(),
-                ))),
-            },
+            Payload::Protocol(_) => Payload::Protocol(RequestResponse::Response(Err(
+                Error::<T>::InvalidMessagePayload.into(),
+            ))),
+            Payload::Endpoint(_) => Payload::Endpoint(RequestResponse::Response(Err(
+                Error::<T>::InvalidMessagePayload.into(),
+            ))),
         };
 
-        let resp_payload = VersionedPayload::V0(response);
+        let resp_payload = if is_v1 {
+            VersionedPayload::V1(response.into())
+        } else {
+            VersionedPayload::V0(response)
+        };
+
         let weight_tag = MessageWeightTag::inbox_response(msg_weight_tag, &resp_payload);
 
         InboxResponses::<T>::insert(
@@ -257,7 +272,7 @@ impl<T: Config> Pallet<T> {
     fn process_incoming_protocol_message_req(
         chain_id: ChainId,
         channel_id: ChannelId,
-        req: ProtocolMessageRequest<BalanceOf<T>>,
+        req: ProtocolMessageRequest<ChannelOpenParams<BalanceOf<T>>>,
         weight_tag: &MessageWeightTag,
     ) -> Result<(), DispatchError> {
         let is_chain_allowed = ChainAllowlist::<T>::get().contains(&chain_id);
@@ -286,7 +301,7 @@ impl<T: Config> Pallet<T> {
     fn process_incoming_protocol_message_response(
         chain_id: ChainId,
         channel_id: ChannelId,
-        req: ProtocolMessageRequest<BalanceOf<T>>,
+        req: ProtocolMessageRequest<ChannelOpenParams<BalanceOf<T>>>,
         resp: ProtocolMessageResponse,
         weight_tag: &MessageWeightTag,
     ) -> DispatchResult {
@@ -361,11 +376,25 @@ impl<T: Config> Pallet<T> {
             *maybe_messages = Some(messages)
         });
 
-        let resp = match (req_msg.payload, resp_msg.payload) {
+        let ConvertedPayload {
+            payload: req,
+            is_v1: is_v1_req,
+        } = req_msg.payload.into_payload_v0();
+        let ConvertedPayload {
+            payload: resp,
+            is_v1: is_v1_resp,
+        } = resp_msg.payload.into_payload_v0();
+
+        assert_eq!(
+            is_v1_req, is_v1_resp,
+            "Both the request and response will always be of same type"
+        );
+
+        let resp = match (req, resp) {
             // process incoming protocol outbox message response.
             (
-                VersionedPayload::V0(Payload::Protocol(RequestResponse::Request(req))),
-                VersionedPayload::V0(Payload::Protocol(RequestResponse::Response(resp))),
+                Payload::Protocol(RequestResponse::Request(req)),
+                Payload::Protocol(RequestResponse::Response(resp)),
             ) => Self::process_incoming_protocol_message_response(
                 dst_chain_id,
                 channel_id,
@@ -376,8 +405,8 @@ impl<T: Config> Pallet<T> {
 
             // process incoming endpoint outbox message response.
             (
-                VersionedPayload::V0(Payload::Endpoint(RequestResponse::Request(req))),
-                VersionedPayload::V0(Payload::Endpoint(RequestResponse::Response(resp))),
+                Payload::Endpoint(RequestResponse::Request(req)),
+                Payload::Endpoint(RequestResponse::Response(resp)),
             ) => {
                 // Firstly, distribute the fees for outbox message execution regardless what the result is,
                 // since the fee is already charged from the sender and the processing of the XDM is finished.

--- a/domains/pallets/messenger/src/messages.rs
+++ b/domains/pallets/messenger/src/messages.rs
@@ -385,10 +385,7 @@ impl<T: Config> Pallet<T> {
             is_v1: is_v1_resp,
         } = resp_msg.payload.into_payload_v0();
 
-        assert_eq!(
-            is_v1_req, is_v1_resp,
-            "Both the request and response will always be of same type"
-        );
+        ensure!(is_v1_req == is_v1_resp, Error::<T>::MessageVersionMismatch);
 
         let resp = match (req, resp) {
             // process incoming protocol outbox message response.

--- a/domains/pallets/messenger/src/mock.rs
+++ b/domains/pallets/messenger/src/mock.rs
@@ -63,6 +63,7 @@ macro_rules! impl_runtime {
             pub const ChannelInitReservePortion: Perbill = Perbill::from_percent(20);
             pub const ChannelFeeModel: FeeModel<Balance> = FeeModel{relay_fee: 1};
             pub const MaxOutgoingMessages: u32 = 25;
+            pub const FeeMultiplier: u32 = 1;
         }
 
         #[derive(
@@ -107,6 +108,8 @@ macro_rules! impl_runtime {
             type ChannelFeeModel = ChannelFeeModel;
             type MaxOutgoingMessages = MaxOutgoingMessages;
             type MessengerOrigin = crate::EnsureMessengerOrigin;
+            type AdjustedWeightToFee = frame_support::weights::IdentityFee<u64>;
+            type FeeMultiplier = FeeMultiplier;
             /// function to fetch endpoint response handler by Endpoint.
             fn get_endpoint_handler(
                 #[allow(unused_variables)] endpoint: &Endpoint,

--- a/domains/pallets/messenger/src/mock.rs
+++ b/domains/pallets/messenger/src/mock.rs
@@ -64,6 +64,7 @@ macro_rules! impl_runtime {
             pub const ChannelFeeModel: FeeModel<Balance> = FeeModel{relay_fee: 1};
             pub const MaxOutgoingMessages: u32 = 25;
             pub const FeeMultiplier: u32 = 1;
+            pub const MessageVersion: crate::MessageVersion = crate::MessageVersion::V0;
         }
 
         #[derive(
@@ -110,6 +111,7 @@ macro_rules! impl_runtime {
             type MessengerOrigin = crate::EnsureMessengerOrigin;
             type AdjustedWeightToFee = frame_support::weights::IdentityFee<u64>;
             type FeeMultiplier = FeeMultiplier;
+            type MessageVersion = MessageVersion;
             /// function to fetch endpoint response handler by Endpoint.
             fn get_endpoint_handler(
                 #[allow(unused_variables)] endpoint: &Endpoint,

--- a/domains/pallets/transporter/src/mock.rs
+++ b/domains/pallets/transporter/src/mock.rs
@@ -57,6 +57,7 @@ parameter_types! {
     pub const ChannelFeeModel: FeeModel<Balance> = FeeModel{relay_fee: 1};
     pub TransactionWeightFee: Balance = 100_000;
     pub const MaxOutgoingMessages: u32 = 25;
+    pub const FeeMultiplier: u32 = 1;
 }
 
 #[derive(
@@ -113,6 +114,9 @@ impl pallet_messenger::Config for MockRuntime {
     }
 
     type MessengerOrigin = pallet_messenger::EnsureMessengerOrigin;
+    type AdjustedWeightToFee =
+        frame_support::weights::ConstantMultiplier<u64, TransactionWeightFee>;
+    type FeeMultiplier = FeeMultiplier;
 }
 
 #[derive(Debug)]

--- a/domains/pallets/transporter/src/mock.rs
+++ b/domains/pallets/transporter/src/mock.rs
@@ -58,6 +58,7 @@ parameter_types! {
     pub TransactionWeightFee: Balance = 100_000;
     pub const MaxOutgoingMessages: u32 = 25;
     pub const FeeMultiplier: u32 = 1;
+    pub const MessageVersion: pallet_messenger::MessageVersion = pallet_messenger::MessageVersion::V0;
 }
 
 #[derive(
@@ -117,6 +118,7 @@ impl pallet_messenger::Config for MockRuntime {
     type AdjustedWeightToFee =
         frame_support::weights::ConstantMultiplier<u64, TransactionWeightFee>;
     type FeeMultiplier = FeeMultiplier;
+    type MessageVersion = MessageVersion;
 }
 
 #[derive(Debug)]

--- a/domains/primitives/messenger/src/endpoint.rs
+++ b/domains/primitives/messenger/src/endpoint.rs
@@ -25,12 +25,43 @@ pub enum Endpoint {
 /// Endpoint request or response payload.
 pub type EndpointPayload = Vec<u8>;
 
+/// Fee collected on src_chain for execution of XDM on both the src and dst chains.
+#[derive(Default, Debug, Encode, Decode, Clone, Eq, PartialEq, TypeInfo)]
+pub struct CollectedFee<Balance> {
+    /// Collected execution fee for src_chain.
+    pub src_chain_fee: Balance,
+    /// Collected execution fee for dst_chain.
+    pub dst_chain_fee: Balance,
+}
+
 /// Request sent by src_endpoint to dst_endpoint.
 #[derive(Debug, Encode, Decode, Clone, Eq, PartialEq, TypeInfo)]
 pub struct EndpointRequest {
     pub src_endpoint: Endpoint,
     pub dst_endpoint: Endpoint,
     pub payload: EndpointPayload,
+}
+
+/// Request sent by src_endpoint to dst_endpoint with collected Fee
+#[derive(Debug, Encode, Decode, Clone, Eq, PartialEq, TypeInfo)]
+pub struct EndpointRequestWithCollectedFee<Balance> {
+    pub req: EndpointRequest,
+    pub collected_fee: CollectedFee<Balance>,
+}
+
+impl<Balance> From<EndpointRequestWithCollectedFee<Balance>> for EndpointRequest {
+    fn from(value: EndpointRequestWithCollectedFee<Balance>) -> Self {
+        value.req
+    }
+}
+
+impl<Balance: Default> From<EndpointRequest> for EndpointRequestWithCollectedFee<Balance> {
+    fn from(value: EndpointRequest) -> Self {
+        EndpointRequestWithCollectedFee {
+            req: value,
+            collected_fee: CollectedFee::default(),
+        }
+    }
 }
 
 /// Response for the message request.

--- a/domains/primitives/messenger/src/messages.rs
+++ b/domains/primitives/messenger/src/messages.rs
@@ -1,7 +1,9 @@
 #[cfg(not(feature = "std"))]
 extern crate alloc;
 
-use crate::endpoint::{Endpoint, EndpointRequest, EndpointResponse};
+use crate::endpoint::{
+    CollectedFee, Endpoint, EndpointRequest, EndpointRequestWithCollectedFee, EndpointResponse,
+};
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 use parity_scale_codec::{Decode, Encode};
@@ -72,13 +74,51 @@ pub struct ChannelOpenParams<Balance> {
     pub fee_model: FeeModel<Balance>,
 }
 
+/// Channel V1 open parameters
+#[derive(Debug, Encode, Decode, Eq, PartialEq, TypeInfo, Copy, Clone)]
+pub struct ChannelOpenParamsV1 {
+    pub max_outgoing_messages: u32,
+}
+
 /// Defines protocol requests performed on chains.
 #[derive(Debug, Encode, Decode, Clone, Eq, PartialEq, TypeInfo)]
-pub enum ProtocolMessageRequest<Balance> {
+pub enum ProtocolMessageRequest<ChannelOpenParams> {
     /// Request to open a channel with foreign chain.
-    ChannelOpen(ChannelOpenParams<Balance>),
+    ChannelOpen(ChannelOpenParams),
     /// Request to close an open channel with foreign chain.
     ChannelClose,
+}
+
+impl<Balance: Default> From<ProtocolMessageRequest<ChannelOpenParamsV1>>
+    for ProtocolMessageRequest<ChannelOpenParams<Balance>>
+{
+    fn from(value: ProtocolMessageRequest<ChannelOpenParamsV1>) -> Self {
+        match value {
+            ProtocolMessageRequest::ChannelOpen(params) => {
+                ProtocolMessageRequest::ChannelOpen(ChannelOpenParams {
+                    max_outgoing_messages: params.max_outgoing_messages,
+                    // default is okay here as fee model is empty for V1
+                    fee_model: FeeModel::default(),
+                })
+            }
+            ProtocolMessageRequest::ChannelClose => ProtocolMessageRequest::ChannelClose,
+        }
+    }
+}
+
+impl<Balance: Default> From<ProtocolMessageRequest<ChannelOpenParams<Balance>>>
+    for ProtocolMessageRequest<ChannelOpenParamsV1>
+{
+    fn from(value: ProtocolMessageRequest<ChannelOpenParams<Balance>>) -> Self {
+        match value {
+            ProtocolMessageRequest::ChannelOpen(params) => {
+                ProtocolMessageRequest::ChannelOpen(ChannelOpenParamsV1 {
+                    max_outgoing_messages: params.max_outgoing_messages,
+                })
+            }
+            ProtocolMessageRequest::ChannelClose => ProtocolMessageRequest::ChannelClose,
+        }
+    }
 }
 
 /// Defines protocol requests performed on chains.
@@ -95,15 +135,113 @@ pub enum RequestResponse<Request, Response> {
 #[derive(Debug, Encode, Decode, Clone, Eq, PartialEq, TypeInfo)]
 pub enum Payload<Balance> {
     /// Protocol message.
-    Protocol(RequestResponse<ProtocolMessageRequest<Balance>, ProtocolMessageResponse>),
+    Protocol(
+        RequestResponse<
+            ProtocolMessageRequest<ChannelOpenParams<Balance>>,
+            ProtocolMessageResponse,
+        >,
+    ),
     /// Endpoint message.
     Endpoint(RequestResponse<EndpointRequest, EndpointResponse>),
+}
+
+impl<Balance: Default> From<PayloadV1<Balance>> for Payload<Balance> {
+    fn from(value: PayloadV1<Balance>) -> Self {
+        match value {
+            PayloadV1::Protocol(RequestResponse::Request(req)) => {
+                Payload::Protocol(RequestResponse::Request(req.into()))
+            }
+            PayloadV1::Protocol(RequestResponse::Response(resp)) => {
+                Payload::Protocol(RequestResponse::Response(resp))
+            }
+            PayloadV1::Endpoint(RequestResponse::Request(req)) => {
+                Payload::Endpoint(RequestResponse::Request(req.into()))
+            }
+            PayloadV1::Endpoint(RequestResponse::Response(resp)) => {
+                Payload::Endpoint(RequestResponse::Response(resp))
+            }
+        }
+    }
+}
+
+/// Payload v1 of the message
+#[derive(Debug, Encode, Decode, Clone, Eq, PartialEq, TypeInfo)]
+pub enum PayloadV1<Balance> {
+    /// Protocol message.
+    Protocol(RequestResponse<ProtocolMessageRequest<ChannelOpenParamsV1>, ProtocolMessageResponse>),
+    /// Endpoint message.
+    Endpoint(RequestResponse<EndpointRequestWithCollectedFee<Balance>, EndpointResponse>),
+}
+
+impl<Balance: Default> From<Payload<Balance>> for PayloadV1<Balance> {
+    fn from(value: Payload<Balance>) -> Self {
+        match value {
+            Payload::Protocol(RequestResponse::Request(req)) => {
+                PayloadV1::Protocol(RequestResponse::Request(req.into()))
+            }
+            Payload::Protocol(RequestResponse::Response(resp)) => {
+                PayloadV1::Protocol(RequestResponse::Response(resp))
+            }
+            Payload::Endpoint(RequestResponse::Request(req)) => {
+                PayloadV1::Endpoint(RequestResponse::Request(req.into()))
+            }
+            Payload::Endpoint(RequestResponse::Response(resp)) => {
+                PayloadV1::Endpoint(RequestResponse::Response(resp))
+            }
+        }
+    }
 }
 
 /// Versioned message payload
 #[derive(Debug, Encode, Decode, Clone, Eq, PartialEq, TypeInfo)]
 pub enum VersionedPayload<Balance> {
+    #[codec(index = 0)]
     V0(Payload<Balance>),
+    #[codec(index = 1)]
+    V1(PayloadV1<Balance>),
+}
+
+#[derive(Debug, Encode, Decode, Clone, Eq, PartialEq, TypeInfo)]
+pub struct ConvertedPayload<Balance> {
+    pub payload: Payload<Balance>,
+    pub is_v1: bool,
+}
+
+impl<Balance> From<Payload<Balance>> for ConvertedPayload<Balance> {
+    fn from(value: Payload<Balance>) -> Self {
+        ConvertedPayload {
+            payload: value,
+            is_v1: false,
+        }
+    }
+}
+
+impl<Balance: Default> From<PayloadV1<Balance>> for ConvertedPayload<Balance> {
+    fn from(value: PayloadV1<Balance>) -> Self {
+        ConvertedPayload {
+            payload: value.into(),
+            is_v1: true,
+        }
+    }
+}
+
+impl<Balance: Default + Clone> VersionedPayload<Balance> {
+    pub fn into_payload_v0(self) -> ConvertedPayload<Balance> {
+        match self {
+            VersionedPayload::V0(payload) => payload.into(),
+            VersionedPayload::V1(payload) => payload.into(),
+        }
+    }
+
+    pub fn maybe_collected_fee(&self) -> Option<CollectedFee<Balance>> {
+        match self {
+            // collected fee is only valid in endpoint v1 request
+            VersionedPayload::V1(PayloadV1::Endpoint(RequestResponse::Request(req))) => {
+                Some(req.collected_fee.clone())
+            }
+            _ => None,
+        }
+    }
 }
 
 /// Message weight tag used to indicate the consumed weight when handling the message
@@ -123,13 +261,20 @@ impl MessageWeightTag {
         match outbox_payload {
             VersionedPayload::V0(Payload::Protocol(RequestResponse::Request(
                 ProtocolMessageRequest::ChannelOpen(_),
+            )))
+            | VersionedPayload::V1(PayloadV1::Protocol(RequestResponse::Request(
+                ProtocolMessageRequest::ChannelOpen(_),
             ))) => MessageWeightTag::ProtocolChannelOpen,
             VersionedPayload::V0(Payload::Protocol(RequestResponse::Request(
                 ProtocolMessageRequest::ChannelClose,
+            )))
+            | VersionedPayload::V1(PayloadV1::Protocol(RequestResponse::Request(
+                ProtocolMessageRequest::ChannelClose,
             ))) => MessageWeightTag::ProtocolChannelClose,
-            VersionedPayload::V0(Payload::Endpoint(RequestResponse::Request(endpoint_req))) => {
-                MessageWeightTag::EndpointRequest(endpoint_req.dst_endpoint.clone())
-            }
+            VersionedPayload::V0(Payload::Endpoint(RequestResponse::Request(req)))
+            | VersionedPayload::V1(PayloadV1::Endpoint(RequestResponse::Request(
+                EndpointRequestWithCollectedFee { req, .. },
+            ))) => MessageWeightTag::EndpointRequest(req.dst_endpoint.clone()),
             _ => MessageWeightTag::None,
         }
     }
@@ -148,6 +293,14 @@ impl MessageWeightTag {
             (
                 MessageWeightTag::EndpointRequest(endpoint),
                 VersionedPayload::V0(Payload::Endpoint(RequestResponse::Response(_))),
+            ) => MessageWeightTag::EndpointResponse(endpoint),
+            (
+                MessageWeightTag::ProtocolChannelOpen,
+                VersionedPayload::V1(PayloadV1::Protocol(RequestResponse::Response(Ok(_)))),
+            ) => MessageWeightTag::ProtocolChannelOpen,
+            (
+                MessageWeightTag::EndpointRequest(endpoint),
+                VersionedPayload::V1(PayloadV1::Endpoint(RequestResponse::Response(_))),
             ) => MessageWeightTag::EndpointResponse(endpoint),
             _ => MessageWeightTag::None,
         }

--- a/domains/runtime/auto-id/src/lib.rs
+++ b/domains/runtime/auto-id/src/lib.rs
@@ -417,6 +417,7 @@ parameter_types! {
     // TODO update the fee model
     pub const ChannelFeeModel: FeeModel<Balance> = FeeModel{relay_fee: SSC};
     pub const MaxOutgoingMessages: u32 = MAX_OUTGOING_MESSAGES;
+    pub const MessageVersion: pallet_messenger::MessageVersion = pallet_messenger::MessageVersion::V0;
 }
 
 // ensure the max outgoing messages is not 0.
@@ -451,6 +452,7 @@ impl pallet_messenger::Config for Runtime {
     type ChannelFeeModel = ChannelFeeModel;
     type MaxOutgoingMessages = MaxOutgoingMessages;
     type MessengerOrigin = pallet_messenger::EnsureMessengerOrigin;
+    type MessageVersion = MessageVersion;
 }
 
 impl<C> frame_system::offchain::CreateTransactionBase<C> for Runtime

--- a/domains/runtime/auto-id/src/lib.rs
+++ b/domains/runtime/auto-id/src/lib.rs
@@ -71,7 +71,7 @@ use static_assertions::const_assert;
 use subspace_runtime_primitives::utility::DefaultNonceProvider;
 use subspace_runtime_primitives::{
     BlockNumber as ConsensusBlockNumber, DomainEventSegmentSize, Hash as ConsensusBlockHash,
-    Moment, SlowAdjustingFeeUpdate, SHANNON, SSC,
+    Moment, SlowAdjustingFeeUpdate, XdmAdjustedWeightToFee, XdmFeeMultipler, SHANNON, SSC,
 };
 
 /// Block type as expected by this runtime.
@@ -437,6 +437,8 @@ impl pallet_messenger::Config for Runtime {
     type Currency = Balances;
     type WeightInfo = pallet_messenger::weights::SubstrateWeight<Runtime>;
     type WeightToFee = ConstantMultiplier<Balance, TransactionWeightFee>;
+    type AdjustedWeightToFee = XdmAdjustedWeightToFee<Runtime>;
+    type FeeMultiplier = XdmFeeMultipler;
     type OnXDMRewards = OnXDMRewards;
     type MmrHash = MmrHash;
     type MmrProofVerifier = MmrProofVerifier;

--- a/domains/runtime/evm/src/lib.rs
+++ b/domains/runtime/evm/src/lib.rs
@@ -96,7 +96,7 @@ use static_assertions::const_assert;
 use subspace_runtime_primitives::utility::MaybeIntoUtilityCall;
 use subspace_runtime_primitives::{
     BlockNumber as ConsensusBlockNumber, DomainEventSegmentSize, Hash as ConsensusBlockHash,
-    Moment, SlowAdjustingFeeUpdate, SHANNON, SSC,
+    Moment, SlowAdjustingFeeUpdate, XdmAdjustedWeightToFee, XdmFeeMultipler, SHANNON, SSC,
 };
 
 /// The address format for describing accounts.
@@ -583,6 +583,8 @@ impl pallet_messenger::Config for Runtime {
     type Currency = Balances;
     type WeightInfo = pallet_messenger::weights::SubstrateWeight<Runtime>;
     type WeightToFee = ConstantMultiplier<Balance, TransactionWeightFee>;
+    type AdjustedWeightToFee = XdmAdjustedWeightToFee<Runtime>;
+    type FeeMultiplier = XdmFeeMultipler;
     type OnXDMRewards = OnXDMRewards;
     type MmrHash = MmrHash;
     type MmrProofVerifier = MmrProofVerifier;

--- a/domains/runtime/evm/src/lib.rs
+++ b/domains/runtime/evm/src/lib.rs
@@ -563,6 +563,7 @@ parameter_types! {
     // TODO update the fee model
     pub const ChannelFeeModel: FeeModel<Balance> = FeeModel{relay_fee: SSC};
     pub const MaxOutgoingMessages: u32 = MAX_OUTGOING_MESSAGES;
+    pub const MessageVersion: pallet_messenger::MessageVersion = pallet_messenger::MessageVersion::V0;
 }
 
 // ensure the max outgoing messages is not 0.
@@ -597,6 +598,7 @@ impl pallet_messenger::Config for Runtime {
     type ChannelFeeModel = ChannelFeeModel;
     type MaxOutgoingMessages = MaxOutgoingMessages;
     type MessengerOrigin = pallet_messenger::EnsureMessengerOrigin;
+    type MessageVersion = MessageVersion;
 }
 
 impl<C> frame_system::offchain::CreateTransactionBase<C> for Runtime

--- a/domains/test/runtime/auto-id/src/lib.rs
+++ b/domains/test/runtime/auto-id/src/lib.rs
@@ -410,6 +410,7 @@ parameter_types! {
     // TODO update the fee model
     pub const ChannelFeeModel: FeeModel<Balance> = FeeModel{relay_fee: SSC};
     pub const MaxOutgoingMessages: u32 = MAX_OUTGOING_MESSAGES;
+    pub const MessageVersion: pallet_messenger::MessageVersion = pallet_messenger::MessageVersion::V0;
 }
 
 // ensure the max outgoing messages is not 0.
@@ -444,6 +445,7 @@ impl pallet_messenger::Config for Runtime {
     type ChannelFeeModel = ChannelFeeModel;
     type MaxOutgoingMessages = MaxOutgoingMessages;
     type MessengerOrigin = pallet_messenger::EnsureMessengerOrigin;
+    type MessageVersion = MessageVersion;
 }
 
 impl<C> frame_system::offchain::CreateTransactionBase<C> for Runtime

--- a/domains/test/runtime/auto-id/src/lib.rs
+++ b/domains/test/runtime/auto-id/src/lib.rs
@@ -71,7 +71,7 @@ use static_assertions::const_assert;
 use subspace_runtime_primitives::utility::DefaultNonceProvider;
 use subspace_runtime_primitives::{
     BlockNumber as ConsensusBlockNumber, DomainEventSegmentSize, Hash as ConsensusBlockHash,
-    Moment, SlowAdjustingFeeUpdate, SSC,
+    Moment, SlowAdjustingFeeUpdate, XdmAdjustedWeightToFee, XdmFeeMultipler, SSC,
 };
 
 /// Block type as expected by this runtime.
@@ -430,6 +430,8 @@ impl pallet_messenger::Config for Runtime {
     type Currency = Balances;
     type WeightInfo = pallet_messenger::weights::SubstrateWeight<Runtime>;
     type WeightToFee = IdentityFee<Balance>;
+    type AdjustedWeightToFee = XdmAdjustedWeightToFee<Runtime>;
+    type FeeMultiplier = XdmFeeMultipler;
     type OnXDMRewards = OnXDMRewards;
     type MmrHash = MmrHash;
     type MmrProofVerifier = MmrProofVerifier;

--- a/domains/test/runtime/evm/src/lib.rs
+++ b/domains/test/runtime/evm/src/lib.rs
@@ -575,6 +575,7 @@ parameter_types! {
     pub const ChannelInitReservePortion: Perbill = Perbill::from_percent(20);
     pub const ChannelFeeModel: FeeModel<Balance> = FeeModel{relay_fee: SSC};
     pub const MaxOutgoingMessages: u32 = MAX_OUTGOING_MESSAGES;
+    pub const MessageVersion: pallet_messenger::MessageVersion = pallet_messenger::MessageVersion::V0;
 }
 
 // ensure the max outgoing messages is not 0.
@@ -631,6 +632,7 @@ impl pallet_messenger::Config for Runtime {
     type ChannelFeeModel = ChannelFeeModel;
     type MaxOutgoingMessages = MaxOutgoingMessages;
     type MessengerOrigin = pallet_messenger::EnsureMessengerOrigin;
+    type MessageVersion = MessageVersion;
 }
 
 impl<C> frame_system::offchain::CreateTransactionBase<C> for Runtime

--- a/domains/test/runtime/evm/src/lib.rs
+++ b/domains/test/runtime/evm/src/lib.rs
@@ -93,7 +93,7 @@ use static_assertions::const_assert;
 use subspace_runtime_primitives::utility::MaybeIntoUtilityCall;
 use subspace_runtime_primitives::{
     BlockNumber as ConsensusBlockNumber, DomainEventSegmentSize, Hash as ConsensusBlockHash,
-    Moment, SlowAdjustingFeeUpdate, SHANNON, SSC,
+    Moment, SlowAdjustingFeeUpdate, XdmAdjustedWeightToFee, XdmFeeMultipler, SHANNON, SSC,
 };
 
 /// The address format for describing accounts.
@@ -617,6 +617,8 @@ impl pallet_messenger::Config for Runtime {
     type Currency = Balances;
     type WeightInfo = pallet_messenger::weights::SubstrateWeight<Runtime>;
     type WeightToFee = ConstantMultiplier<Balance, TransactionWeightFee>;
+    type AdjustedWeightToFee = XdmAdjustedWeightToFee<Runtime>;
+    type FeeMultiplier = XdmFeeMultipler;
     type OnXDMRewards = OnXDMRewards;
     type MmrHash = MmrHash;
     type MmrProofVerifier = MmrProofVerifier;

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -626,6 +626,7 @@ parameter_types! {
     pub const ChannelInitReservePortion: Perbill = Perbill::from_percent(20);
     pub const ChannelFeeModel: FeeModel<Balance> = FeeModel{relay_fee: SSC};
     pub const MaxOutgoingMessages: u32 = MAX_OUTGOING_MESSAGES;
+    pub const MessageVersion: pallet_messenger::MessageVersion = pallet_messenger::MessageVersion::V0;
 }
 
 // ensure the max outgoing messages is not 0.
@@ -678,6 +679,7 @@ impl pallet_messenger::Config for Runtime {
     type ChannelFeeModel = ChannelFeeModel;
     type MaxOutgoingMessages = MaxOutgoingMessages;
     type MessengerOrigin = pallet_messenger::EnsureMessengerOrigin;
+    type MessageVersion = MessageVersion;
 }
 
 impl<C> frame_system::offchain::CreateTransactionBase<C> for Runtime

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -110,7 +110,8 @@ use subspace_core_primitives::{hashes, PublicKey, Randomness, SlotNumber, U256};
 use subspace_runtime_primitives::utility::DefaultNonceProvider;
 use subspace_runtime_primitives::{
     AccountId, Balance, BlockNumber, ConsensusEventSegmentSize, FindBlockRewardAddress, Hash,
-    HoldIdentifier, Moment, Nonce, Signature, MIN_REPLICATION_FACTOR, SHANNON, SSC,
+    HoldIdentifier, Moment, Nonce, Signature, XdmAdjustedWeightToFee, XdmFeeMultipler,
+    MIN_REPLICATION_FACTOR, SHANNON, SSC,
 };
 use subspace_test_primitives::DOMAINS_BLOCK_PRUNING_DEPTH;
 
@@ -663,6 +664,8 @@ impl pallet_messenger::Config for Runtime {
     type Currency = Balances;
     type WeightInfo = pallet_messenger::weights::SubstrateWeight<Runtime>;
     type WeightToFee = ConstantMultiplier<Balance, TransactionWeightFee>;
+    type AdjustedWeightToFee = XdmAdjustedWeightToFee<Runtime>;
+    type FeeMultiplier = XdmFeeMultipler;
     type OnXDMRewards = OnXDMRewards;
     type MmrHash = mmr::Hash;
     type MmrProofVerifier = MmrProofVerifier;


### PR DESCRIPTION
This PR introduces V1 message format. This is part of the Audit issue #2439

## Notable changes
- Introduces v1 message format, that pass the collected fees at src_chain to the dst_chain so that dst_chain does not use its own WeightToFee but rather take the fee collected at src_chain.
- Removed FeeModel from channel open params
- Set MessageVersion to V0 until runtimes are upgraded to handle V1 message formats

There is not code difference between V0 and V1 when handling the message except the Fee calculation. So we convert V1 message to V0 and execute the message. If the v1 request is recieved, we send back v1 response itself.

Since MessageVersion to be used is set to V0, V1 will not be used by the runtimes yet until its explictly changes. For the migration process, please look at the #3445 

Closes: #3446

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
