### PR TITLE
Fix default pruning params for domains

### DIFF
--- a/domains/runtime/auto-id/build.rs
+++ b/domains/runtime/auto-id/build.rs
@@ -1,6 +1,7 @@
 fn main() {
     #[cfg(feature = "std")]
     {
+        std::env::set_var("WASM_BUILD_TYPE", "release");
         substrate_wasm_builder::WasmBuilder::new()
             .with_current_project()
             .export_heap_base()

--- a/domains/runtime/evm/build.rs
+++ b/domains/runtime/evm/build.rs
@@ -1,6 +1,7 @@
 fn main() {
     #[cfg(feature = "std")]
     {
+        std::env::set_var("WASM_BUILD_TYPE", "release");
         substrate_wasm_builder::WasmBuilder::new()
             .with_current_project()
             .export_heap_base()

--- a/domains/service/src/config.rs
+++ b/domains/service/src/config.rs
@@ -95,7 +95,7 @@ pub struct SubstrateConfiguration {
     /// Keystore configuration
     pub keystore: KeystoreConfig,
     /// State pruning settings
-    pub state_pruning: Option<PruningMode>,
+    pub state_pruning: PruningMode,
     /// Number of blocks to keep in the db.
     ///
     /// NOTE: only finalized blocks are subject for removal!
@@ -209,7 +209,7 @@ impl From<SubstrateConfiguration> for Configuration {
             },
             data_path: configuration.base_path.clone(),
             trie_cache_maximum_size: configuration.trie_cache_size,
-            state_pruning: configuration.state_pruning,
+            state_pruning: Some(configuration.state_pruning),
             blocks_pruning: configuration.blocks_pruning,
             executor: configuration.executor,
             wasm_runtime_overrides: None,


### PR DESCRIPTION
I have missed setting default pruning params for Domains through CLI as the state pruning and block pruning defaulted to Archive-canonical and 256 blocks respectively.

I have updated them to default cli values and if the user explicitly overrides them, then we double check the minimum pruning params

Also suppressed the warning while ensuring the pruning params on consensus chain when running as domain since consensus has default lower pruning params and leads to unnecessary warning.

Also ensured domain runtimes are built as release even when building in debug profile as domains runtime size wont fit into genesis on consensus

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
