### PR TITLE
Fix incorrect peer port autodetection and substream limit exceeded errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1459,9 +1459,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.7.2"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 dependencies = [
  "serde",
 ]
@@ -2124,7 +2124,7 @@ dependencies = [
  "sp-messenger",
  "sp-runtime",
  "subspace-runtime-primitives",
- "thiserror 2.0.0",
+ "thiserror 2.0.12",
  "tracing",
 ]
 
@@ -2889,7 +2889,7 @@ dependencies = [
  "subspace-test-runtime",
  "subspace-test-service",
  "tempfile",
- "thiserror 2.0.0",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
 ]
@@ -3029,7 +3029,7 @@ dependencies = [
  "substrate-build-script-utils",
  "substrate-frame-rpc-system",
  "substrate-prometheus-endpoint",
- "thiserror 2.0.0",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
 ]
@@ -3675,7 +3675,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb42427514b063d97ce21d5199f36c0c307d981434a6be32582bc79fe5bd2303"
 dependencies = [
  "expander",
- "indexmap 2.5.0",
+ "indexmap 2.8.0",
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
@@ -4725,7 +4725,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.5.0",
+ "indexmap 2.8.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -4744,7 +4744,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.1.0",
- "indexmap 2.5.0",
+ "indexmap 2.8.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -4815,6 +4815,12 @@ dependencies = [
  "allocator-api2",
  "serde",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 
 [[package]]
 name = "hashlink"
@@ -5530,12 +5536,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.5.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
+checksum = "3954d50fe15b02142bf25d3b8bdadb634ec3948f103d04ffe3031bc8fe9d7058"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.2",
 ]
 
 [[package]]
@@ -6158,7 +6164,7 @@ dependencies = [
  "multiaddr 0.18.2",
  "pin-project",
  "rw-stream-sink",
- "thiserror 2.0.0",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -6191,7 +6197,7 @@ dependencies = [
  "quick-protobuf-codec",
  "rand",
  "rand_core",
- "thiserror 2.0.0",
+ "thiserror 2.0.12",
  "tracing",
  "web-time",
 ]
@@ -6227,7 +6233,7 @@ dependencies = [
  "rw-stream-sink",
  "serde",
  "smallvec",
- "thiserror 2.0.0",
+ "thiserror 2.0.12",
  "tracing",
  "unsigned-varint 0.8.0",
  "web-time",
@@ -6296,7 +6302,7 @@ dependencies = [
  "quick-protobuf",
  "quick-protobuf-codec",
  "smallvec",
- "thiserror 2.0.0",
+ "thiserror 2.0.12",
  "tracing",
 ]
 
@@ -6313,7 +6319,7 @@ dependencies = [
  "rand",
  "serde",
  "sha2 0.10.8",
- "thiserror 2.0.0",
+ "thiserror 2.0.12",
  "tracing",
  "zeroize",
 ]
@@ -6340,7 +6346,7 @@ dependencies = [
  "serde",
  "sha2 0.10.8",
  "smallvec",
- "thiserror 2.0.0",
+ "thiserror 2.0.12",
  "tracing",
  "uint 0.9.5",
  "web-time",
@@ -6402,7 +6408,7 @@ dependencies = [
  "sha2 0.10.8",
  "snow",
  "static_assertions",
- "thiserror 2.0.0",
+ "thiserror 2.0.12",
  "tracing",
  "x25519-dalek",
  "zeroize",
@@ -6457,7 +6463,7 @@ dependencies = [
  "ring 0.17.13",
  "rustls 0.23.18",
  "socket2 0.5.8",
- "thiserror 2.0.0",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
 ]
@@ -6562,7 +6568,7 @@ dependencies = [
  "ring 0.17.13",
  "rustls 0.23.18",
  "rustls-webpki 0.101.7",
- "thiserror 2.0.0",
+ "thiserror 2.0.12",
  "x509-parser",
  "yasna",
 ]
@@ -6595,7 +6601,7 @@ dependencies = [
  "pin-project-lite",
  "rw-stream-sink",
  "soketto 0.8.0",
- "thiserror 2.0.0",
+ "thiserror 2.0.12",
  "tracing",
  "url",
  "webpki-roots 0.25.4",
@@ -6609,7 +6615,7 @@ dependencies = [
  "either",
  "futures",
  "libp2p-core",
- "thiserror 2.0.0",
+ "thiserror 2.0.12",
  "tracing",
  "yamux 0.12.1",
  "yamux 0.13.4",
@@ -6758,7 +6764,7 @@ dependencies = [
  "futures-timer",
  "hex-literal",
  "hickory-resolver",
- "indexmap 2.5.0",
+ "indexmap 2.8.0",
  "libc",
  "mockall 0.13.1",
  "multiaddr 0.17.1",
@@ -7738,7 +7744,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7b1d40dd8f367db3c65bec8d3dd47d4a604ee8874480738f93191bddab4e0e0"
 dependencies = [
  "expander",
- "indexmap 2.5.0",
+ "indexmap 2.8.0",
  "itertools 0.11.0",
  "petgraph",
  "proc-macro-crate 3.2.0",
@@ -8525,7 +8531,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b7cafe60d6cf8e62e1b9b2ea516a089c008945bb5a275416789e7db0bc199dc"
 dependencies = [
  "memchr",
- "thiserror 2.0.0",
+ "thiserror 2.0.12",
  "ucd-trie",
 ]
 
@@ -8570,7 +8576,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap 2.5.0",
+ "indexmap 2.8.0",
 ]
 
 [[package]]
@@ -9350,7 +9356,7 @@ dependencies = [
  "asynchronous-codec 0.7.0",
  "bytes",
  "quick-protobuf",
- "thiserror 2.0.0",
+ "thiserror 2.0.12",
  "unsigned-varint 0.8.0",
 ]
 
@@ -10443,7 +10449,7 @@ dependencies = [
  "subspace-kzg",
  "subspace-proof-of-space",
  "subspace-verification",
- "thiserror 2.0.0",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
 ]
@@ -10478,7 +10484,7 @@ dependencies = [
  "subspace-kzg",
  "subspace-networking",
  "subspace-rpc-primitives",
- "thiserror 2.0.0",
+ "thiserror 2.0.12",
  "tracing",
 ]
 
@@ -11100,7 +11106,7 @@ dependencies = [
  "strum_macros 0.26.4",
  "subspace-core-primitives",
  "substrate-prometheus-endpoint",
- "thiserror 2.0.0",
+ "thiserror 2.0.12",
  "tracing",
 ]
 
@@ -11211,7 +11217,7 @@ dependencies = [
  "async-trait",
  "futures",
  "futures-timer",
- "indexmap 2.5.0",
+ "indexmap 2.8.0",
  "itertools 0.11.0",
  "linked-hash-map",
  "log",
@@ -12302,7 +12308,7 @@ dependencies = [
  "subspace-kzg",
  "subspace-proof-of-space",
  "subspace-verification",
- "thiserror 2.0.0",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -12510,7 +12516,7 @@ dependencies = [
  "subspace-runtime-primitives",
  "subspace-test-service",
  "tempfile",
- "thiserror 2.0.0",
+ "thiserror 2.0.12",
  "tokio",
  "trie-db",
 ]
@@ -13217,7 +13223,7 @@ dependencies = [
  "subspace-erasure-coding",
  "subspace-kzg",
  "subspace-verification",
- "thiserror 2.0.0",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -13251,7 +13257,7 @@ dependencies = [
  "subspace-archiving",
  "subspace-core-primitives",
  "subspace-erasure-coding",
- "thiserror 2.0.0",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
 ]
@@ -13352,7 +13358,7 @@ dependencies = [
  "subspace-verification",
  "substrate-bip39",
  "tempfile",
- "thiserror 2.0.0",
+ "thiserror 2.0.12",
  "thread-priority",
  "tokio",
  "tokio-stream",
@@ -13388,7 +13394,7 @@ dependencies = [
  "subspace-kzg",
  "subspace-proof-of-space",
  "subspace-verification",
- "thiserror 2.0.0",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
  "winapi",
@@ -13432,7 +13438,7 @@ dependencies = [
  "serde",
  "subspace-core-primitives",
  "subspace-data-retrieval",
- "thiserror 2.0.0",
+ "thiserror 2.0.12",
  "tracing",
 ]
 
@@ -13525,7 +13531,7 @@ dependencies = [
  "subspace-runtime-primitives",
  "subspace-service",
  "substrate-build-script-utils",
- "thiserror 2.0.0",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
 ]
@@ -13571,7 +13577,7 @@ dependencies = [
  "subspace-core-primitives",
  "subspace-logging",
  "subspace-metrics",
- "thiserror 2.0.0",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -13643,7 +13649,7 @@ dependencies = [
  "substrate-build-script-utils",
  "substrate-prometheus-endpoint",
  "tempfile",
- "thiserror 2.0.0",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -13690,7 +13696,7 @@ dependencies = [
  "criterion",
  "rand",
  "subspace-core-primitives",
- "thiserror 2.0.0",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -13867,7 +13873,7 @@ dependencies = [
  "subspace-verification",
  "substrate-frame-rpc-system",
  "substrate-prometheus-endpoint",
- "thiserror 2.0.0",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
 ]
@@ -14042,7 +14048,7 @@ dependencies = [
  "subspace-core-primitives",
  "subspace-kzg",
  "subspace-proof-of-space",
- "thiserror 2.0.0",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -14466,11 +14472,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.0"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15291287e9bff1bc6f9ff3409ed9af665bec7a5fc8ac079ea96be07bca0e2668"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
- "thiserror-impl 2.0.0",
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -14486,9 +14492,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.0"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22efd00f33f93fa62848a7cab956c3d38c8d43095efda1decfc2b3a5dc0b8972"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -14779,7 +14785,7 @@ version = "0.22.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
 dependencies = [
- "indexmap 2.5.0",
+ "indexmap 2.8.0",
  "serde",
  "serde_spanned",
  "toml_datetime",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,7 +58,7 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "rand",
+ "rand 0.8.5",
  "sha1",
  "smallvec",
  "tokio",
@@ -287,10 +287,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.15",
  "once_cell",
  "version_check",
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -539,7 +539,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -575,7 +575,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048"
 dependencies = [
- "asn1-rs-derive",
+ "asn1-rs-derive 0.5.1",
  "asn1-rs-impl",
  "displaydoc",
  "nom",
@@ -586,10 +586,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "asn1-rs"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56624a96882bb8c26d61312ae18cb45868e5a9992ea73c58e45c3101e56a1e60"
+dependencies = [
+ "asn1-rs-derive 0.6.0",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 2.0.12",
+ "time",
+]
+
+[[package]]
 name = "asn1-rs-derive"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+ "synstructure 0.13.1",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -755,7 +783,7 @@ dependencies = [
  "nuid",
  "once_cell",
  "portable-atomic",
- "rand",
+ "rand 0.8.5",
  "regex",
  "ring 0.17.13",
  "rustls-native-certs 0.7.3",
@@ -1099,10 +1127,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
 dependencies = [
  "futures-core",
- "getrandom",
+ "getrandom 0.2.15",
  "instant",
  "pin-project-lite",
- "rand",
+ "rand 0.8.5",
  "tokio",
 ]
 
@@ -1175,7 +1203,7 @@ dependencies = [
 [[package]]
 name = "binary-merkle-tree"
 version = "16.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "hash-db",
  "log",
@@ -1200,7 +1228,7 @@ dependencies = [
  "bs58",
  "hmac 0.12.1",
  "k256",
- "rand_core",
+ "rand_core 0.6.4",
  "ripemd",
  "secp256k1 0.27.0",
  "sha2 0.10.8",
@@ -1215,8 +1243,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93f2635620bf0b9d4576eb7bb9a38a55df78bd1205d26fa994b25911a69f212f"
 dependencies = [
  "bitcoin_hashes 0.11.0",
- "rand",
- "rand_core",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "serde",
  "unicode-normalization",
 ]
@@ -1850,7 +1878,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "once_cell",
  "tiny-keccak",
 ]
@@ -2175,7 +2203,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array 0.14.7",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle 2.6.1",
  "zeroize",
 ]
@@ -2187,7 +2215,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array 0.14.7",
- "rand_core",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -2232,7 +2260,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-parachain-inherent"
 version = "0.15.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2242,7 +2270,7 @@ dependencies = [
  "parity-scale-codec",
  "sc-client-api",
  "sp-api",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa)",
  "sp-inherents",
  "sp-runtime",
  "sp-state-machine",
@@ -2254,7 +2282,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-core"
 version = "0.17.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "parity-scale-codec",
  "polkadot-core-primitives",
@@ -2270,7 +2298,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-parachain-inherent"
 version = "0.17.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2284,7 +2312,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-proof-size-hostfunction"
 version = "0.11.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "sp-externalities",
  "sp-runtime-interface",
@@ -2294,7 +2322,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-interface"
 version = "0.21.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2313,7 +2341,7 @@ dependencies = [
 [[package]]
 name = "cumulus-test-relay-sproof-builder"
 version = "0.17.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
@@ -2520,7 +2548,21 @@ version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
 dependencies = [
- "asn1-rs",
+ "asn1-rs 0.6.2",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
+name = "der-parser"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs 0.7.1",
  "displaydoc",
  "nom",
  "num-bigint",
@@ -2851,7 +2893,7 @@ dependencies = [
  "pallet-utility",
  "parity-scale-codec",
  "parking_lot 0.12.3",
- "rand",
+ "rand 0.8.5",
  "sc-cli",
  "sc-client-api",
  "sc-consensus",
@@ -3064,7 +3106,7 @@ dependencies = [
  "frame-system",
  "pallet-transaction-payment",
  "pallet-transaction-payment-rpc",
- "rand",
+ "rand 0.8.5",
  "sc-client-api",
  "sc-domains",
  "sc-network",
@@ -3176,7 +3218,7 @@ checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand_core",
+ "rand_core 0.6.4",
  "serde",
  "sha2 0.10.8",
  "signature",
@@ -3194,7 +3236,7 @@ dependencies = [
  "ed25519",
  "hashbrown 0.14.5",
  "hex",
- "rand_core",
+ "rand_core 0.6.4",
  "sha2 0.10.8",
  "zeroize",
 ]
@@ -3218,7 +3260,7 @@ dependencies = [
  "generic-array 0.14.7",
  "group",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "sec1",
  "serdect",
  "subtle 2.6.1",
@@ -3773,7 +3815,7 @@ dependencies = [
  "pallet-evm",
  "parity-scale-codec",
  "prometheus",
- "rand",
+ "rand 0.8.5",
  "rlp",
  "sc-client-api",
  "sc-network",
@@ -3812,7 +3854,7 @@ dependencies = [
  "rustc-hex",
  "serde",
  "serde_json",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa)",
 ]
 
 [[package]]
@@ -3848,7 +3890,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
  "subtle 2.6.1",
 ]
 
@@ -3923,7 +3965,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
 dependencies = [
  "byteorder",
- "rand",
+ "rand 0.8.5",
  "rustc-hex",
  "static_assertions",
 ]
@@ -3962,7 +4004,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 [[package]]
 name = "fork-tree"
 version = "13.0.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -4090,7 +4132,7 @@ checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 [[package]]
 name = "frame-benchmarking"
 version = "39.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -4114,7 +4156,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "46.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "Inflector",
  "array-bytes",
@@ -4135,7 +4177,7 @@ dependencies = [
  "parity-scale-codec",
  "polkadot-parachain-primitives",
  "polkadot-primitives",
- "rand",
+ "rand 0.8.5",
  "rand_pcg",
  "sc-block-builder",
  "sc-chain-spec",
@@ -4152,7 +4194,7 @@ dependencies = [
  "sp-block-builder",
  "sp-blockchain",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa)",
  "sp-database",
  "sp-externalities",
  "sp-genesis-builder",
@@ -4176,7 +4218,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "39.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "aquamarine",
  "frame-support",
@@ -4229,7 +4271,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "39.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "aquamarine",
  "array-bytes",
@@ -4272,7 +4314,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "31.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -4285,14 +4327,14 @@ dependencies = [
  "proc-macro-warning",
  "proc-macro2",
  "quote",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa)",
  "syn 2.0.98",
 ]
 
 [[package]]
 name = "frame-support-procedural-tools"
 version = "13.0.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate 3.2.0",
@@ -4304,7 +4346,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "12.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4314,7 +4356,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "39.1.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "cfg-if",
  "docify",
@@ -4334,7 +4376,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "39.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4348,7 +4390,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "35.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "docify",
  "parity-scale-codec",
@@ -4358,7 +4400,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.45.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -4613,8 +4655,20 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
 ]
 
 [[package]]
@@ -4623,8 +4677,8 @@ version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea1015b5a70616b688dc230cfe50c8af89d972cb132d5a622814d29773b10b9"
 dependencies = [
- "rand",
- "rand_core",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -4697,7 +4751,7 @@ dependencies = [
  "parking_lot 0.12.3",
  "portable-atomic",
  "quanta",
- "rand",
+ "rand 0.8.5",
  "smallvec",
  "spinning_top",
 ]
@@ -4709,7 +4763,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle 2.6.1",
 ]
 
@@ -4904,7 +4958,7 @@ dependencies = [
  "idna",
  "ipnet",
  "once_cell",
- "rand",
+ "rand 0.8.5",
  "socket2 0.5.8",
  "thiserror 1.0.64",
  "tinyvec",
@@ -4926,7 +4980,7 @@ dependencies = [
  "lru-cache",
  "once_cell",
  "parking_lot 0.12.3",
- "rand",
+ "rand 0.8.5",
  "resolv-conf",
  "smallvec",
  "thiserror 1.0.64",
@@ -5425,7 +5479,7 @@ dependencies = [
  "hyper 1.4.1",
  "hyper-util",
  "log",
- "rand",
+ "rand 0.8.5",
  "tokio",
  "url",
  "xmltree",
@@ -5882,7 +5936,7 @@ dependencies = [
  "jsonrpsee-types 0.24.8",
  "parking_lot 0.12.3",
  "pin-project",
- "rand",
+ "rand 0.8.5",
  "rustc-hash 2.0.0",
  "serde",
  "serde_json",
@@ -6139,7 +6193,7 @@ dependencies = [
  "either",
  "futures",
  "futures-timer",
- "getrandom",
+ "getrandom 0.2.15",
  "libp2p-allow-block-list",
  "libp2p-autonat",
  "libp2p-connection-limits",
@@ -6195,8 +6249,8 @@ dependencies = [
  "libp2p-swarm",
  "quick-protobuf",
  "quick-protobuf-codec",
- "rand",
- "rand_core",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "thiserror 2.0.12",
  "tracing",
  "web-time",
@@ -6229,7 +6283,7 @@ dependencies = [
  "parking_lot 0.12.3",
  "pin-project",
  "quick-protobuf",
- "rand",
+ "rand 0.8.5",
  "rw-stream-sink",
  "serde",
  "smallvec",
@@ -6268,7 +6322,7 @@ dependencies = [
  "fnv",
  "futures",
  "futures-timer",
- "getrandom",
+ "getrandom 0.2.15",
  "hex_fmt",
  "libp2p-core",
  "libp2p-identity",
@@ -6276,7 +6330,7 @@ dependencies = [
  "prometheus-client",
  "quick-protobuf",
  "quick-protobuf-codec",
- "rand",
+ "rand 0.8.5",
  "regex",
  "serde",
  "sha2 0.10.8",
@@ -6316,7 +6370,7 @@ dependencies = [
  "hkdf",
  "multihash 0.19.1",
  "quick-protobuf",
- "rand",
+ "rand 0.8.5",
  "serde",
  "sha2 0.10.8",
  "thiserror 2.0.12",
@@ -6342,7 +6396,7 @@ dependencies = [
  "libp2p-swarm",
  "quick-protobuf",
  "quick-protobuf-codec",
- "rand",
+ "rand 0.8.5",
  "serde",
  "sha2 0.10.8",
  "smallvec",
@@ -6364,7 +6418,7 @@ dependencies = [
  "libp2p-core",
  "libp2p-identity",
  "libp2p-swarm",
- "rand",
+ "rand 0.8.5",
  "smallvec",
  "socket2 0.5.8",
  "tokio",
@@ -6404,7 +6458,7 @@ dependencies = [
  "multihash 0.19.1",
  "once_cell",
  "quick-protobuf",
- "rand",
+ "rand 0.8.5",
  "sha2 0.10.8",
  "snow",
  "static_assertions",
@@ -6425,7 +6479,7 @@ dependencies = [
  "libp2p-core",
  "libp2p-identity",
  "libp2p-swarm",
- "rand",
+ "rand 0.8.5",
  "tracing",
  "web-time",
 ]
@@ -6459,7 +6513,7 @@ dependencies = [
  "libp2p-tls",
  "parking_lot 0.12.3",
  "quinn",
- "rand",
+ "rand 0.8.5",
  "ring 0.17.13",
  "rustls 0.23.18",
  "socket2 0.5.8",
@@ -6480,7 +6534,7 @@ dependencies = [
  "libp2p-core",
  "libp2p-identity",
  "libp2p-swarm",
- "rand",
+ "rand 0.8.5",
  "smallvec",
  "tracing",
  "web-time",
@@ -6502,7 +6556,7 @@ dependencies = [
  "lru",
  "multistream-select",
  "once_cell",
- "rand",
+ "rand 0.8.5",
  "smallvec",
  "tokio",
  "tracing",
@@ -6534,7 +6588,7 @@ dependencies = [
  "libp2p-swarm",
  "libp2p-tcp",
  "libp2p-yamux",
- "rand",
+ "rand 0.8.5",
  "tracing",
 ]
 
@@ -6569,7 +6623,7 @@ dependencies = [
  "rustls 0.23.18",
  "rustls-webpki 0.101.7",
  "thiserror 2.0.12",
- "x509-parser",
+ "x509-parser 0.16.0",
  "yasna",
 ]
 
@@ -6645,7 +6699,7 @@ dependencies = [
  "libsecp256k1-core",
  "libsecp256k1-gen-ecmult",
  "libsecp256k1-gen-genmult",
- "rand",
+ "rand 0.8.5",
  "serde",
  "sha2 0.9.9",
  "typenum",
@@ -6751,9 +6805,9 @@ checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
 
 [[package]]
 name = "litep2p"
-version = "0.9.0"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ca6ee50a125dc4fc4e9a3ae3640010796d1d07bc517a0ac715fdf0b24a0b6ac"
+checksum = "fa3aa5628ae2b2283aa01dfa58947f1926aedba0160dd25041e2cd4bc71534c9"
 dependencies = [
  "async-trait",
  "bs58",
@@ -6770,12 +6824,11 @@ dependencies = [
  "multiaddr 0.17.1",
  "multihash 0.17.0",
  "network-interface",
- "nohash-hasher",
  "parking_lot 0.12.3",
  "pin-project",
  "prost 0.12.6",
  "prost-build",
- "rand",
+ "rand 0.8.5",
  "rcgen 0.10.0",
  "ring 0.16.20",
  "rustls 0.20.9",
@@ -6785,18 +6838,18 @@ dependencies = [
  "smallvec",
  "snow",
  "socket2 0.5.8",
- "static_assertions",
- "thiserror 1.0.64",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
  "tokio-tungstenite",
  "tokio-util",
  "tracing",
- "uint 0.9.5",
+ "uint 0.10.0",
  "unsigned-varint 0.8.0",
  "url",
  "x25519-dalek",
- "x509-parser",
+ "x509-parser 0.17.0",
+ "yamux 0.13.4",
  "yasna",
  "zeroize",
 ]
@@ -7015,7 +7068,7 @@ checksum = "58c38e2799fc0978b65dfff8023ec7843e2330bb462f19198840b34b6582397d"
 dependencies = [
  "byteorder",
  "keccak",
- "rand_core",
+ "rand_core 0.6.4",
  "zeroize",
 ]
 
@@ -7058,7 +7111,7 @@ dependencies = [
  "hermit-abi 0.3.9",
  "libc",
  "log",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
 
@@ -7079,8 +7132,8 @@ dependencies = [
  "lioness",
  "log",
  "parking_lot 0.12.3",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "rand_distr",
  "subtle 2.6.1",
  "thiserror 1.0.64",
@@ -7090,7 +7143,7 @@ dependencies = [
 [[package]]
 name = "mmr-gadget"
 version = "43.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "futures",
  "log",
@@ -7109,7 +7162,7 @@ dependencies = [
 [[package]]
 name = "mmr-rpc"
 version = "39.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "jsonrpsee 0.24.8",
  "parity-scale-codec",
@@ -7335,7 +7388,7 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bddcd3bf5144b6392de80e04c347cd7fab2508f6df16a85fc496ecd5cec39bc"
 dependencies = [
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -7443,9 +7496,9 @@ dependencies = [
  "data-encoding",
  "ed25519",
  "ed25519-dalek",
- "getrandom",
+ "getrandom 0.2.15",
  "log",
- "rand",
+ "rand 0.8.5",
  "signatory",
 ]
 
@@ -7517,7 +7570,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc895af95856f929163a0aa20c26a78d26bfdc839f51b9d5aa7a5b79e52b7e83"
 dependencies = [
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -7677,7 +7730,16 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8d8034d9489cdaf79228eb9f6a3b8d7bb32ba00d6645ebd48eef4077ceb5bd9"
 dependencies = [
- "asn1-rs",
+ "asn1-rs 0.6.2",
+]
+
+[[package]]
+name = "oid-registry"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs 0.7.1",
 ]
 
 [[package]]
@@ -7801,13 +7863,13 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "subspace-runtime-primitives",
- "x509-parser",
+ "x509-parser 0.16.0",
 ]
 
 [[package]]
 name = "pallet-balances"
 version = "40.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -7838,7 +7900,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "39.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -7855,7 +7917,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "39.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8061,7 +8123,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr"
 version = "39.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8078,7 +8140,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "39.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -8089,7 +8151,7 @@ dependencies = [
 [[package]]
 name = "pallet-preimage"
 version = "39.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8138,7 +8200,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "40.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8177,7 +8239,7 @@ dependencies = [
  "log",
  "pallet-balances",
  "parity-scale-codec",
- "rand",
+ "rand 0.8.5",
  "scale-info",
  "schnorrkel",
  "serde",
@@ -8214,7 +8276,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "39.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8229,7 +8291,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "38.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8259,7 +8321,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "39.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8275,7 +8337,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "42.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "jsonrpsee 0.24.8",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -8291,7 +8353,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "39.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -8324,7 +8386,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "39.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8343,8 +8405,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e69bf016dc406eff7d53a7d3f7cf1c2e72c82b9088aac1118591e36dd2cd3e9"
 dependencies = [
  "bitcoin_hashes 0.13.0",
- "rand",
- "rand_core",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "serde",
  "unicode-normalization",
 ]
@@ -8364,7 +8426,7 @@ dependencies = [
  "lz4",
  "memmap2 0.5.10",
  "parking_lot 0.12.3",
- "rand",
+ "rand 0.8.5",
  "siphasher 0.3.11",
  "snap",
  "winapi",
@@ -8470,7 +8532,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
 dependencies = [
  "base64ct",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle 2.6.1",
 ]
 
@@ -8651,7 +8713,7 @@ dependencies = [
 [[package]]
 name = "polkadot-core-primitives"
 version = "16.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -8662,7 +8724,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-metrics"
 version = "21.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "bs58",
  "futures",
@@ -8681,7 +8743,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-network-protocol"
 version = "21.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -8693,7 +8755,7 @@ dependencies = [
  "parity-scale-codec",
  "polkadot-node-primitives",
  "polkadot-primitives",
- "rand",
+ "rand 0.8.5",
  "sc-authority-discovery",
  "sc-network",
  "sc-network-types",
@@ -8706,7 +8768,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-primitives"
 version = "17.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "bitvec",
  "bounded-vec",
@@ -8732,7 +8794,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-types"
 version = "21.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "async-trait",
  "bitvec",
@@ -8761,7 +8823,7 @@ dependencies = [
 [[package]]
 name = "polkadot-overseer"
 version = "21.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "async-trait",
  "futures",
@@ -8783,7 +8845,7 @@ dependencies = [
 [[package]]
 name = "polkadot-parachain-primitives"
 version = "15.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "bounded-collections",
  "derive_more 0.99.18",
@@ -8799,7 +8861,7 @@ dependencies = [
 [[package]]
 name = "polkadot-primitives"
 version = "17.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "bitvec",
  "hex-literal",
@@ -8827,7 +8889,7 @@ dependencies = [
 [[package]]
 name = "polkadot-sdk-frame"
 version = "0.8.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8861,7 +8923,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-table"
 version = "17.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
@@ -9024,7 +9086,7 @@ version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -9328,7 +9390,7 @@ dependencies = [
  "libc",
  "once_cell",
  "raw-cpuid",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "web-sys",
  "winapi",
 ]
@@ -9386,7 +9448,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fadfaed2cd7f389d0161bb73eeb07b7b78f8691047a6f3e73caaeae55310a4a6"
 dependencies = [
  "bytes",
- "rand",
+ "rand 0.8.5",
  "ring 0.17.13",
  "rustc-hash 2.0.0",
  "rustls 0.23.18",
@@ -9419,6 +9481,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+
+[[package]]
 name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9431,8 +9499,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -9442,7 +9521,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -9451,7 +9540,16 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.2",
 ]
 
 [[package]]
@@ -9461,7 +9559,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -9470,7 +9568,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59cad018caf63deb318e5a4586d99a24424a364f40f1e5778c29aca23f4fc73e"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -9572,7 +9670,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "libredox",
  "thiserror 1.0.64",
 ]
@@ -9757,7 +9855,7 @@ checksum = "70ac5d832aa16abd7d1def883a8545280c20a60f523a370aa3a9617c2b8550ee"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.15",
  "libc",
  "untrusted 0.9.0",
  "windows-sys 0.52.0",
@@ -9856,7 +9954,7 @@ dependencies = [
  "kzg",
  "libc",
  "once_cell",
- "rand",
+ "rand 0.8.5",
  "rayon",
  "smallvec",
 ]
@@ -10160,7 +10258,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "30.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "log",
  "sp-core",
@@ -10171,7 +10269,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.48.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "async-trait",
  "futures",
@@ -10184,7 +10282,7 @@ dependencies = [
  "parity-scale-codec",
  "prost 0.12.6",
  "prost-build",
- "rand",
+ "rand 0.8.5",
  "sc-client-api",
  "sc-network",
  "sc-network-types",
@@ -10201,7 +10299,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.48.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "futures",
  "futures-timer",
@@ -10223,7 +10321,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.43.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -10238,7 +10336,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "41.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "array-bytes",
  "docify",
@@ -10254,7 +10352,7 @@ dependencies = [
  "serde_json",
  "sp-blockchain",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa)",
  "sp-genesis-builder",
  "sp-io",
  "sp-runtime",
@@ -10265,7 +10363,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "12.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
@@ -10276,7 +10374,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.50.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "array-bytes",
  "chrono",
@@ -10289,7 +10387,7 @@ dependencies = [
  "names",
  "parity-bip39",
  "parity-scale-codec",
- "rand",
+ "rand 0.8.5",
  "regex",
  "rpassword",
  "sc-client-api",
@@ -10318,7 +10416,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "38.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "fnv",
  "futures",
@@ -10345,7 +10443,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.45.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -10370,7 +10468,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.47.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "async-trait",
  "futures",
@@ -10394,7 +10492,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.47.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "async-trait",
  "futures",
@@ -10422,8 +10520,8 @@ dependencies = [
  "futures",
  "parity-scale-codec",
  "parking_lot 0.12.3",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "rayon",
  "sc-client-api",
  "sc-consensus",
@@ -10511,7 +10609,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.41.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
@@ -10534,7 +10632,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.36.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "polkavm",
  "sc-allocator",
@@ -10547,7 +10645,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-polkavm"
 version = "0.33.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "log",
  "polkavm",
@@ -10558,7 +10656,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.36.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -10576,7 +10674,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.47.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "console",
  "futures",
@@ -10593,7 +10691,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "34.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "array-bytes",
  "parking_lot 0.12.3",
@@ -10607,7 +10705,7 @@ dependencies = [
 [[package]]
 name = "sc-mixnet"
 version = "0.18.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "array-bytes",
  "arrayvec 0.7.6",
@@ -10636,7 +10734,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.48.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -10661,7 +10759,7 @@ dependencies = [
  "pin-project",
  "prost 0.12.6",
  "prost-build",
- "rand",
+ "rand 0.8.5",
  "sc-client-api",
  "sc-network-common",
  "sc-network-types",
@@ -10687,7 +10785,7 @@ dependencies = [
 [[package]]
 name = "sc-network-common"
 version = "0.47.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "async-trait",
  "bitflags 1.3.2",
@@ -10705,7 +10803,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.48.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "ahash",
  "futures",
@@ -10724,7 +10822,7 @@ dependencies = [
 [[package]]
 name = "sc-network-light"
 version = "0.47.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -10745,7 +10843,7 @@ dependencies = [
 [[package]]
 name = "sc-network-sync"
 version = "0.47.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -10781,7 +10879,7 @@ dependencies = [
 [[package]]
 name = "sc-network-transactions"
 version = "0.47.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "array-bytes",
  "futures",
@@ -10800,7 +10898,7 @@ dependencies = [
 [[package]]
 name = "sc-network-types"
 version = "0.15.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "bs58",
  "ed25519-dalek",
@@ -10809,7 +10907,7 @@ dependencies = [
  "log",
  "multiaddr 0.18.2",
  "multihash 0.19.1",
- "rand",
+ "rand 0.8.5",
  "thiserror 1.0.64",
  "zeroize",
 ]
@@ -10817,7 +10915,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "43.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "array-bytes",
  "bytes",
@@ -10833,7 +10931,7 @@ dependencies = [
  "once_cell",
  "parity-scale-codec",
  "parking_lot 0.12.3",
- "rand",
+ "rand 0.8.5",
  "rustls 0.23.18",
  "sc-client-api",
  "sc-network",
@@ -10883,7 +10981,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.18.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -10892,7 +10990,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "43.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "futures",
  "jsonrpsee 0.24.8",
@@ -10924,7 +11022,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.47.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "jsonrpsee 0.24.8",
  "parity-scale-codec",
@@ -10944,7 +11042,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "20.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "dyn-clone",
  "forwarded-header-value",
@@ -10968,7 +11066,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-spec-v2"
 version = "0.48.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "array-bytes",
  "futures",
@@ -10979,7 +11077,7 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.3",
- "rand",
+ "rand 0.8.5",
  "sc-chain-spec",
  "sc-client-api",
  "sc-rpc",
@@ -11000,7 +11098,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.49.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "async-trait",
  "directories",
@@ -11012,7 +11110,7 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
  "pin-project",
- "rand",
+ "rand 0.8.5",
  "sc-chain-spec",
  "sc-client-api",
  "sc-client-db",
@@ -11064,7 +11162,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.37.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -11075,7 +11173,7 @@ dependencies = [
 [[package]]
 name = "sc-storage-monitor"
 version = "0.23.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "clap",
  "fs4 0.7.0",
@@ -11132,20 +11230,20 @@ dependencies = [
 [[package]]
 name = "sc-sysinfo"
 version = "41.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "derive_more 0.99.18",
  "futures",
  "libc",
  "log",
- "rand",
+ "rand 0.8.5",
  "rand_pcg",
  "regex",
  "sc-telemetry",
  "serde",
  "serde_json",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa)",
  "sp-io",
  "sp-std",
 ]
@@ -11153,7 +11251,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "28.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "chrono",
  "futures",
@@ -11161,7 +11259,7 @@ dependencies = [
  "log",
  "parking_lot 0.12.3",
  "pin-project",
- "rand",
+ "rand 0.8.5",
  "sc-network",
  "sc-utils",
  "serde",
@@ -11173,7 +11271,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "38.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "chrono",
  "console",
@@ -11201,7 +11299,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "11.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
@@ -11212,7 +11310,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "38.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "async-trait",
  "futures",
@@ -11230,7 +11328,7 @@ dependencies = [
  "sp-api",
  "sp-blockchain",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa)",
  "sp-runtime",
  "sp-tracing",
  "sp-transaction-pool",
@@ -11243,7 +11341,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "38.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "async-trait",
  "futures",
@@ -11259,7 +11357,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "18.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "async-channel 1.9.0",
  "futures",
@@ -11439,7 +11537,7 @@ dependencies = [
  "curve25519-dalek",
  "getrandom_or_panic",
  "merlin",
- "rand_core",
+ "rand_core 0.6.4",
  "serde_bytes",
  "sha2 0.10.8",
  "subtle 2.6.1",
@@ -11785,7 +11883,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1e303f8205714074f6068773f0e29527e0453937fe837c9717d066635b65f31"
 dependencies = [
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "signature",
  "zeroize",
 ]
@@ -11797,7 +11895,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest 0.10.7",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -11815,9 +11913,9 @@ dependencies = [
 
 [[package]]
 name = "simple-dns"
-version = "0.7.1"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c80e565e7dcc4f1ef247e2f395550d4cf7d777746d5988e7e4e3156b71077fc"
+checksum = "dee851d0e5e7af3721faea1843e8015e820a234f81fda3dea9247e15bac9a86a"
 dependencies = [
  "bitflags 2.6.0",
 ]
@@ -11932,8 +12030,8 @@ dependencies = [
  "pbkdf2",
  "pin-project",
  "poly1305",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "ruzstd",
  "schnorrkel",
  "serde",
@@ -11975,8 +12073,8 @@ dependencies = [
  "no-std-net",
  "parking_lot 0.12.3",
  "pin-project",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "serde",
  "serde_json",
  "siphasher 1.0.1",
@@ -12002,7 +12100,7 @@ dependencies = [
  "blake2 0.10.6",
  "chacha20poly1305",
  "curve25519-dalek",
- "rand_core",
+ "rand_core 0.6.4",
  "ring 0.17.13",
  "rustc_version",
  "sha2 0.10.8",
@@ -12040,7 +12138,7 @@ dependencies = [
  "futures",
  "httparse",
  "log",
- "rand",
+ "rand 0.8.5",
  "sha-1",
 ]
 
@@ -12056,14 +12154,14 @@ dependencies = [
  "http 1.1.0",
  "httparse",
  "log",
- "rand",
+ "rand 0.8.5",
  "sha1",
 ]
 
 [[package]]
 name = "sp-api"
 version = "35.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "docify",
  "hash-db",
@@ -12085,7 +12183,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "21.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "Inflector",
  "blake2 0.10.6",
@@ -12099,7 +12197,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "39.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12111,7 +12209,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "26.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "docify",
  "integer-sqrt",
@@ -12125,7 +12223,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "35.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12144,13 +12242,13 @@ dependencies = [
  "sp-externalities",
  "sp-runtime-interface",
  "subspace-runtime-primitives",
- "x509-parser",
+ "x509-parser 0.16.0",
 ]
 
 [[package]]
 name = "sp-block-builder"
 version = "35.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "sp-api",
  "sp-inherents",
@@ -12171,7 +12269,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "38.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -12190,7 +12288,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.41.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "async-trait",
  "futures",
@@ -12205,7 +12303,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.41.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -12221,7 +12319,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.41.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -12239,7 +12337,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-beefy"
 version = "23.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12247,7 +12345,7 @@ dependencies = [
  "sp-api",
  "sp-application-crypto",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa)",
  "sp-io",
  "sp-keystore",
  "sp-mmr-primitives",
@@ -12259,7 +12357,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-grandpa"
 version = "22.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -12276,7 +12374,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.41.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12314,7 +12412,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "35.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "array-bytes",
  "bitflags 1.3.2",
@@ -12337,13 +12435,13 @@ dependencies = [
  "parking_lot 0.12.3",
  "paste",
  "primitive-types 0.13.1",
- "rand",
+ "rand 0.8.5",
  "scale-info",
  "schnorrkel",
  "secp256k1 0.28.2",
  "secrecy",
  "serde",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa)",
  "sp-debug-derive",
  "sp-externalities",
  "sp-runtime-interface",
@@ -12374,7 +12472,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing"
 version = "0.1.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -12387,17 +12485,17 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "quote",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa)",
  "syn 2.0.98",
 ]
 
 [[package]]
 name = "sp-database"
 version = "10.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.3",
@@ -12406,7 +12504,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "14.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12448,8 +12546,8 @@ dependencies = [
  "num-traits",
  "pallet-evm",
  "parity-scale-codec",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "rlp",
  "rs_merkle",
  "scale-info",
@@ -12490,7 +12588,7 @@ dependencies = [
  "pallet-balances",
  "pallet-ethereum",
  "parity-scale-codec",
- "rand",
+ "rand 0.8.5",
  "rlp",
  "sc-cli",
  "sc-client-api",
@@ -12547,7 +12645,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.30.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -12557,7 +12655,7 @@ dependencies = [
 [[package]]
 name = "sp-genesis-builder"
 version = "0.16.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12569,7 +12667,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "35.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -12582,7 +12680,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "39.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "bytes",
  "docify",
@@ -12594,7 +12692,7 @@ dependencies = [
  "rustversion",
  "secp256k1 0.28.2",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa)",
  "sp-externalities",
  "sp-keystore",
  "sp-runtime-interface",
@@ -12608,7 +12706,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "40.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "sp-core",
  "sp-runtime",
@@ -12618,7 +12716,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.41.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
@@ -12629,7 +12727,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "11.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "thiserror 1.0.64",
  "zstd 0.12.4",
@@ -12677,7 +12775,7 @@ dependencies = [
 [[package]]
 name = "sp-metadata-ir"
 version = "0.8.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "frame-metadata 18.0.0",
  "parity-scale-codec",
@@ -12687,7 +12785,7 @@ dependencies = [
 [[package]]
 name = "sp-mixnet"
 version = "0.13.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12698,7 +12796,7 @@ dependencies = [
 [[package]]
 name = "sp-mmr-primitives"
 version = "35.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -12724,7 +12822,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "35.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -12734,7 +12832,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "13.0.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "backtrace",
  "regex",
@@ -12743,7 +12841,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "33.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "rustc-hash 1.1.0",
  "serde",
@@ -12753,7 +12851,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "40.1.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "binary-merkle-tree",
  "docify",
@@ -12764,7 +12862,7 @@ dependencies = [
  "num-traits",
  "parity-scale-codec",
  "paste",
- "rand",
+ "rand 0.8.5",
  "scale-info",
  "serde",
  "simple-mermaid",
@@ -12782,7 +12880,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "29.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -12801,7 +12899,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "18.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "Inflector",
  "expander",
@@ -12814,7 +12912,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "37.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12828,7 +12926,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "37.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -12841,13 +12939,13 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.44.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "hash-db",
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.3",
- "rand",
+ "rand 0.8.5",
  "smallvec",
  "sp-core",
  "sp-externalities",
@@ -12861,20 +12959,20 @@ dependencies = [
 [[package]]
 name = "sp-statement-store"
 version = "19.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "aes-gcm",
  "curve25519-dalek",
  "ed25519-dalek",
  "hkdf",
  "parity-scale-codec",
- "rand",
+ "rand 0.8.5",
  "scale-info",
  "sha2 0.10.8",
  "sp-api",
  "sp-application-crypto",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa)",
  "sp-externalities",
  "sp-runtime",
  "sp-runtime-interface",
@@ -12885,12 +12983,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "14.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 
 [[package]]
 name = "sp-storage"
 version = "22.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "impl-serde 0.5.0",
  "parity-scale-codec",
@@ -12918,7 +13016,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "35.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -12930,7 +13028,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "17.0.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "parity-scale-codec",
  "tracing",
@@ -12941,7 +13039,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "35.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -12950,7 +13048,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "35.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -12964,7 +13062,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "38.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "ahash",
  "hash-db",
@@ -12972,7 +13070,7 @@ dependencies = [
  "nohash-hasher",
  "parity-scale-codec",
  "parking_lot 0.12.3",
- "rand",
+ "rand 0.8.5",
  "scale-info",
  "schnellru",
  "sp-core",
@@ -12986,7 +13084,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "38.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "impl-serde 0.5.0",
  "parity-scale-codec",
@@ -13003,7 +13101,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "15.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "parity-scale-codec",
  "proc-macro-warning",
@@ -13015,7 +13113,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "21.0.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -13027,7 +13125,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "31.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "bounded-collections",
  "parity-scale-codec",
@@ -13105,7 +13203,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 [[package]]
 name = "staging-xcm"
 version = "15.0.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "array-bytes",
  "bounded-collections",
@@ -13216,7 +13314,7 @@ version = "0.1.0"
 dependencies = [
  "criterion",
  "parity-scale-codec",
- "rand",
+ "rand 0.8.5",
  "rayon",
  "serde",
  "subspace-core-primitives",
@@ -13236,7 +13334,7 @@ dependencies = [
  "hex",
  "num-traits",
  "parity-scale-codec",
- "rand",
+ "rand 0.8.5",
  "rayon",
  "scale-info",
  "serde",
@@ -13268,7 +13366,7 @@ version = "0.1.0"
 dependencies = [
  "criterion",
  "kzg",
- "rand",
+ "rand 0.8.5",
  "rust-kzg-blst",
  "subspace-core-primitives",
  "subspace-kzg",
@@ -13337,7 +13435,7 @@ dependencies = [
  "parking_lot 0.12.3",
  "pin-project",
  "prometheus-client",
- "rand",
+ "rand 0.8.5",
  "rayon",
  "schnorrkel",
  "serde",
@@ -13382,7 +13480,7 @@ dependencies = [
  "libc",
  "parity-scale-codec",
  "parking_lot 0.12.3",
- "rand",
+ "rand 0.8.5",
  "rayon",
  "schnorrkel",
  "serde",
@@ -13450,8 +13548,8 @@ dependencies = [
  "derive_more 1.0.0",
  "kzg",
  "parking_lot 0.12.3",
- "rand",
- "rand_core",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "rust-kzg-blst",
  "spin 0.9.8",
  "static_assertions",
@@ -13494,7 +13592,7 @@ dependencies = [
  "pallet-sudo",
  "pallet-transaction-payment",
  "parity-scale-codec",
- "rand",
+ "rand 0.8.5",
  "sc-chain-spec",
  "sc-cli",
  "sc-client-api",
@@ -13570,7 +13668,7 @@ dependencies = [
  "parking_lot 0.12.3",
  "pin-project",
  "prometheus-client",
- "rand",
+ "rand 0.8.5",
  "schnellru",
  "serde",
  "serde_json",
@@ -13694,7 +13792,7 @@ dependencies = [
  "aes 0.9.0-pre.2",
  "core_affinity",
  "criterion",
- "rand",
+ "rand 0.8.5",
  "subspace-core-primitives",
  "thiserror 2.0.12",
 ]
@@ -13997,7 +14095,7 @@ dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
  "parking_lot 0.12.3",
- "rand",
+ "rand 0.8.5",
  "sc-block-builder",
  "sc-client-api",
  "sc-consensus",
@@ -14067,12 +14165,12 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "11.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "42.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "docify",
  "frame-system-rpc-runtime-api",
@@ -14092,7 +14190,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.17.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "http-body-util",
  "hyper 1.4.1",
@@ -14106,7 +14204,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-client"
 version = "2.0.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "array-bytes",
  "async-trait",
@@ -14133,7 +14231,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "25.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "build-helper",
  "cargo_metadata",
@@ -14722,16 +14820,17 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.20.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "212d5dcb2a1ce06d81107c3d0ffa3121fe974b73f068c8282cb1c32328113b6c"
+checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
 dependencies = [
  "futures-util",
  "log",
- "rustls 0.21.12",
- "rustls-native-certs 0.6.3",
+ "rustls 0.23.18",
+ "rustls-native-certs 0.8.1",
+ "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.24.1",
+ "tokio-rustls 0.26.0",
  "tungstenite",
 ]
 
@@ -14881,7 +14980,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum"
 version = "17.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "coarsetime",
  "polkadot-primitives",
@@ -14892,7 +14991,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "expander",
  "proc-macro-crate 3.2.0",
@@ -14978,20 +15077,20 @@ checksum = "f4f195fd851901624eee5a58c4bb2b4f06399148fcd0ed336e6f1cb60a9881df"
 
 [[package]]
 name = "tungstenite"
-version = "0.20.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e3dac10fd62eaf6617d3a904ae222845979aec67c615d1c842b4002c7666fb9"
+checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
 dependencies = [
- "byteorder",
  "bytes",
  "data-encoding",
- "http 0.2.12",
+ "http 1.1.0",
  "httparse",
  "log",
- "rand",
- "rustls 0.21.12",
+ "rand 0.9.0",
+ "rustls 0.23.18",
+ "rustls-pki-types",
  "sha1",
- "thiserror 1.0.64",
+ "thiserror 2.0.12",
  "url",
  "utf-8",
 ]
@@ -15010,7 +15109,7 @@ checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
  "digest 0.10.7",
- "rand",
+ "rand 0.8.5",
  "static_assertions",
 ]
 
@@ -15056,8 +15155,8 @@ version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04f903f293d11f31c0c29e4148f6dc0d033a7f80cebc0282bea147611667d289"
 dependencies = [
- "getrandom",
- "rand",
+ "getrandom 0.2.15",
+ "rand 0.8.5",
  "serde",
  "web-time",
 ]
@@ -15222,9 +15321,9 @@ dependencies = [
  "arrayref",
  "constcat",
  "digest 0.10.7",
- "rand",
- "rand_chacha",
- "rand_core",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
  "sha2 0.10.8",
  "sha3",
  "thiserror 1.0.64",
@@ -15263,12 +15362,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
+
+[[package]]
 name = "wasix"
 version = "0.12.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1fbb4ef9bbca0c1170e0b00dd28abc9e3b68669821600cad1caaed606583c6d"
 dependencies = [
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -15627,7 +15735,7 @@ dependencies = [
  "memfd",
  "memoffset",
  "paste",
- "rand",
+ "rand 0.8.5",
  "rustix 0.36.17",
  "wasmtime-asm-macros",
  "wasmtime-environ",
@@ -16052,6 +16160,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags 2.6.0",
+]
+
+[[package]]
 name = "write16"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -16079,7 +16196,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
 dependencies = [
  "curve25519-dalek",
- "rand_core",
+ "rand_core 0.6.4",
  "serde",
  "zeroize",
 ]
@@ -16090,15 +16207,32 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69"
 dependencies = [
- "asn1-rs",
+ "asn1-rs 0.6.2",
  "data-encoding",
- "der-parser",
+ "der-parser 9.0.0",
  "lazy_static",
  "nom",
- "oid-registry",
+ "oid-registry 0.7.1",
  "ring 0.17.13",
  "rusticata-macros",
  "thiserror 1.0.64",
+ "time",
+]
+
+[[package]]
+name = "x509-parser"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4569f339c0c402346d4a75a9e39cf8dad310e287eef1ff56d4c68e5067f53460"
+dependencies = [
+ "asn1-rs 0.7.1",
+ "data-encoding",
+ "der-parser 10.0.0",
+ "lazy_static",
+ "nom",
+ "oid-registry 0.8.1",
+ "rusticata-macros",
+ "thiserror 2.0.12",
  "time",
 ]
 
@@ -16116,7 +16250,7 @@ dependencies = [
 [[package]]
 name = "xcm-procedural"
 version = "11.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2d0d460c37f6816d8bcdea7d6f35eeba72a42c44#2d0d460c37f6816d8bcdea7d6f35eeba72a42c44"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=7c38b7ed5742bb3b53fc97f61da46033c48f9eaa#7c38b7ed5742bb3b53fc97f61da46033c48f9eaa"
 dependencies = [
  "Inflector",
  "proc-macro2",
@@ -16150,7 +16284,7 @@ dependencies = [
  "nohash-hasher",
  "parking_lot 0.12.3",
  "pin-project",
- "rand",
+ "rand 0.8.5",
  "static_assertions",
 ]
 
@@ -16165,7 +16299,7 @@ dependencies = [
  "nohash-hasher",
  "parking_lot 0.12.3",
  "pin-project",
- "rand",
+ "rand 0.8.5",
  "static_assertions",
  "web-time",
 ]
@@ -16222,7 +16356,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "byteorder",
- "zerocopy-derive",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
+dependencies = [
+ "zerocopy-derive 0.8.24",
 ]
 
 [[package]]
@@ -16230,6 +16373,17 @@ name = "zerocopy-derive"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6612,7 +6612,7 @@ dependencies = [
  "thiserror 2.0.0",
  "tracing",
  "yamux 0.12.1",
- "yamux 0.13.3",
+ "yamux 0.13.4",
 ]
 
 [[package]]
@@ -16150,9 +16150,9 @@ dependencies = [
 
 [[package]]
 name = "yamux"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31b5e376a8b012bee9c423acdbb835fc34d45001cfa3106236a624e4b738028"
+checksum = "17610762a1207ee816c6fadc29220904753648aba0a9ed61c7b8336e80a559c4"
 dependencies = [
  "futures",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,7 +112,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "mio",
- "socket2 0.5.7",
+ "socket2 0.5.8",
  "tokio",
  "tracing",
 ]
@@ -193,7 +193,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "smallvec",
- "socket2 0.5.7",
+ "socket2 0.5.8",
  "time",
  "url",
 ]
@@ -4899,7 +4899,7 @@ dependencies = [
  "ipnet",
  "once_cell",
  "rand",
- "socket2 0.5.7",
+ "socket2 0.5.8",
  "thiserror 1.0.64",
  "tinyvec",
  "tokio",
@@ -5200,7 +5200,7 @@ dependencies = [
  "http-body 1.0.1",
  "hyper 1.4.1",
  "pin-project-lite",
- "socket2 0.5.7",
+ "socket2 0.5.8",
  "tokio",
  "tower-service",
  "tracing",
@@ -5604,7 +5604,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
 dependencies = [
- "socket2 0.5.7",
+ "socket2 0.5.8",
  "widestring",
  "windows-sys 0.48.0",
  "winreg",
@@ -6360,7 +6360,7 @@ dependencies = [
  "libp2p-swarm",
  "rand",
  "smallvec",
- "socket2 0.5.7",
+ "socket2 0.5.8",
  "tokio",
  "tracing",
 ]
@@ -6456,7 +6456,7 @@ dependencies = [
  "rand",
  "ring 0.17.13",
  "rustls 0.23.18",
- "socket2 0.5.7",
+ "socket2 0.5.8",
  "thiserror 2.0.0",
  "tokio",
  "tracing",
@@ -6544,7 +6544,7 @@ dependencies = [
  "libc",
  "libp2p-core",
  "libp2p-identity",
- "socket2 0.5.7",
+ "socket2 0.5.8",
  "tokio",
  "tracing",
 ]
@@ -6778,7 +6778,7 @@ dependencies = [
  "simple-dns",
  "smallvec",
  "snow",
- "socket2 0.5.7",
+ "socket2 0.5.8",
  "static_assertions",
  "thiserror 1.0.64",
  "tokio",
@@ -9367,7 +9367,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.0.0",
  "rustls 0.23.18",
- "socket2 0.5.7",
+ "socket2 0.5.8",
  "thiserror 1.0.64",
  "tokio",
  "tracing",
@@ -9398,7 +9398,7 @@ checksum = "4fe68c2e9e1a1234e218683dbdf9f9dfcb094113c5ac2b938dfcb9bab4c4140b"
 dependencies = [
  "libc",
  "once_cell",
- "socket2 0.5.7",
+ "socket2 0.5.8",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -12015,9 +12015,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
+checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -14643,7 +14643,7 @@ dependencies = [
  "parking_lot 0.12.3",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.5.7",
+ "socket2 0.5.8",
  "tokio-macros",
  "windows-sys 0.52.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,13 +73,13 @@ fp-account = { version = "1.0.0-dev", git = "https://github.com/autonomys/fronti
 fp-evm = { version = "3.0.0-dev", git = "https://github.com/autonomys/frontier", rev = "986eb1ad6ec69c16d05d142b7e731b4b69e3b409" }
 fp-rpc = { version = "3.0.0-dev", git = "https://github.com/autonomys/frontier", rev = "986eb1ad6ec69c16d05d142b7e731b4b69e3b409", default-features = false }
 fp-self-contained = { version = "1.0.0-dev", git = "https://github.com/autonomys/frontier", rev = "986eb1ad6ec69c16d05d142b7e731b4b69e3b409", default-features = false }
-frame-benchmarking = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44", default-features = false }
-frame-benchmarking-cli = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44", default-features = false }
-frame-executive = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44", default-features = false }
-frame-support = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44", default-features = false }
-frame-system = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44", default-features = false }
-frame-system-benchmarking = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44", default-features = false }
-frame-system-rpc-runtime-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44", default-features = false }
+frame-benchmarking = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa", default-features = false }
+frame-benchmarking-cli = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa", default-features = false }
+frame-executive = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa", default-features = false }
+frame-support = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa", default-features = false }
+frame-system = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa", default-features = false }
+frame-system-benchmarking = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa", default-features = false }
+frame-system-rpc-runtime-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa", default-features = false }
 fs2 = "0.4.3"
 fs4 = "0.9.1"
 futures = "0.3.31"
@@ -99,18 +99,18 @@ log = { version = "0.4.22", default-features = false }
 memmap2 = "0.9.5"
 memory-db = { version = "0.32.0", default-features = false }
 mimalloc = "0.1.43"
-mmr-gadget = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44" }
-mmr-rpc = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44" }
+mmr-gadget = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa" }
+mmr-rpc = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa" }
 multihash = "0.19.1"
 nohash-hasher = "0.2.0"
 num-traits = { version = "0.2.18", default-features = false }
 num_cpus = "1.16.0"
 ouroboros = "0.18.4"
 pallet-auto-id = { version = "0.1.0", path = "domains/pallets/auto-id", default-features = false }
-pallet-balances = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44", default-features = false }
+pallet-balances = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa", default-features = false }
 pallet-block-fees = { version = "0.1.0", path = "domains/pallets/block-fees", default-features = false }
-pallet-collective = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44", default-features = false }
-pallet-democracy = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44", default-features = false }
+pallet-collective = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa", default-features = false }
+pallet-democracy = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa", default-features = false }
 pallet-domain-id = { version = "0.1.0", path = "domains/pallets/domain-id", default-features = false }
 pallet-domain-sudo = { version = "0.1.0", path = "domains/pallets/domain-sudo", default-features = false }
 pallet-domains = { version = "0.1.0", path = "crates/pallet-domains", default-features = false }
@@ -122,23 +122,23 @@ pallet-evm-precompile-sha3fips = { version = "2.0.0-dev", git = "https://github.
 pallet-evm-precompile-simple = { version = "2.0.0-dev", git = "https://github.com/autonomys/frontier", rev = "986eb1ad6ec69c16d05d142b7e731b4b69e3b409", default-features = false }
 pallet-evm-tracker = { version = "0.1.0", path = "domains/pallets/evm-tracker", default-features = false }
 pallet-messenger = { version = "0.1.0", path = "domains/pallets/messenger", default-features = false }
-pallet-mmr = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44", default-features = false }
-pallet-multisig = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44", default-features = false }
-pallet-preimage = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44", default-features = false }
+pallet-mmr = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa", default-features = false }
+pallet-multisig = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa", default-features = false }
+pallet-preimage = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa", default-features = false }
 pallet-rewards = { version = "0.1.0", path = "crates/pallet-rewards", default-features = false }
 pallet-runtime-configs = { version = "0.1.0", path = "crates/pallet-runtime-configs", default-features = false }
-pallet-scheduler = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44", default-features = false }
+pallet-scheduler = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa", default-features = false }
 pallet-storage-overlay-checks = { version = "0.1.0", path = "domains/test/pallets/storage_overlay_checks", default-features = false }
 pallet-subspace = { version = "0.1.0", path = "crates/pallet-subspace", default-features = false }
 pallet-subspace-mmr = { version = "0.1.0", path = "crates/pallet-subspace-mmr", default-features = false }
-pallet-sudo = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44", default-features = false }
-pallet-timestamp = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44", default-features = false }
+pallet-sudo = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa", default-features = false }
+pallet-timestamp = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa", default-features = false }
 pallet-transaction-fees = { version = "0.1.0", path = "crates/pallet-transaction-fees", default-features = false }
-pallet-transaction-payment = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44", default-features = false }
-pallet-transaction-payment-rpc = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44" }
-pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44", default-features = false }
+pallet-transaction-payment = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa", default-features = false }
+pallet-transaction-payment-rpc = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa" }
+pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa", default-features = false }
 pallet-transporter = { version = "0.1.0", path = "domains/pallets/transporter", default-features = false }
-pallet-utility = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44", default-features = false }
+pallet-utility = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa", default-features = false }
 parity-scale-codec = { version = "3.6.12", default-features = false }
 parking_lot = "0.12.2"
 pem = "3.0.4"
@@ -154,42 +154,42 @@ ring = "0.17.8"
 rlp = "0.6"
 rs_merkle = { version = "1.4.2", default-features = false }
 rust-kzg-blst = { git = "https://github.com/grandinetech/rust-kzg", rev = "6c8fcc623df3d7e8c0f30951a49bfea764f90bf4", default-features = false }
-sc-basic-authorship = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44" }
-sc-block-builder = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44" }
-sc-chain-spec = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44" }
-sc-cli = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44", default-features = false }
-sc-client-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44" }
-sc-consensus = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44" }
-sc-consensus-slots = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44" }
+sc-basic-authorship = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa" }
+sc-block-builder = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa" }
+sc-chain-spec = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa" }
+sc-cli = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa", default-features = false }
+sc-client-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa" }
+sc-consensus = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa" }
+sc-consensus-slots = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa" }
 sc-consensus-subspace = { version = "0.1.0", path = "crates/sc-consensus-subspace" }
 sc-consensus-subspace-rpc = { version = "0.1.0", path = "crates/sc-consensus-subspace-rpc" }
 sc-domains = { version = "0.1.0", path = "crates/sc-domains" }
-sc-executor = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44", default-features = false }
-sc-executor-common = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44" }
-sc-informant = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44" }
-sc-keystore = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44" }
-sc-network = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44" }
-sc-network-common = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44" }
-sc-network-gossip = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44" }
-sc-network-sync = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44", default-features = false }
-sc-network-transactions = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44" }
-sc-offchain = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44" }
+sc-executor = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa", default-features = false }
+sc-executor-common = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa" }
+sc-informant = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa" }
+sc-keystore = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa" }
+sc-network = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa" }
+sc-network-common = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa" }
+sc-network-gossip = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa" }
+sc-network-sync = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa", default-features = false }
+sc-network-transactions = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa" }
+sc-offchain = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa" }
 sc-proof-of-time = { version = "0.1.0", path = "crates/sc-proof-of-time" }
-sc-rpc = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44" }
-sc-rpc-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44" }
-sc-rpc-server = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44" }
-sc-service = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44", default-features = false }
-sc-state-db = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44" }
-sc-storage-monitor = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44", default-features = false }
+sc-rpc = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa" }
+sc-rpc-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa" }
+sc-rpc-server = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa" }
+sc-service = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa", default-features = false }
+sc-state-db = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa" }
+sc-storage-monitor = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa", default-features = false }
 sc-subspace-block-relay = { version = "0.1.0", path = "crates/sc-subspace-block-relay" }
 sc-subspace-chain-specs = { version = "0.1.0", path = "crates/sc-subspace-chain-specs" }
 sc-subspace-sync-common = { version = "0.1.0", path = "shared/sc-subspace-sync-common", default-features = false }
-sc-sysinfo = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44", default-features = false }
-sc-telemetry = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44" }
-sc-tracing = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44" }
-sc-transaction-pool = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44" }
-sc-transaction-pool-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44" }
-sc-utils = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44" }
+sc-sysinfo = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa", default-features = false }
+sc-telemetry = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa" }
+sc-tracing = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa" }
+sc-transaction-pool = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa" }
+sc-transaction-pool-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa" }
+sc-utils = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa" }
 scale-info = { version = "2.11.2", default-features = false }
 schnellru = "0.2.4"
 schnorrkel = { version = "0.11.4", default-features = false }
@@ -198,47 +198,47 @@ serde = { version = "1.0.216", default-features = false }
 serde-big-array = "0.5.1"
 serde_json = "1.0.133"
 sha2 = { version = "0.10.7", default-features = false }
-sp-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44", default-features = false }
-sp-application-crypto = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44", default-features = false }
-sp-arithmetic = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44" }
+sp-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa", default-features = false }
+sp-application-crypto = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa", default-features = false }
+sp-arithmetic = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa" }
 sp-auto-id = { version = "0.1.0", path = "domains/primitives/auto-id", default-features = false }
-sp-block-builder = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44", default-features = false }
+sp-block-builder = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa", default-features = false }
 sp-block-fees = { version = "0.1.0", path = "domains/primitives/block-fees", default-features = false }
-sp-blockchain = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44", default-features = false }
-sp-consensus = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44" }
-sp-consensus-slots = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44", default-features = false }
+sp-blockchain = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa", default-features = false }
+sp-consensus = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa" }
+sp-consensus-slots = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa", default-features = false }
 sp-consensus-subspace = { version = "0.1.0", path = "crates/sp-consensus-subspace", default-features = false }
-sp-core = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44", default-features = false }
+sp-core = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa", default-features = false }
 sp-domain-digests = { version = "0.1.0", path = "domains/primitives/digests", default-features = false }
 sp-domain-sudo = { version = "0.1.0", path = "domains/primitives/domain-sudo", default-features = false }
 sp-domains = { version = "0.1.0", path = "crates/sp-domains", default-features = false }
 sp-domains-fraud-proof = { version = "0.1.0", path = "crates/sp-domains-fraud-proof", default-features = false }
 sp-evm-tracker = { version = "0.1.0", path = "domains/primitives/evm-tracker", default-features = false }
 sp-executive = { version = "0.1.0", path = "domains/primitives/executive", default-features = false }
-sp-externalities = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44", default-features = false }
-sp-genesis-builder = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44", default-features = false }
-sp-inherents = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44", default-features = false }
-sp-io = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44", default-features = false }
-sp-keyring = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44" }
-sp-keystore = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44" }
+sp-externalities = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa", default-features = false }
+sp-genesis-builder = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa", default-features = false }
+sp-inherents = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa", default-features = false }
+sp-io = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa", default-features = false }
+sp-keyring = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa" }
+sp-keystore = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa" }
 sp-messenger = { version = "0.1.0", path = "domains/primitives/messenger", default-features = false }
 sp-messenger-host-functions = { version = "0.1.0", path = "domains/primitives/messenger-host-functions", default-features = false }
-sp-mmr-primitives = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44", default-features = false }
+sp-mmr-primitives = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa", default-features = false }
 sp-objects = { version = "0.1.0", path = "crates/sp-objects", default-features = false }
-sp-offchain = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44", default-features = false }
-sp-runtime = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44", default-features = false }
-sp-runtime-interface = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44", default-features = false }
-sp-session = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44", default-features = false }
-sp-state-machine = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44", default-features = false }
-sp-std = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44", default-features = false }
-sp-storage = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44", default-features = false }
+sp-offchain = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa", default-features = false }
+sp-runtime = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa", default-features = false }
+sp-runtime-interface = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa", default-features = false }
+sp-session = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa", default-features = false }
+sp-state-machine = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa", default-features = false }
+sp-std = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa", default-features = false }
+sp-storage = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa", default-features = false }
 sp-subspace-mmr = { version = "0.1.0", path = "crates/sp-subspace-mmr", default-features = false }
-sp-timestamp = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44", default-features = false }
-sp-tracing = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44", default-features = false }
-sp-transaction-pool = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44", default-features = false }
-sp-trie = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44", default-features = false }
-sp-version = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44", default-features = false }
-sp-weights = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44", default-features = false }
+sp-timestamp = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa", default-features = false }
+sp-tracing = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa", default-features = false }
+sp-transaction-pool = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa", default-features = false }
+sp-trie = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa", default-features = false }
+sp-version = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa", default-features = false }
+sp-weights = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa", default-features = false }
 spin = "0.9.7"
 sppark = { version = "0.1.8", git = "https://github.com/autonomys/sppark", rev = "b2a181eb99c8200f1a604f04122551ea39fbf63f" }
 ss58-registry = "1.51.0"
@@ -267,11 +267,11 @@ subspace-test-runtime = { version = "0.1.0", path = "test/subspace-test-runtime"
 subspace-test-service = { version = "0.1.0", path = "test/subspace-test-service" }
 subspace-verification = { version = "0.1.0", path = "crates/subspace-verification", default-features = false }
 substrate-bip39 = "0.6.0"
-substrate-build-script-utils = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44" }
-substrate-frame-rpc-system = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44" }
-substrate-prometheus-endpoint = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44" }
-substrate-test-client = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44" }
-substrate-wasm-builder = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44" }
+substrate-build-script-utils = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa" }
+substrate-frame-rpc-system = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa" }
+substrate-prometheus-endpoint = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa" }
+substrate-test-client = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa" }
+substrate-wasm-builder = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa" }
 supports-color = "3.0.1"
 tempfile = "3.13.0"
 thiserror = { version = "2.0.0", default-features = false }
@@ -360,50 +360,50 @@ lto = "fat"
 # Reason: We need to patch substrate dependency of frontier to our fork
 # TODO: Remove if/when we are using upstream substrate instead of fork
 [patch."https://github.com/paritytech/polkadot-sdk.git"]
-frame-benchmarking = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44" }
-frame-support = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44" }
-frame-system = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44" }
-sc-block-builder = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44" }
-sc-client-db = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44" }
-sc-consensus = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44" }
-sc-consensus-slots = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44" }
-sc-client-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44" }
-sc-network = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44" }
-sc-network-common = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44" }
-sc-network-sync = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44" }
-sc-rpc = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44" }
-sc-service = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44" }
-sc-telemetry = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44" }
-sc-transaction-pool = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44" }
-sc-transaction-pool-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44" }
-sc-utils = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44" }
-sp-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44" }
-sp-application-crypto = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44" }
-sp-arithmetic = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44" }
-sp-block-builder = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44" }
-sp-blockchain = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44" }
-sp-consensus = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44" }
-sp-consensus-slots = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44" }
-sp-core = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44" }
-sp-crypto-hashing = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44" }
-sp-database = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44" }
-sp-debug-derive = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44" }
-sp-externalities = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44" }
-sp-inherents = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44" }
-sp-io = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44" }
-sp-keystore = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44" }
-sp-runtime = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44" }
-sp-runtime-interface = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44" }
-sp-state-machine = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44" }
-sp-std = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44" }
-sp-storage = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44" }
-sp-timestamp = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44" }
-sp-trie = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44" }
-sp-version = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44" }
-sp-weights = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44" }
-staging-xcm = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44" }
-substrate-prometheus-endpoint = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44" }
-xcm-procedural = { git = "https://github.com/subspace/polkadot-sdk", rev = "2d0d460c37f6816d8bcdea7d6f35eeba72a42c44" }
+frame-benchmarking = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa" }
+frame-support = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa" }
+frame-system = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa" }
+sc-block-builder = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa" }
+sc-client-db = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa" }
+sc-consensus = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa" }
+sc-consensus-slots = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa" }
+sc-client-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa" }
+sc-network = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa" }
+sc-network-common = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa" }
+sc-network-sync = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa" }
+sc-rpc = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa" }
+sc-service = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa" }
+sc-telemetry = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa" }
+sc-transaction-pool = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa" }
+sc-transaction-pool-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa" }
+sc-utils = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa" }
+sp-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa" }
+sp-application-crypto = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa" }
+sp-arithmetic = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa" }
+sp-block-builder = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa" }
+sp-blockchain = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa" }
+sp-consensus = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa" }
+sp-consensus-slots = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa" }
+sp-core = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa" }
+sp-crypto-hashing = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa" }
+sp-database = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa" }
+sp-debug-derive = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa" }
+sp-externalities = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa" }
+sp-inherents = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa" }
+sp-io = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa" }
+sp-keystore = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa" }
+sp-runtime = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa" }
+sp-runtime-interface = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa" }
+sp-state-machine = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa" }
+sp-std = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa" }
+sp-storage = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa" }
+sp-timestamp = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa" }
+sp-trie = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa" }
+sp-version = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa" }
+sp-weights = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa" }
+staging-xcm = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa" }
+substrate-prometheus-endpoint = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa" }
+xcm-procedural = { git = "https://github.com/subspace/polkadot-sdk", rev = "7c38b7ed5742bb3b53fc97f61da46033c48f9eaa" }
 
 [patch."https://github.com/subspace/polkadot-sdk.git"]
 # De-duplicate extra copy that comes from Substrate repo

--- a/crates/subspace-networking/src/behavior/persistent_parameters.rs
+++ b/crates/subspace-networking/src/behavior/persistent_parameters.rs
@@ -685,7 +685,7 @@ pub(crate) fn remove_p2p_suffix(mut address: Multiaddr) -> Multiaddr {
     address
 }
 
-/// Appends a P2p protocol suffix to the multiaddress if require3d.
+/// Appends a P2p protocol suffix to the multiaddress if required.
 pub(crate) fn append_p2p_suffix(peer_id: PeerId, mut address: Multiaddr) -> Multiaddr {
     let last_protocol = address.pop();
 

--- a/crates/subspace-networking/src/node_runner.rs
+++ b/crates/subspace-networking/src/node_runner.rs
@@ -390,7 +390,7 @@ impl NodeRunner {
         let mut external_addresses = self.swarm.external_addresses().cloned().collect::<Vec<_>>();
 
         if let Some(shared) = self.shared_weak.upgrade() {
-            debug!(?external_addresses, "Renew external addresses.",);
+            debug!(?external_addresses, "Renew external addresses.");
             let mut addresses = shared.external_addresses.lock();
             addresses.clear();
             addresses.append(&mut external_addresses);
@@ -411,7 +411,7 @@ impl NodeRunner {
     }
 
     fn handle_removed_address_event(&mut self, event: PeerAddressRemovedEvent) {
-        trace!(?event, "Peer addressed removed event.",);
+        trace!(?event, "Peer address removed event.");
 
         let bootstrap_node_ids = strip_peer_id(self.bootstrap_addresses.clone())
             .into_iter()
@@ -473,7 +473,9 @@ impl NodeRunner {
             SwarmEvent::Behaviour(Event::Autonat(event)) => {
                 self.handle_autonat_event(event).await;
             }
-            SwarmEvent::NewListenAddr { address, .. } => {
+            ref event @ SwarmEvent::NewListenAddr { ref address, .. } => {
+                trace!(?event, "New local listener  event.");
+
                 let shared = match self.shared_weak.upgrade() {
                     Some(shared) => shared,
                     None => {
@@ -481,7 +483,7 @@ impl NodeRunner {
                     }
                 };
                 shared.listeners.lock().push(address.clone());
-                shared.handlers.new_listener.call_simple(&address);
+                shared.handlers.new_listener.call_simple(address);
             }
             ref event @ SwarmEvent::ListenerClosed { ref addresses, .. } => {
                 trace!(?event, "Local listener closed event.");
@@ -1097,7 +1099,7 @@ impl NodeRunner {
                             ) || cancelled;
                         }
                         Err(error) => {
-                            debug!(?error, "Put record query failed.",);
+                            debug!(?error, "Put record query failed.");
                         }
                     }
                 }


### PR DESCRIPTION
This PR updates our substrate fork to include 3 network connection/stream bug fixes:

A peer address autodetection fix, which works around a libp2p bug that pollutes the peer set with ephemeral outbound ports:
- https://github.com/paritytech/polkadot-sdk/pull/7338

Peer connection substream fixes, which correctly detect and react to I/O errors on connections by closing substreams: 
- https://github.com/paritytech/polkadot-sdk/pull/7640
- https://github.com/paritytech/polkadot-sdk/pull/7724

Close https://github.com/autonomys/subspace/issues/3450

Some updates were required to other dependencies to resolve lockfile version conflicts.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
