### PR TITLE
Remove Domain upgrade delay and Schedule in the next consensus block

### DIFF
--- a/crates/pallet-domains/src/benchmarking.rs
+++ b/crates/pallet-domains/src/benchmarking.rs
@@ -524,7 +524,7 @@ mod benchmarks {
         _(RawOrigin::Root, runtime_id, genesis_storage.clone());
 
         let scheduled_at = frame_system::Pallet::<T>::current_block_number()
-            .checked_add(&T::DomainRuntimeUpgradeDelay::get())
+            .checked_add(&BlockNumberFor::<T>::from(1u32))
             .expect("must not overflow");
         let scheduled_upgrade = ScheduledRuntimeUpgrades::<T>::get(scheduled_at, runtime_id)
             .expect("scheduled upgrade must exist");

--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -312,10 +312,6 @@ mod pallet {
         #[pallet::constant]
         type ConfirmationDepthK: Get<BlockNumberFor<Self>>;
 
-        /// Delay before a domain runtime is upgraded.
-        #[pallet::constant]
-        type DomainRuntimeUpgradeDelay: Get<BlockNumberFor<Self>>;
-
         /// Currency type used by the domains for staking and other currency related stuff.
         type Currency: Inspect<Self::AccountId, Balance = Self::Balance>
             + Mutate<Self::AccountId>

--- a/crates/pallet-domains/src/tests.rs
+++ b/crates/pallet-domains/src/tests.rs
@@ -86,7 +86,6 @@ parameter_types! {
     pub const MaximumReceiptDrift: BlockNumber = 128;
     pub const InitialDomainTxRange: u64 = 3;
     pub const DomainTxRangeAdjustmentInterval: u64 = 100;
-    pub const DomainRuntimeUpgradeDelay: BlockNumber = 100;
     pub const MaxDomainBlockSize: u32 = 1024 * 1024;
     pub const MaxDomainBlockWeight: Weight = Weight::from_parts(1024 * 1024, 0);
     pub const DomainInstantiationDeposit: Balance = 100;
@@ -249,7 +248,6 @@ impl pallet_domains::Config for Test {
     type Balance = Balance;
     type DomainHeader = DomainHeader;
     type ConfirmationDepthK = ConfirmationDepthK;
-    type DomainRuntimeUpgradeDelay = DomainRuntimeUpgradeDelay;
     type Currency = Balances;
     type Share = Balance;
     type HoldIdentifier = HoldIdentifierWrapper;

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -813,8 +813,6 @@ parameter_types! {
     pub const MaximumReceiptDrift: BlockNumber = 128;
     pub const InitialDomainTxRange: u64 = INITIAL_DOMAIN_TX_RANGE;
     pub const DomainTxRangeAdjustmentInterval: u64 = TX_RANGE_ADJUSTMENT_INTERVAL_BLOCKS;
-    /// Runtime upgrade is delayed for 1 day at 6 sec block time.
-    pub const DomainRuntimeUpgradeDelay: BlockNumber = 14_400;
     /// Minimum operator stake to become an operator.
     // TODO: this value should be properly updated before mainnet
     pub const MinOperatorStake: Balance = 100 * SSC;
@@ -902,7 +900,6 @@ impl pallet_domains::Config for Runtime {
     type Balance = Balance;
     type DomainHeader = sp_runtime::generic::Header<DomainNumber, BlakeTwo256>;
     type ConfirmationDepthK = ConfirmationDepthK;
-    type DomainRuntimeUpgradeDelay = DomainRuntimeUpgradeDelay;
     type Currency = Balances;
     type Share = Balance;
     type HoldIdentifier = HoldIdentifierWrapper;

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -771,7 +771,6 @@ parameter_types! {
     pub const MaximumReceiptDrift: BlockNumber = 2;
     pub const InitialDomainTxRange: u64 = INITIAL_DOMAIN_TX_RANGE;
     pub const DomainTxRangeAdjustmentInterval: u64 = 100;
-    pub const DomainRuntimeUpgradeDelay: BlockNumber = 10;
     pub const MinOperatorStake: Balance = 100 * SSC;
     pub const MinNominatorStake: Balance = SSC;
     /// Use the consensus chain's `Normal` extrinsics block size limit as the domain block size limit
@@ -850,7 +849,6 @@ impl pallet_domains::Config for Runtime {
     type Balance = Balance;
     type DomainHeader = DomainHeader;
     type ConfirmationDepthK = ConfirmationDepthK;
-    type DomainRuntimeUpgradeDelay = DomainRuntimeUpgradeDelay;
     type Currency = Balances;
     type Share = Balance;
     type HoldIdentifier = HoldIdentifierWrapper;


### PR DESCRIPTION
Currently the default delay is 14_400 which is quiet high. We initially had this delay to ensure client have time to upgrade their nodes if the new runtime break the existing client.
While we may still have such a scenario, not all upgrades require such a delay. 

For such specific cases, like we always do, do a client release and after enough time do a runtime upgrade.
This is inline with how consensus runtime upgrades are done.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
