### PR TITLE
Provide executor config and Trie cache size through cli

### DIFF
--- a/crates/subspace-node/src/commands/run/consensus.rs
+++ b/crates/subspace-node/src/commands/run/consensus.rs
@@ -1,4 +1,4 @@
-use crate::commands::run::shared::RpcOptions;
+use crate::commands::run::shared::{RpcOptions, TrieCacheParams};
 use crate::{chain_spec, derive_pot_external_entropy, Error};
 use clap::Parser;
 use prometheus_client::registry::Registry;
@@ -485,6 +485,10 @@ pub(super) struct ConsensusChainOptions {
     /// Options for Runtime
     #[clap(flatten)]
     pub runtime_params: RuntimeParams,
+
+    /// Options for Trie cache.
+    #[clap(flatten)]
+    pub trie_cache_params: TrieCacheParams,
 }
 
 pub(super) struct PrometheusConfiguration {
@@ -529,6 +533,7 @@ pub(super) fn create_consensus_chain_configuration(
         mut timekeeper_options,
         mut sync,
         runtime_params,
+        trie_cache_params,
     } = consensus_node_options;
 
     let transaction_pool;
@@ -706,6 +711,7 @@ pub(super) fn create_consensus_chain_configuration(
             default_heap_pages: None,
             runtime_cache_size: runtime_params.runtime_cache_size,
         },
+        trie_cache_size: trie_cache_params.trie_cache_maximum_size(),
     };
     let consensus_chain_config = Configuration::from(consensus_chain_config);
 

--- a/crates/subspace-node/src/commands/run/domain.rs
+++ b/crates/subspace-node/src/commands/run/domain.rs
@@ -1,4 +1,4 @@
-use crate::commands::run::shared::RpcOptions;
+use crate::commands::run::shared::{RpcOptions, TrieCacheParams};
 use crate::commands::shared::{store_key_in_keystore, KeystoreOptions};
 use crate::Error;
 use clap::Parser;
@@ -132,6 +132,10 @@ pub(super) struct DomainOptions {
     #[clap(flatten)]
     pub runtime_params: RuntimeParams,
 
+    /// Options for Trie cache.
+    #[clap(flatten)]
+    pub trie_cache_params: TrieCacheParams,
+
     /// Additional args for domain.
     #[clap(raw = true)]
     additional_args: Vec<String>,
@@ -161,6 +165,7 @@ pub(super) fn create_domain_configuration(
         keystore_options,
         pool_config,
         runtime_params,
+        trie_cache_params,
         additional_args,
     } = domain_options;
 
@@ -380,6 +385,7 @@ pub(super) fn create_domain_configuration(
             default_heap_pages: None,
             runtime_cache_size: runtime_params.runtime_cache_size,
         },
+        trie_cache_size: trie_cache_params.trie_cache_maximum_size(),
     };
 
     Ok(DomainConfiguration {

--- a/crates/subspace-node/src/commands/run/domain.rs
+++ b/crates/subspace-node/src/commands/run/domain.rs
@@ -16,14 +16,15 @@ use evm_domain_runtime::AccountId as AccountId20;
 use futures::StreamExt;
 use sc_chain_spec::{ChainType, GenericChainSpec, NoExtension, Properties};
 use sc_cli::{
-    Cors, KeystoreParams, PruningParams, RpcMethods, TransactionPoolParams, RPC_DEFAULT_PORT,
+    Cors, KeystoreParams, PruningParams, RpcMethods, RuntimeParams, TransactionPoolParams,
+    RPC_DEFAULT_PORT,
 };
 use sc_consensus_subspace::block_import::BlockImportingNotification;
 use sc_consensus_subspace::notification::SubspaceNotificationStream;
 use sc_network::config::{MultiaddrWithPeerId, NonReservedPeerMode, SetConfig, TransportConfig};
 use sc_network::{NetworkPeers, NetworkRequest};
 use sc_proof_of_time::source::PotSlotInfo;
-use sc_service::config::KeystoreConfig;
+use sc_service::config::{ExecutorConfiguration, KeystoreConfig};
 use sc_service::Configuration;
 use sc_transaction_pool_api::OffchainTransactionPoolFactory;
 use sc_utils::mpsc::{TracingUnboundedReceiver, TracingUnboundedSender};
@@ -127,6 +128,10 @@ pub(super) struct DomainOptions {
     #[clap(flatten)]
     pool_config: TransactionPoolParams,
 
+    /// Options for Runtime
+    #[clap(flatten)]
+    pub runtime_params: RuntimeParams,
+
     /// Additional args for domain.
     #[clap(raw = true)]
     additional_args: Vec<String>,
@@ -155,8 +160,8 @@ pub(super) fn create_domain_configuration(
         mut keystore_suri,
         keystore_options,
         pool_config,
+        runtime_params,
         additional_args,
-        ..
     } = domain_options;
 
     let domain_id;
@@ -369,6 +374,12 @@ pub(super) fn create_domain_configuration(
         telemetry_endpoints: consensus_chain_configuration.telemetry_endpoints.clone(),
         force_authoring: false,
         chain_spec: Box::new(chain_spec),
+        executor: ExecutorConfiguration {
+            wasm_method: Default::default(),
+            max_runtime_instances: runtime_params.max_runtime_instances,
+            default_heap_pages: None,
+            runtime_cache_size: runtime_params.runtime_cache_size,
+        },
     };
 
     Ok(DomainConfiguration {

--- a/crates/subspace-node/src/commands/run/shared.rs
+++ b/crates/subspace-node/src/commands/run/shared.rs
@@ -95,3 +95,24 @@ pub(super) struct RpcOptions<const DEFAULT_PORT: u16> {
     #[arg(long)]
     pub(super) rpc_cors: Option<Cors>,
 }
+
+/// Parameters for Trie cache.
+#[derive(Debug, Parser)]
+pub struct TrieCacheParams {
+    /// Specify the state cache size.
+    ///
+    /// Providing `0` will disable the cache.
+    #[arg(long, value_name = "Bytes", default_value_t = 67108864)]
+    pub trie_cache_size: usize,
+}
+
+impl TrieCacheParams {
+    /// Specify the trie cache maximum size.
+    pub fn trie_cache_maximum_size(&self) -> Option<usize> {
+        if self.trie_cache_size == 0 {
+            None
+        } else {
+            Some(self.trie_cache_size)
+        }
+    }
+}

--- a/crates/subspace-service/src/config.rs
+++ b/crates/subspace-service/src/config.rs
@@ -120,6 +120,8 @@ pub struct SubstrateConfiguration {
     pub chain_spec: Box<dyn ChainSpec>,
     /// Executor configuration
     pub executor: ExecutorConfiguration,
+    /// Trie cache size
+    pub trie_cache_size: Option<usize>,
 }
 
 impl From<SubstrateConfiguration> for Configuration {
@@ -212,8 +214,7 @@ impl From<SubstrateConfiguration> for Configuration {
                 path: configuration.base_path.join("db"),
             },
             data_path: configuration.base_path.clone(),
-            // Substrate's default
-            trie_cache_maximum_size: Some(64 * 1024 * 1024),
+            trie_cache_maximum_size: configuration.trie_cache_size,
             state_pruning: Some(configuration.state_pruning),
             blocks_pruning: configuration.blocks_pruning,
             executor: configuration.executor,

--- a/crates/subspace-service/src/config.rs
+++ b/crates/subspace-service/src/config.rs
@@ -118,6 +118,8 @@ pub struct SubstrateConfiguration {
     pub force_authoring: bool,
     /// Chain specification
     pub chain_spec: Box<dyn ChainSpec>,
+    /// Executor configuration
+    pub executor: ExecutorConfiguration,
 }
 
 impl From<SubstrateConfiguration> for Configuration {
@@ -214,14 +216,7 @@ impl From<SubstrateConfiguration> for Configuration {
             trie_cache_maximum_size: Some(64 * 1024 * 1024),
             state_pruning: Some(configuration.state_pruning),
             blocks_pruning: configuration.blocks_pruning,
-            executor: ExecutorConfiguration {
-                wasm_method: Default::default(),
-                // Substrate's default
-                max_runtime_instances: 8,
-                default_heap_pages: None,
-                // Substrate's default
-                runtime_cache_size: 2,
-            },
+            executor: configuration.executor,
             wasm_runtime_overrides: None,
             rpc: RpcConfiguration {
                 addr: rpc_addr,

--- a/domains/service/src/config.rs
+++ b/domains/service/src/config.rs
@@ -110,6 +110,8 @@ pub struct SubstrateConfiguration {
     pub force_authoring: bool,
     /// Chain specification
     pub chain_spec: Box<dyn ChainSpec>,
+    /// Executor configuration
+    pub executor: ExecutorConfiguration,
 }
 
 impl From<SubstrateConfiguration> for Configuration {
@@ -208,14 +210,7 @@ impl From<SubstrateConfiguration> for Configuration {
             trie_cache_maximum_size: Some(64 * 1024 * 1024),
             state_pruning: configuration.state_pruning,
             blocks_pruning: configuration.blocks_pruning,
-            executor: ExecutorConfiguration {
-                wasm_method: Default::default(),
-                // Substrate's default
-                max_runtime_instances: 8,
-                default_heap_pages: None,
-                // Substrate's default
-                runtime_cache_size: 2,
-            },
+            executor: configuration.executor,
             wasm_runtime_overrides: None,
             rpc: RpcConfiguration {
                 addr: rpc_addr,

--- a/domains/service/src/config.rs
+++ b/domains/service/src/config.rs
@@ -112,6 +112,8 @@ pub struct SubstrateConfiguration {
     pub chain_spec: Box<dyn ChainSpec>,
     /// Executor configuration
     pub executor: ExecutorConfiguration,
+    /// Trie cache size
+    pub trie_cache_size: Option<usize>,
 }
 
 impl From<SubstrateConfiguration> for Configuration {
@@ -206,8 +208,7 @@ impl From<SubstrateConfiguration> for Configuration {
                 path: configuration.base_path.join("db"),
             },
             data_path: configuration.base_path.clone(),
-            // Substrate's default
-            trie_cache_maximum_size: Some(64 * 1024 * 1024),
+            trie_cache_maximum_size: configuration.trie_cache_size,
             state_pruning: configuration.state_pruning,
             blocks_pruning: configuration.blocks_pruning,
             executor: configuration.executor,


### PR DESCRIPTION
While running the RPC node for Blockscout, which while indexing seems to require more than 8 instances of same runtime cache. Unfortunately our cli config always default to 8 as a substrate default.

This PR provides the Runtime parameters to set the custom instances cache count per runtime. The default is still 8 unless explicitly passed through cli and maximum would be 32 as per substrate limit.

Closes: #3430
Closes: #3453

@DaMandal0rian once this is pulled into a new release, 

for rpc nodes that uses BlockScount, you can pass additional cli param `--max-runtime-instances` with 32, as this is maximum, for both Consensus and Domain as well and `--trie-cache-size` with `1073741824` (1 GB) like we tested with the patch


### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
