### PR TITLE
Add domain starting checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13714,6 +13714,7 @@ dependencies = [
  "sc-chain-spec",
  "sc-cli",
  "sc-client-api",
+ "sc-client-db",
  "sc-consensus-slots",
  "sc-consensus-subspace",
  "sc-domains",

--- a/crates/subspace-malicious-operator/src/bin/subspace-malicious-operator.rs
+++ b/crates/subspace-malicious-operator/src/bin/subspace-malicious-operator.rs
@@ -293,6 +293,11 @@ fn main() -> Result<(), Error> {
                 )?
             };
 
+            let domain_backend = sc_service::new_db_backend::<DomainBlock>(
+                    domain_config.db_config(),
+                )
+                .map_err(|error| Error::Other(format!("Failed to create domain backend: {error:?}")))?;
+
             let domain_starter = DomainInstanceStarter {
                 domain_cli,
                 consensus_client: consensus_chain_node.client.clone(),
@@ -310,6 +315,7 @@ fn main() -> Result<(), Error> {
                 consensus_sync_service: consensus_chain_node.sync_service.clone(),
                 domain_message_receiver,
                 gossip_message_sink: xdm_gossip_worker_builder.gossip_msg_sink(),
+                domain_backend,
                 domain_config,
             };
 

--- a/crates/subspace-malicious-operator/src/bin/subspace-malicious-operator.rs
+++ b/crates/subspace-malicious-operator/src/bin/subspace-malicious-operator.rs
@@ -329,8 +329,9 @@ fn main() -> Result<(), Error> {
                     "domain",
                     None,
                     Box::pin(async move {
-                        let bootstrap_result_fut = fetch_domain_bootstrap_info::<DomainBlock, _, _>(
+                        let bootstrap_result_fut = fetch_domain_bootstrap_info::<DomainBlock, _, _, _>(
                             &*domain_starter.consensus_client,
+                            &*domain_starter.domain_backend,
                             domain_id,
                         );
                         let bootstrap_result = match bootstrap_result_fut.await {

--- a/crates/subspace-malicious-operator/src/chain_spec.rs
+++ b/crates/subspace-malicious-operator/src/chain_spec.rs
@@ -3,7 +3,7 @@ use evm_domain_runtime::{AccountId as AccountId20, EVMChainIdConfig, EVMConfig, 
 use hex_literal::hex;
 use parity_scale_codec::Encode;
 use sc_chain_spec::GenericChainSpec;
-use sc_service::{ChainSpec, ChainType};
+use sc_service::ChainType;
 use sp_core::crypto::AccountId32;
 use sp_core::{sr25519, Pair, Public};
 use sp_domains::storage::RawGenesis;
@@ -90,15 +90,11 @@ pub(crate) fn consensus_dev_sudo_account() -> AccountId32 {
     get_account_id_from_seed("Alice")
 }
 
-pub fn create_domain_spec(
-    chain_id: &str,
-    raw_genesis: RawGenesis,
-) -> Result<Box<dyn sc_cli::ChainSpec>, String> {
-    let mut chain_spec = match chain_id {
+pub fn create_domain_spec(chain_id: &str) -> Result<Box<dyn sc_cli::ChainSpec>, String> {
+    let chain_spec = match chain_id {
         "dev" => domain_dev_config()?,
         path => GenericChainSpec::from_json_file(std::path::PathBuf::from(path))?,
     };
-    chain_spec.set_storage(raw_genesis.into_storage());
     Ok(Box::new(chain_spec))
 }
 

--- a/crates/subspace-malicious-operator/src/lib.rs
+++ b/crates/subspace-malicious-operator/src/lib.rs
@@ -5,6 +5,7 @@ mod malicious_bundle_producer;
 mod malicious_bundle_tamper;
 pub mod malicious_domain_instance_starter;
 
+pub use chain_spec::create_domain_spec;
 use clap::Parser;
 use sc_chain_spec::GenericChainSpec;
 use sc_cli::{

--- a/crates/subspace-malicious-operator/src/malicious_domain_instance_starter.rs
+++ b/crates/subspace-malicious-operator/src/malicious_domain_instance_starter.rs
@@ -1,5 +1,5 @@
 use crate::malicious_bundle_producer::MaliciousBundleProducer;
-use crate::{create_malicious_operator_configuration, DomainCli};
+use crate::DomainCli;
 use cross_domain_message_gossip::{ChainMsg, Message};
 use domain_client_operator::snap_sync::ConsensusChainSyncParams;
 use domain_client_operator::{BootstrapResult, OperatorStreams};
@@ -10,11 +10,11 @@ use domain_service::providers::DefaultProvider;
 use domain_service::{FullBackend, FullClient};
 use evm_domain_runtime::AccountId as AccountId20;
 use futures::StreamExt;
-use sc_cli::CliConfiguration;
 use sc_consensus_subspace::block_import::BlockImportingNotification;
 use sc_consensus_subspace::notification::SubspaceNotificationStream;
 use sc_consensus_subspace::slot_worker::NewSlotNotification;
 use sc_network::{NetworkPeers, NetworkRequest};
+use sc_service::Configuration;
 use sc_transaction_pool_api::OffchainTransactionPoolFactory;
 use sc_utils::mpsc::{TracingUnboundedReceiver, TracingUnboundedSender};
 use sp_api::ProvideRuntimeApi;
@@ -24,7 +24,6 @@ use sp_core::crypto::AccountId32;
 use sp_core::traits::SpawnEssentialNamed;
 use sp_domains::{DomainInstanceData, RuntimeType};
 use sp_keystore::KeystorePtr;
-use std::path::PathBuf;
 use std::sync::Arc;
 use subspace_runtime::RuntimeApi as CRuntimeApi;
 use subspace_runtime_primitives::opaque::Block as CBlock;
@@ -35,8 +34,6 @@ use subspace_service::FullClient as CFullClient;
 /// bootstrap result
 pub struct DomainInstanceStarter {
     pub domain_cli: DomainCli,
-    pub base_path: PathBuf,
-    pub tokio_handle: tokio::runtime::Handle,
     pub consensus_client: Arc<CFullClient<CRuntimeApi>>,
     pub consensus_keystore: KeystorePtr,
     pub consensus_offchain_tx_pool_factory: OffchainTransactionPoolFactory<CBlock>,
@@ -47,6 +44,7 @@ pub struct DomainInstanceStarter {
     pub domain_message_receiver: TracingUnboundedReceiver<ChainMsg>,
     pub gossip_message_sink: TracingUnboundedSender<Message>,
     pub consensus_network: Arc<dyn NetworkPeers + Send + Sync>,
+    pub domain_config: Configuration,
 }
 
 impl DomainInstanceStarter {
@@ -68,8 +66,6 @@ impl DomainInstanceStarter {
 
         let DomainInstanceStarter {
             domain_cli,
-            base_path,
-            tokio_handle,
             consensus_client,
             consensus_keystore,
             consensus_offchain_tx_pool_factory,
@@ -79,21 +75,13 @@ impl DomainInstanceStarter {
             domain_message_receiver,
             gossip_message_sink,
             consensus_network,
+            mut domain_config,
         } = self;
 
         let domain_id = domain_cli.domain_id.into();
-        let domain_config = {
-            let chain_id = domain_cli.run.chain_id(domain_cli.run.is_dev()?)?;
-            let domain_spec =
-                crate::chain_spec::create_domain_spec(chain_id.as_str(), raw_genesis)?;
-            create_malicious_operator_configuration::<DomainCli>(
-                domain_id,
-                base_path.into(),
-                &domain_cli,
-                domain_spec,
-                tokio_handle,
-            )?
-        };
+        domain_config
+            .chain_spec
+            .set_storage(raw_genesis.into_storage());
 
         let block_importing_notification_stream = block_importing_notification_stream
             .subscribe()

--- a/crates/subspace-malicious-operator/src/malicious_domain_instance_starter.rs
+++ b/crates/subspace-malicious-operator/src/malicious_domain_instance_starter.rs
@@ -44,6 +44,7 @@ pub struct DomainInstanceStarter {
     pub domain_message_receiver: TracingUnboundedReceiver<ChainMsg>,
     pub gossip_message_sink: TracingUnboundedSender<Message>,
     pub consensus_network: Arc<dyn NetworkPeers + Send + Sync>,
+    pub domain_backend: Arc<FullBackend<DomainBlock>>,
     pub domain_config: Configuration,
 }
 
@@ -75,6 +76,7 @@ impl DomainInstanceStarter {
             domain_message_receiver,
             gossip_message_sink,
             consensus_network,
+            domain_backend,
             mut domain_config,
         } = self;
 
@@ -155,6 +157,7 @@ impl DomainInstanceStarter {
                         ConsensusChainSyncParams<_, Arc<dyn NetworkRequest + Sync + Send>>,
                     >,
                     challenge_period: DOMAINS_BLOCK_PRUNING_DEPTH,
+                    domain_backend,
                 };
 
                 let mut domain_node = domain_service::new_full::<
@@ -218,6 +221,7 @@ impl DomainInstanceStarter {
                         ConsensusChainSyncParams<_, Arc<dyn NetworkRequest + Sync + Send>>,
                     >,
                     challenge_period: DOMAINS_BLOCK_PRUNING_DEPTH,
+                    domain_backend,
                 };
 
                 let mut domain_node = domain_service::new_full::<

--- a/crates/subspace-node/Cargo.toml
+++ b/crates/subspace-node/Cargo.toml
@@ -43,6 +43,7 @@ prometheus-client.workspace = true
 sc-chain-spec.workspace = true
 sc-cli.workspace = true
 sc-client-api.workspace = true
+sc-client-db.workspace = true
 sc-consensus-slots.workspace = true
 sc-consensus-subspace.workspace = true
 sc-domains.workspace = true

--- a/crates/subspace-node/src/commands/run.rs
+++ b/crates/subspace-node/src/commands/run.rs
@@ -333,10 +333,12 @@ pub async fn run(run_options: RunOptions) -> Result<(), Error> {
                         let span = info_span!("Domain");
                         let _enter = span.enter();
 
-                        let bootstrap_result_fut = fetch_domain_bootstrap_info::<DomainBlock, _, _>(
-                            &*domain_start_options.consensus_client,
-                            domain_configuration.domain_id,
-                        );
+                        let bootstrap_result_fut =
+                            fetch_domain_bootstrap_info::<DomainBlock, _, _, _>(
+                                &*domain_start_options.consensus_client,
+                                &*domain_start_options.domain_backend,
+                                domain_configuration.domain_id,
+                            );
 
                         let bootstrap_result = match bootstrap_result_fut.await {
                             Ok(bootstrap_result) => bootstrap_result,

--- a/crates/subspace-node/src/commands/run.rs
+++ b/crates/subspace-node/src/commands/run.rs
@@ -20,12 +20,15 @@ use domain_runtime_primitives::opaque::Block as DomainBlock;
 use futures::stream::StreamExt;
 use futures::FutureExt;
 use sc_cli::Signals;
+use sc_client_api::HeaderBackend;
 use sc_consensus_slots::SlotProportion;
 use sc_service::{BlocksPruning, Configuration, PruningMode};
 use sc_state_db::Constraints;
 use sc_storage_monitor::StorageMonitorService;
 use sc_transaction_pool_api::OffchainTransactionPoolFactory;
 use sc_utils::mpsc::tracing_unbounded;
+use sp_api::ProvideRuntimeApi;
+use sp_consensus_subspace::SubspaceApi;
 use sp_core::traits::SpawnEssentialNamed;
 use sp_messenger::messages::ChainId;
 use std::env;
@@ -286,6 +289,24 @@ pub async fn run(run_options: RunOptions) -> Result<(), Error> {
                     );
             };
 
+            let domain_backend = {
+                let consensus_best_hash = consensus_chain_node.client.info().best_hash;
+                let chain_constants = consensus_chain_node
+                    .client
+                    .runtime_api()
+                    .chain_constants(consensus_best_hash)
+                    .map_err(|err| Error::Other(err.to_string()))?;
+                Arc::new(
+                    sc_client_db::Backend::new(
+                        domain_configuration.domain_config.db_config(),
+                        chain_constants.confirmation_depth_k().into(),
+                    )
+                    .map_err(|error| {
+                        Error::Other(format!("Failed to create domain backend: {error:?}"))
+                    })?,
+                )
+            };
+
             let domain_start_options = DomainStartOptions {
                 consensus_client: consensus_chain_node.client.clone(),
                 consensus_offchain_tx_pool_factory: OffchainTransactionPoolFactory::new(
@@ -298,6 +319,7 @@ pub async fn run(run_options: RunOptions) -> Result<(), Error> {
                 consensus_network_sync_oracle: consensus_chain_node.sync_service.clone(),
                 domain_message_receiver,
                 gossip_message_sink,
+                domain_backend,
             };
 
             consensus_chain_node

--- a/crates/subspace-node/src/commands/run/domain.rs
+++ b/crates/subspace-node/src/commands/run/domain.rs
@@ -438,6 +438,7 @@ pub(super) struct DomainStartOptions {
     pub(super) domain_message_receiver:
         TracingUnboundedReceiver<cross_domain_message_gossip::ChainMsg>,
     pub(super) gossip_message_sink: TracingUnboundedSender<cross_domain_message_gossip::Message>,
+    pub(super) domain_backend: Arc<FullBackend<DomainBlock>>,
 }
 
 pub(super) async fn run_domain<CNR>(
@@ -481,6 +482,7 @@ where
         consensus_network_sync_oracle,
         domain_message_receiver,
         gossip_message_sink,
+        domain_backend,
     } = domain_start_options;
 
     let block_importing_notification_stream = block_importing_notification_stream
@@ -563,6 +565,7 @@ where
                 confirmation_depth_k: chain_constants.confirmation_depth_k(),
                 consensus_chain_sync_params,
                 challenge_period: DOMAINS_BLOCK_PRUNING_DEPTH,
+                domain_backend,
             };
 
             let mut domain_node = domain_service::new_full::<
@@ -604,6 +607,7 @@ where
                 confirmation_depth_k: chain_constants.confirmation_depth_k(),
                 consensus_chain_sync_params,
                 challenge_period: DOMAINS_BLOCK_PRUNING_DEPTH,
+                domain_backend,
             };
 
             let mut domain_node = domain_service::new_full::<

--- a/domains/client/domain-operator/src/fetch_domain_bootstrap_info.rs
+++ b/domains/client/domain-operator/src/fetch_domain_bootstrap_info.rs
@@ -81,8 +81,8 @@ where
     // which is unexpected as the domain chain is derived from the consensus chain.
     if is_domain_started {
         return Err(
-            "The domain chain is ahead of the consensus chain, possibly uncleaned `domains`
-            folder from the last run"
+            "The domain chain is ahead of the consensus chain, inconsistent `db` and `domains`
+            folders from the last run"
                 .to_string()
                 .into(),
         );

--- a/domains/client/domain-operator/src/fetch_domain_bootstrap_info.rs
+++ b/domains/client/domain-operator/src/fetch_domain_bootstrap_info.rs
@@ -63,7 +63,8 @@ where
         //    in inconsistent `raw_genesis`
         if !is_domain_started && !domain_best_number.is_zero() {
             return Err(
-                "An existing consensus node can’t be restarted as a domain node"
+                "An existing consensus node can't be restarted as a domain node, in order to
+                proceed please wipe the `db` and `domains` folders"
                     .to_string()
                     .into(),
             );

--- a/domains/client/domain-operator/src/fetch_domain_bootstrap_info.rs
+++ b/domains/client/domain-operator/src/fetch_domain_bootstrap_info.rs
@@ -63,7 +63,7 @@ where
         //    in inconsistent `raw_genesis`
         if !is_domain_started && !domain_best_number.is_zero() {
             return Err(
-                "Unable to restart the existing consensus node as a domain node"
+                "An existing consensus node can’t be restarted as a domain node"
                     .to_string()
                     .into(),
             );

--- a/domains/client/domain-operator/src/fetch_domain_bootstrap_info.rs
+++ b/domains/client/domain-operator/src/fetch_domain_bootstrap_info.rs
@@ -1,9 +1,10 @@
 use futures::StreamExt;
+use sc_client_api::backend::Backend;
 use sc_client_api::{BlockchainEvents, ImportNotifications};
 use sp_api::ProvideRuntimeApi;
 use sp_blockchain::HeaderBackend;
 use sp_domains::{DomainId, DomainInstanceData, DomainsApi, DomainsDigestItem};
-use sp_runtime::traits::{Block as BlockT, Header as HeaderT, NumberFor};
+use sp_runtime::traits::{Block as BlockT, Header as HeaderT, NumberFor, Zero};
 
 #[derive(Debug)]
 pub struct BootstrapResult<CBlock: BlockT> {
@@ -20,8 +21,9 @@ pub struct BootstrapResult<CBlock: BlockT> {
     pub imported_block_notification_stream: ImportNotifications<CBlock>,
 }
 
-pub async fn fetch_domain_bootstrap_info<Block, CBlock, CClient>(
+pub async fn fetch_domain_bootstrap_info<Block, CBlock, CClient, DomainBackend>(
     consensus_client: &CClient,
+    domain_backend: &DomainBackend,
     self_domain_id: DomainId,
 ) -> Result<BootstrapResult<CBlock>, Box<dyn std::error::Error>>
 where
@@ -29,7 +31,12 @@ where
     CBlock: BlockT,
     CClient: HeaderBackend<CBlock> + ProvideRuntimeApi<CBlock> + BlockchainEvents<CBlock>,
     CClient::Api: DomainsApi<CBlock, Block::Header>,
+    DomainBackend: Backend<Block>,
 {
+    // The genesis block is finalized when the chain is initialized, if `finalized_state`
+    // is non-empty meaning the domain chain is already started in the last run.
+    let is_domain_started = domain_backend.blockchain().info().finalized_state.is_some();
+
     let mut imported_block_notification_stream =
         consensus_client.every_import_notification_stream();
 
@@ -39,11 +46,46 @@ where
         .runtime_api()
         .domain_instance_data(best_hash, self_domain_id)?
     {
+        let domain_best_number = consensus_client
+            .runtime_api()
+            .domain_best_number(best_hash, self_domain_id)?
+            .unwrap_or_default();
+
+        // The `domain_best_number` is the expected best domain block after the operator has
+        // processed the consensus block at `best_hash`. If `domain_best_number` is not zero
+        // and the domain chain is not started, the domain block `0..domain_best_number` are
+        // missed, we can not preceed running as a domain node because:
+        //
+        // - The consensus block and state that derive the domain block `0..domain_best_number`
+        //    may not available anymore
+        //
+        // - There may be domain runtime upgrade in `0..domain_best_number` which will result
+        //    in inconsistent `raw_genesis`
+        if !is_domain_started && !domain_best_number.is_zero() {
+            return Err(
+                "Unable to restart the existing consensus node as a domain node"
+                    .to_string()
+                    .into(),
+            );
+        }
+
         return Ok(BootstrapResult {
             domain_instance_data,
             domain_created_at,
             imported_block_notification_stream,
         });
+    }
+
+    // The domain instance data is not found in the consensus chain while the domain chain
+    // is already started meaning the domain chain is running ahead of the consensus chain,
+    // which is unexpected as the domain chain is derived from the consensus chain.
+    if is_domain_started {
+        return Err(
+            "The domain chain is ahead of the consensus chain, possibly uncleaned `domains`
+            folder from the last run"
+                .to_string()
+                .into(),
+        );
     }
 
     // Check each imported consensus block to get the domain instance data

--- a/domains/client/domain-operator/src/tests.rs
+++ b/domains/client/domain-operator/src/tests.rs
@@ -8208,7 +8208,7 @@ async fn test_domain_node_starting_check() {
     .build_evm_node(Role::Authority, Alice, &mut ferdie)
     .await;
 
-    // Produce 5 consensus block with bundle
+    // Produce 5 consensus block without bundle
     for _ in 0..5 {
         ferdie.produce_block_with_extrinsics(vec![]).await.unwrap();
     }

--- a/domains/client/domain-operator/src/tests.rs
+++ b/domains/client/domain-operator/src/tests.rs
@@ -6182,7 +6182,8 @@ async fn test_restart_domain_operator() {
             .path()
             .join(format!("alice/domain-{EVM_DOMAIN_ID:?}"))
             .as_path()
-            .join("paritydb/lock"),
+            .join("paritydb")
+            .join("lock"),
     )
     .unwrap();
 

--- a/domains/client/domain-operator/src/tests.rs
+++ b/domains/client/domain-operator/src/tests.rs
@@ -8250,7 +8250,7 @@ async fn test_domain_node_starting_check() {
     assert_eq!(bob.client.info().best_number, 6);
 
     // Start another domain node with the same consensus node shoule be failed now
-    // because there are already domain block produced, the domain node has to start
+    // because there domain blocks are already produced, the domain node has to start
     // with a fresh consensus node
     let result = async move {
         std::panic::AssertUnwindSafe(

--- a/domains/client/domain-operator/src/tests.rs
+++ b/domains/client/domain-operator/src/tests.rs
@@ -6142,10 +6142,6 @@ async fn test_unordered_cross_domains_message_should_work() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-// TODO: https://github.com/autonomys/subspace/pull/1954 broke this on Windows, we suspect the test
-//  is racy, but didn't find why and why it only fails on Windows. This needs to be fixed and test
-//  un-ignored on Windows.
-#[cfg_attr(windows, ignore)]
 async fn test_restart_domain_operator() {
     let directory = TempDir::new().expect("Must be able to create temporary directory");
 
@@ -6174,18 +6170,8 @@ async fn test_restart_domain_operator() {
     let next_slot = ferdie.next_slot();
 
     // Stop Ferdie and Alice and delete their database lock files
-    drop(ferdie);
-    drop(alice);
-    std::fs::remove_file(directory.path().join("ferdie/paritydb/lock")).unwrap();
-    std::fs::remove_file(
-        directory
-            .path()
-            .join(format!("alice/domain-{EVM_DOMAIN_ID:?}"))
-            .as_path()
-            .join("paritydb")
-            .join("lock"),
-    )
-    .unwrap();
+    ferdie.stop().unwrap();
+    alice.stop().unwrap();
 
     // Restart Ferdie
     let mut ferdie = MockConsensusNode::run(

--- a/domains/test/service/src/chain_spec.rs
+++ b/domains/test/service/src/chain_spec.rs
@@ -1,20 +1,16 @@
 //! Chain specification for the domain test runtime.
 
-use sc_service::{ChainSpec, ChainType, GenericChainSpec};
-use sp_domains::storage::RawGenesis;
+use sc_service::{ChainType, GenericChainSpec};
 
 /// Create chain spec
-pub fn create_domain_spec(raw_genesis: RawGenesis) -> GenericChainSpec {
-    let mut chain_spec = GenericChainSpec::builder(
-        evm_domain_test_runtime::WASM_BINARY.expect("WASM binary was not build, please build it!"),
+pub fn create_domain_spec() -> GenericChainSpec {
+    GenericChainSpec::builder(
+        // Code doesn't matter, it will be replaced before running just like genesis storage
+        &[],
         None,
     )
     .with_name("Local Testnet")
     .with_id("local_testnet")
     .with_chain_type(ChainType::Local)
-    .build();
-
-    chain_spec.set_storage(raw_genesis.into_storage());
-
-    chain_spec
+    .build()
 }

--- a/domains/test/service/src/domain.rs
+++ b/domains/test/service/src/domain.rs
@@ -145,7 +145,6 @@ where
         role: Role,
         mock_consensus_node: &mut MockConsensusNode,
     ) -> Self {
-        let base_path = BasePath::new(base_path.path().join(format!("domain-{domain_id:?}")));
         let mut domain_config = node_config(
             domain_id,
             tokio_handle.clone(),
@@ -580,7 +579,11 @@ impl DomainNodeBuilder {
             EVM_DOMAIN_ID,
             self.tokio_handle,
             key,
-            self.base_path,
+            BasePath::new(
+                self.base_path
+                    .path()
+                    .join(format!("domain-{EVM_DOMAIN_ID:?}")),
+            ),
             self.domain_nodes,
             self.domain_nodes_exclusive,
             self.skip_empty_bundle_production,
@@ -600,6 +603,33 @@ impl DomainNodeBuilder {
     ) -> AutoIdDomainNode {
         DomainNode::build(
             AUTO_ID_DOMAIN_ID,
+            self.tokio_handle,
+            key,
+            BasePath::new(
+                self.base_path
+                    .path()
+                    .join(format!("domain-{AUTO_ID_DOMAIN_ID:?}")),
+            ),
+            self.domain_nodes,
+            self.domain_nodes_exclusive,
+            self.skip_empty_bundle_production,
+            self.maybe_operator_id,
+            role,
+            mock_consensus_node,
+        )
+        .await
+    }
+
+    /// Build an EVM domain node with the given domain id
+    pub async fn build_evm_node_with(
+        self,
+        role: Role,
+        key: EcdsaKeyring,
+        mock_consensus_node: &mut MockConsensusNode,
+        domain_id: DomainId,
+    ) -> EvmDomainNode {
+        DomainNode::build(
+            domain_id,
             self.tokio_handle,
             key,
             self.base_path,

--- a/domains/test/service/src/domain.rs
+++ b/domains/test/service/src/domain.rs
@@ -589,7 +589,7 @@ impl DomainNodeBuilder {
             BasePath::new(
                 self.base_path
                     .path()
-                    .join(format!("domain-{EVM_DOMAIN_ID:?}")),
+                    .join(format!("domain-{EVM_DOMAIN_ID}")),
             ),
             self.domain_nodes,
             self.domain_nodes_exclusive,
@@ -615,7 +615,7 @@ impl DomainNodeBuilder {
             BasePath::new(
                 self.base_path
                     .path()
-                    .join(format!("domain-{AUTO_ID_DOMAIN_ID:?}")),
+                    .join(format!("domain-{AUTO_ID_DOMAIN_ID}")),
             ),
             self.domain_nodes,
             self.domain_nodes_exclusive,

--- a/domains/test/service/src/domain.rs
+++ b/domains/test/service/src/domain.rs
@@ -164,9 +164,13 @@ where
             domain_created_at,
             imported_block_notification_stream,
             ..
-        } = fetch_domain_bootstrap_info::<Block, _, _>(&*mock_consensus_node.client, domain_id)
-            .await
-            .expect("Failed to get domain instance data");
+        } = fetch_domain_bootstrap_info::<Block, _, _, _>(
+            &*mock_consensus_node.client,
+            &*domain_backend,
+            domain_id,
+        )
+        .await
+        .expect("Failed to get domain instance data");
 
         domain_config
             .chain_spec

--- a/domains/test/service/src/domain.rs
+++ b/domains/test/service/src/domain.rs
@@ -475,7 +475,7 @@ where
     /// Take and stop the domain node and delete its database lock file
     pub fn stop(self) -> Result<(), std::io::Error> {
         // Remove the database lock file
-        std::fs::remove_file(self.base_path.path().join("paritydb/lock"))?;
+        std::fs::remove_file(self.base_path.path().join("paritydb").join("lock"))?;
         Ok(())
     }
 }


### PR DESCRIPTION
This PR is part of #3391 

This adds checks to the domain starting process to detect and exit early in case of some unexpected situations:
- Restarting an arbitrary consensus node as a domain node, where the consensus node has already synced to a block that is beyond the block that derives the first domain block
-  Restarting a domain node while the consensus chain `db` folder is cleaned up, the domain chain `domains` folder is not

This PR also comes with some minor refactoring and test.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
