### PR TITLE
Increase reserved peers reconnection intervals

### DIFF
--- a/crates/subspace-networking/src/constructor.rs
+++ b/crates/subspace-networking/src/constructor.rs
@@ -68,14 +68,18 @@ const MAX_CONCURRENT_STREAMS_PER_CONNECTION: usize = 10;
 const ENABLE_GOSSIP_PROTOCOL: bool = false;
 
 const TEMPORARY_BANS_CACHE_SIZE: u32 = 10_000;
-const TEMPORARY_BANS_DEFAULT_BACKOFF_INITIAL_INTERVAL: Duration = Duration::from_secs(5);
+/// The initial temporary ban delay, before attempting a reconnection.
+/// This is also effectively the fixed reconnection delay for reserved peers disconnected by the
+/// remote end.
+const TEMPORARY_BANS_DEFAULT_BACKOFF_INITIAL_INTERVAL: Duration = Duration::from_secs(10);
 const TEMPORARY_BANS_DEFAULT_BACKOFF_RANDOMIZATION_FACTOR: f64 = 0.1;
 const TEMPORARY_BANS_DEFAULT_BACKOFF_MULTIPLIER: f64 = 1.5;
 const TEMPORARY_BANS_DEFAULT_MAX_INTERVAL: Duration = Duration::from_secs(30 * 60);
 
 /// We pause between reserved peers dialing otherwise we could do multiple dials to offline peers
 /// wasting resources and producing a ton of log records.
-const DIALING_INTERVAL_IN_SECS: Duration = Duration::from_secs(1);
+// TODO: replace this with a capped exponential backoff, like temporary bans.
+const DIALING_INTERVAL_IN_SECS: Duration = Duration::from_secs(5);
 
 /// Specific YAMUX settings for Subspace applications: additional buffer space for pieces and
 /// substream's limit.


### PR DESCRIPTION
### Questions for reviewers

Should the reconnection delays be a larger multiple of the idle limit?
For example, should they be 9 seconds for standard reconnections, and 30 seconds for temporary bans?

### Problem

Currently, bootstrap nodes are immediately dropping connections because their substream limit has been exceeded:
> 2025-03-20T20:48:38.773888Z  WARN Consensus: libp2p_kad::handler: New inbound substream to peer exceeds inbound substream limit. No older substream waiting to be reused. Dropping new substream. peer=PeerId("12D3KooWPE9kkNgsdP1RReHpiTWsunjRKybjXA6rGgcj3tjWFiU2")
> 2025-03-20T20:48:38.710579Z  WARN Consensus: libp2p_kad::handler: New inbound substream to peer exceeds inbound substream limit. No older substream waiting to be reused. Dropping new substream. peer=PeerId("12D3KooWF97hMHZLw7DCVMo1DPSC27xWmEW4RQo5jbLn9nLS2Azk")

This increases the load on the bootstrap nodes, making it harder for other peers to bootstrap.

### Solution

This PR increases the reserved peers reconnection delays so they are greater than the idle connection limit (3 seconds), giving new peers more opportunity to connect to the bootstrap nodes.

Longer-term, we should use a capped exponential back off instead. I opened ticket #3449 for that.

This doesn't directly fix the issue (see #3450), but it will decrease the network load, and hopefully improve peer reputations.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
