### PR TITLE
Re-use the last piece for the next object in a batch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13358,7 +13358,6 @@ dependencies = [
  "subspace-core-primitives",
  "subspace-erasure-coding",
  "subspace-logging",
- "subspace-runtime-primitives",
  "thiserror 2.0.12",
  "tokio",
  "tracing",

--- a/crates/subspace-core-primitives/src/objects.rs
+++ b/crates/subspace-core-primitives/src/objects.rs
@@ -4,15 +4,12 @@
 //! * for objects within a block
 //! * for global objects in the global history of the blockchain (inside a piece)
 
-#[cfg(not(feature = "std"))]
-extern crate alloc;
-
 use crate::hashes::Blake3Hash;
 use crate::pieces::PieceIndex;
-#[cfg(not(feature = "std"))]
-use alloc::vec::Vec;
 use core::default::Default;
 use parity_scale_codec::{Decode, Encode};
+use scale_info::prelude::vec;
+use scale_info::prelude::vec::Vec;
 use scale_info::TypeInfo;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -140,6 +137,14 @@ impl GlobalObjectMapping {
     pub fn from_objects(objects: impl IntoIterator<Item = GlobalObject>) -> Self {
         Self::V0 {
             objects: objects.into_iter().collect(),
+        }
+    }
+
+    /// Returns a newly created GlobalObjectMapping from a single object mapping
+    #[inline]
+    pub fn from_object(object: GlobalObject) -> Self {
+        Self::V0 {
+            objects: vec![object],
         }
     }
 

--- a/crates/subspace-gateway-rpc/README.md
+++ b/crates/subspace-gateway-rpc/README.md
@@ -4,6 +4,8 @@ RPC API for Subspace Gateway.
 
 ### Using the gateway RPCs
 
+#### Getting Object Mappings
+
 The gateway RPCs can fetch data using object mappings supplied by a node.
 
 Launch a node with `--create-object-mappings blockNumber --sync full`, and wait for mappings from
@@ -41,7 +43,9 @@ subspace_subscribeObjectMappings
 }
 ```
 
-Then use those mappings to get object data from the gateway RPCs:
+#### Using Object Mappings to get Objects
+
+Use those mappings to get object data from the gateway RPCs:
 ```sh
 $ websocat --jsonrpc ws://127.0.0.1:9955
 subspace_fetchObject {"mappings": {"v0": {"objects": [["0000000000000000000000000000000000000000000000000000000000000000", 0, 0]]}}}
@@ -53,6 +57,16 @@ subspace_fetchObject {"mappings": {"v0": {"objects": [["000000000000000000000000
   "result": ["00000000"]
 }
 ```
+
+For efficiency, objects in a batch should be sorted by increasing piece index. And objects with
+the same piece index should be sorted by increasing offset. This allows the last piece to be
+re-used for the next object in the batch.
+
+Batches should be split if the gap between object piece indexes is 6 or more. Those objects
+can't share any pieces, because a maximum-sized object only uses 6 pieces. (Batches should also
+be split so that the response stays within the RPC response size limit.)
+
+### Advanced Usage
 
 #### Missed Mappings
 

--- a/crates/subspace-gateway-rpc/src/lib.rs
+++ b/crates/subspace-gateway-rpc/src/lib.rs
@@ -83,8 +83,15 @@ impl DerefMut for HexData {
 /// Provides rpc methods for interacting with a Subspace DSN Gateway.
 #[rpc(client, server)]
 pub trait SubspaceGatewayRpcApi {
-    /// Get object data from DSN object mappings.
+    /// Get object data from a DSN object mapping batch.
     /// Returns an error if any object fetch was unsuccessful.
+    ///
+    /// For efficiency, objects in a batch should be sorted by increasing piece index. Objects with
+    /// the same piece index should be sorted by increasing offset. This allows the last piece to
+    /// be re-used for the next object in the batch.
+    ///
+    /// Batches should be split if the gap between object piece indexes is 6 or more. Those objects
+    /// can't share any pieces, because a maximum-sized object only uses 6 pieces.
     #[method(name = "subspace_fetchObject")]
     async fn fetch_object(&self, mappings: GlobalObjectMapping) -> Result<Vec<HexData>, Error>;
 }

--- a/crates/subspace-gateway/src/commands/http/server.rs
+++ b/crates/subspace-gateway/src/commands/http/server.rs
@@ -109,7 +109,11 @@ where
         }
     };
 
-    // TODO: return a multi-part response, with one part per object
+    // TODO:
+    // - return a multi-part response, with one part per object.
+    // - add the object hash to each part, so we can sort mappings by piece index and offset,
+    //   for more efficient piece re-use. See the `ObjectFetcher::fetch_objects` performance docs
+    //   for more details.
     HttpResponse::Ok()
         .content_type("application/octet-stream")
         .body(objects.concat())

--- a/crates/subspace-service/Cargo.toml
+++ b/crates/subspace-service/Cargo.toml
@@ -102,6 +102,9 @@ sp-session.workspace = true
 frame-system-rpc-runtime-api.workspace = true
 pallet-transaction-payment-rpc-runtime-api.workspace = true
 
+[dev-dependencies]
+static_assertions.workspace = true
+
 [features]
 runtime-benchmarks = [
     "dep:frame-benchmarking",

--- a/crates/subspace-service/src/lib.rs
+++ b/crates/subspace-service/src/lib.rs
@@ -1380,3 +1380,20 @@ fn extract_confirmation_depth(chain_spec: &dyn ChainSpec) -> Option<u32> {
     .ok()?;
     u32::decode(&mut encoded_confirmation_depth.as_slice()).ok()
 }
+
+#[cfg(test)]
+mod test {
+    use static_assertions::const_assert_eq;
+    use subspace_data_retrieval::object_fetcher::MAX_BLOCK_LENGTH as ARCHIVER_MAX_BLOCK_LENGTH;
+    use subspace_runtime_primitives::MAX_BLOCK_LENGTH as CONSENSUS_RUNTIME_MAX_BLOCK_LENGTH;
+
+    /// Runtime and archiver code must agree on the consensus block length.
+    /// (This avoids importing all the runtime primitives code into the farmer and gateway.)
+    #[test]
+    fn max_block_length_consistent() {
+        const_assert_eq!(
+            CONSENSUS_RUNTIME_MAX_BLOCK_LENGTH,
+            ARCHIVER_MAX_BLOCK_LENGTH,
+        );
+    }
+}

--- a/shared/subspace-data-retrieval/Cargo.toml
+++ b/shared/subspace-data-retrieval/Cargo.toml
@@ -20,13 +20,13 @@ parity-scale-codec = { workspace = true, features = ["derive"] }
 subspace-archiving.workspace = true
 subspace-core-primitives = { workspace = true, features = ["std"] }
 subspace-erasure-coding.workspace = true
-subspace-runtime-primitives = { workspace = true, features = ["std"] }
+# This crate can't depend on any runtime code, because it needs to be independent of Substrate.
 thiserror.workspace = true
 tokio = { workspace = true, features = ["sync", "rt"] }
 tracing = { workspace = true, features = ["std"] }
 
 [dev-dependencies]
-rand.workspace = true
+rand = { workspace = true, features = ["std", "std_rng"] }
 subspace-logging.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 

--- a/shared/subspace-data-retrieval/src/object_fetcher.rs
+++ b/shared/subspace-data-retrieval/src/object_fetcher.rs
@@ -20,6 +20,8 @@ mod segment_header;
 #[cfg(test)]
 mod tests;
 
+pub use segment_header::MAX_BLOCK_LENGTH;
+
 /// The maximum object length the implementation in this module can reliably handle.
 ///
 /// Currently objects are limited by the largest block size in the consensus chain, which is 5 MB.

--- a/shared/subspace-data-retrieval/src/object_fetcher/segment_header.rs
+++ b/shared/subspace-data-retrieval/src/object_fetcher/segment_header.rs
@@ -12,7 +12,6 @@ use subspace_core_primitives::objects::GlobalObject;
 use subspace_core_primitives::segments::{
     ArchivedBlockProgress, LastArchivedBlock, SegmentCommitment, SegmentHeader, SegmentIndex,
 };
-use subspace_runtime_primitives::MAX_BLOCK_LENGTH;
 
 /// The maximum amount of segment padding.
 ///
@@ -21,6 +20,10 @@ use subspace_runtime_primitives::MAX_BLOCK_LENGTH;
 /// 63 or less, and the maximum block size is in the range 2^14 to 2^30 - 1.
 /// <https://docs.substrate.io/reference/scale-codec/#fn-1>
 pub const MAX_SEGMENT_PADDING: usize = 3;
+
+/// Maximum block length for non-`Normal` extrinsic is 5 MiB.
+/// This is a copy of the constant in `subspace_runtime_primitives`.
+pub const MAX_BLOCK_LENGTH: u32 = 5 * 1024 * 1024;
 
 /// The segment version this code knows how to parse.
 const SEGMENT_VERSION_VARIANT: u8 = 0;
@@ -156,7 +159,6 @@ mod test {
     use parity_scale_codec::{Compact, CompactLen};
     use subspace_archiving::archiver::Segment;
     use subspace_core_primitives::objects::BlockObjectMapping;
-    use subspace_runtime_primitives::MAX_BLOCK_LENGTH;
 
     #[test]
     fn max_segment_padding_constant() {

--- a/shared/subspace-data-retrieval/src/object_fetcher/tests.rs
+++ b/shared/subspace-data-retrieval/src/object_fetcher/tests.rs
@@ -2,8 +2,13 @@
 
 use super::*;
 use crate::object_fetcher::partial_object::PADDING_BYTE_VALUE;
+use crate::piece_getter::get_pieces_individually;
+use async_trait::async_trait;
+use futures::lock::Mutex;
+use futures::Stream;
 use parity_scale_codec::{Compact, CompactLen, Encode};
 use rand::{thread_rng, RngCore};
+use std::collections::HashMap;
 use std::fmt::Debug;
 use std::iter;
 use subspace_core_primitives::hashes::blake3_hash;
@@ -12,6 +17,57 @@ use subspace_core_primitives::segments::{
     SegmentHeader,
 };
 use subspace_logging::init_logger;
+
+/// A piece getter that panics if called - used to make sure that caches work
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+struct PanicPieceGetter;
+
+#[async_trait]
+impl PieceGetter for PanicPieceGetter {
+    async fn get_piece(&self, piece_index: PieceIndex) -> anyhow::Result<Option<Piece>> {
+        unreachable!("the cache failed to answer the request for piece: {piece_index:?}")
+    }
+
+    async fn get_pieces<'a>(
+        &'a self,
+        piece_indices: Vec<PieceIndex>,
+    ) -> anyhow::Result<
+        Box<dyn Stream<Item = (PieceIndex, anyhow::Result<Option<Piece>>)> + Send + Unpin + 'a>,
+    > {
+        unreachable!("the cache failed to answer the request for pieces: {piece_indices:?}")
+    }
+}
+
+/// A piece getter that counts how often each piece is requested.
+/// Doesn't actually return any pieces.
+#[derive(Clone, Debug, Default)]
+struct CountingPieceGetter(Arc<Mutex<HashMap<PieceIndex, usize>>>);
+
+impl CountingPieceGetter {
+    /// Returns the number of times each piece index has been requested.
+    async fn piece_index_counts(&self) -> HashMap<PieceIndex, usize> {
+        self.0.lock().await.clone()
+    }
+}
+
+#[async_trait]
+impl PieceGetter for CountingPieceGetter {
+    async fn get_piece(&self, piece_index: PieceIndex) -> anyhow::Result<Option<Piece>> {
+        *self.0.lock().await.entry(piece_index).or_default() += 1;
+
+        Ok(None)
+    }
+
+    async fn get_pieces<'a>(
+        &'a self,
+        piece_indices: Vec<PieceIndex>,
+    ) -> anyhow::Result<
+        Box<dyn Stream<Item = (PieceIndex, anyhow::Result<Option<Piece>>)> + Send + Unpin + 'a>,
+    > {
+        // This could be implemented more efficiently, but it's only used in tests
+        get_pieces_individually(|piece_index| self.get_piece(piece_index), piece_indices)
+    }
+}
 
 /// Converts the supplied number to a `PieceIndex`.
 fn idx<N>(piece_index: N) -> PieceIndex
@@ -353,12 +409,20 @@ fn byte_position_in_extract_raw_data(
 fn create_object_fetcher(
     pieces: Vec<Piece>,
     start_piece_index: usize,
-) -> ObjectFetcher<Vec<(PieceIndex, Piece)>> {
+    first_piece_getter: Option<Box<dyn PieceGetter + Send + Sync>>,
+    last_piece_getter: Option<Box<dyn PieceGetter + Send + Sync>>,
+) -> ObjectFetcher<impl PieceGetter> {
     let piece_getter = pieces
         .into_iter()
         .enumerate()
         .map(|(i, piece)| (idx(start_piece_index + (i * 2)), piece))
-        .collect();
+        .collect::<Vec<(PieceIndex, Piece)>>();
+
+    // Add the supplied first and last piece getters
+    let piece_getter = first_piece_getter
+        .with_fallback(piece_getter)
+        .with_fallback(last_piece_getter);
+
     ObjectFetcher::new(Arc::new(piece_getter), max_supported_object_length())
 }
 
@@ -389,7 +453,7 @@ async fn get_single_piece_object_no_padding() {
     write_object_length(vec![&mut piece], offset, object_len, None);
     let (mapping, object_data) =
         create_mapping(vec![&piece], piece_index, offset, object_len, None, None);
-    let object_fetcher = create_object_fetcher(vec![piece.clone()], piece_index);
+    let object_fetcher = create_object_fetcher(vec![piece.clone()], piece_index, None, None);
 
     // Now get the object back
     let mut cache = None;
@@ -407,7 +471,7 @@ async fn get_single_piece_object_no_padding() {
     write_object_length(vec![&mut piece], offset, object_len, None);
     let (mapping, object_data) =
         create_mapping(vec![&piece], piece_index, offset, object_len, None, None);
-    let object_fetcher = create_object_fetcher(vec![piece.clone()], piece_index);
+    let object_fetcher = create_object_fetcher(vec![piece.clone()], piece_index, None, None);
 
     let mut cache = None;
     let fetched_data = object_fetcher.fetch_object(mapping, &mut cache).await;
@@ -424,7 +488,7 @@ async fn get_single_piece_object_no_padding() {
     write_object_length(vec![&mut piece], offset, object_len, None);
     let (mapping, object_data) =
         create_mapping(vec![&piece], piece_index, offset, object_len, None, None);
-    let object_fetcher = create_object_fetcher(vec![piece.clone()], piece_index);
+    let object_fetcher = create_object_fetcher(vec![piece.clone()], piece_index, None, None);
 
     let mut cache = None;
     let fetched_data = object_fetcher.fetch_object(mapping, &mut cache).await;
@@ -450,7 +514,7 @@ async fn get_single_piece_object_potential_padding() {
     write_object_length(vec![&mut piece], offset, object_len, None);
     let (mapping, object_data) =
         create_mapping(vec![&piece], piece_index, offset, object_len, None, None);
-    let object_fetcher = create_object_fetcher(vec![piece.clone()], piece_index);
+    let object_fetcher = create_object_fetcher(vec![piece.clone()], piece_index, None, None);
 
     let mut cache = None;
     let fetched_data = object_fetcher.fetch_object(mapping, &mut cache).await;
@@ -469,7 +533,7 @@ async fn get_single_piece_object_potential_padding() {
     write_object_length(vec![&mut piece], offset, object_len, None);
     let (mapping, object_data) =
         create_mapping(vec![&piece], piece_index, offset, object_len, None, None);
-    let object_fetcher = create_object_fetcher(vec![piece.clone()], piece_index);
+    let object_fetcher = create_object_fetcher(vec![piece.clone()], piece_index, None, None);
 
     let mut cache = None;
     let fetched_data = object_fetcher.fetch_object(mapping, &mut cache).await;
@@ -489,7 +553,7 @@ async fn get_single_piece_object_potential_padding() {
     write_object_length(vec![&mut piece], offset, object_len, None);
     let (mapping, object_data) =
         create_mapping(vec![&piece], piece_index, offset, object_len, None, None);
-    let object_fetcher = create_object_fetcher(vec![piece.clone()], piece_index);
+    let object_fetcher = create_object_fetcher(vec![piece.clone()], piece_index, None, None);
 
     let mut cache = None;
     let fetched_data = object_fetcher.fetch_object(mapping, &mut cache).await;
@@ -508,7 +572,7 @@ async fn get_single_piece_object_potential_padding() {
     write_object_length(vec![&mut piece], offset, object_len, None);
     let (mapping, object_data) =
         create_mapping(vec![&piece], piece_index, offset, object_len, None, None);
-    let object_fetcher = create_object_fetcher(vec![piece.clone()], piece_index);
+    let object_fetcher = create_object_fetcher(vec![piece.clone()], piece_index, None, None);
 
     let mut cache = None;
     let fetched_data = object_fetcher.fetch_object(mapping, &mut cache).await;
@@ -527,7 +591,7 @@ async fn get_single_piece_object_potential_padding() {
     write_object_length(vec![&mut piece], offset, object_len, None);
     let (mapping, object_data) =
         create_mapping(vec![&piece], piece_index, offset, object_len, None, None);
-    let object_fetcher = create_object_fetcher(vec![piece.clone()], piece_index);
+    let object_fetcher = create_object_fetcher(vec![piece.clone()], piece_index, None, None);
 
     let mut cache = None;
     let fetched_data = object_fetcher.fetch_object(mapping, &mut cache).await;
@@ -563,7 +627,8 @@ async fn get_multi_piece_object_length_outside_padding() {
         None,
         Some(after_segment_header),
     );
-    let object_fetcher = create_object_fetcher(vec![piece1, piece2.clone()], start_piece_index);
+    let object_fetcher =
+        create_object_fetcher(vec![piece1, piece2.clone()], start_piece_index, None, None);
 
     let mut cache = None;
     let fetched_data = object_fetcher.fetch_object(mapping, &mut cache).await;
@@ -590,7 +655,8 @@ async fn get_multi_piece_object_length_outside_padding() {
         None,
         Some(after_segment_header),
     );
-    let object_fetcher = create_object_fetcher(vec![piece1, piece2.clone()], start_piece_index);
+    let object_fetcher =
+        create_object_fetcher(vec![piece1, piece2.clone()], start_piece_index, None, None);
 
     let mut cache = None;
     let fetched_data = object_fetcher.fetch_object(mapping, &mut cache).await;
@@ -618,7 +684,8 @@ async fn get_multi_piece_object_length_outside_padding() {
         Some(skip_padding),
         Some(after_segment_header),
     );
-    let object_fetcher = create_object_fetcher(vec![piece1, piece2.clone()], start_piece_index);
+    let object_fetcher =
+        create_object_fetcher(vec![piece1, piece2.clone()], start_piece_index, None, None);
 
     let mut cache = None;
     let fetched_data = object_fetcher.fetch_object(mapping, &mut cache).await;
@@ -651,6 +718,8 @@ async fn get_multi_piece_object_length_outside_padding() {
     let object_fetcher = create_object_fetcher(
         vec![piece1, piece2, piece3, piece4.clone()],
         start_piece_index,
+        None,
+        None,
     );
 
     let mut cache = None;
@@ -689,6 +758,8 @@ async fn get_multi_piece_object_length_outside_padding() {
     let object_fetcher = create_object_fetcher(
         vec![piece1, piece2, piece3, piece4.clone()],
         start_piece_index,
+        None,
+        None,
     );
 
     let mut cache = None;
@@ -732,6 +803,8 @@ async fn get_multi_piece_object_length_outside_padding() {
     let object_fetcher = create_object_fetcher(
         vec![piece1, piece2, piece3, piece4, piece5, piece6.clone()],
         start_piece_index,
+        None,
+        None,
     );
 
     let mut cache = None;
@@ -781,7 +854,8 @@ async fn get_multi_piece_object_length_overlaps_padding() {
         None,
         Some(after_segment_header),
     );
-    let object_fetcher = create_object_fetcher(vec![piece1, piece2.clone()], start_piece_index);
+    let object_fetcher =
+        create_object_fetcher(vec![piece1, piece2.clone()], start_piece_index, None, None);
 
     let mut cache = None;
     let fetched_data = object_fetcher.fetch_object(mapping, &mut cache).await;
@@ -818,7 +892,8 @@ async fn get_multi_piece_object_length_overlaps_padding() {
         None,
         Some(after_segment_header),
     );
-    let object_fetcher = create_object_fetcher(vec![piece1, piece2.clone()], start_piece_index);
+    let object_fetcher =
+        create_object_fetcher(vec![piece1, piece2.clone()], start_piece_index, None, None);
 
     let mut cache = None;
     let fetched_data = object_fetcher.fetch_object(mapping, &mut cache).await;
@@ -863,10 +938,192 @@ async fn get_multi_piece_object_length_overlaps_padding() {
         Some(skip_padding),
         Some(after_segment_header),
     );
-    let object_fetcher = create_object_fetcher(vec![piece1, piece2.clone()], start_piece_index);
+    let object_fetcher =
+        create_object_fetcher(vec![piece1, piece2.clone()], start_piece_index, None, None);
 
     let mut cache = None;
     let fetched_data = object_fetcher.fetch_object(mapping, &mut cache).await;
     assert_eq!(cache, Some((idx(start_piece_index + 2), piece2)));
     assert_eq!(fetched_data.map(hex::encode), Ok(hex::encode(object_data)));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn last_piece_cache_works() {
+    init_logger();
+
+    // We need to cover 4 known good cases:
+    // (empty caches are tested by the tests above)
+
+    // - single mapping, cache already has the piece (middle of segment)
+    let offset = 0;
+    let object_len = 1000;
+    let piece_index = 60;
+
+    let mut piece = random_piece();
+
+    write_object_length(vec![&mut piece], offset, object_len, None);
+    let (mapping, object_data) =
+        create_mapping(vec![&piece], piece_index, offset, object_len, None, None);
+    // Passing a PanicPieceGetter as the first piece getter makes sure the last piece cache is used before the ObjectFetcher's piece getters
+    let object_fetcher = create_object_fetcher(
+        vec![piece.clone()],
+        piece_index,
+        Some(Box::new(PanicPieceGetter)),
+        Some(Box::new(PanicPieceGetter)),
+    );
+
+    let mut cache = Some((idx(piece_index), piece.clone()));
+    let fetched_data = object_fetcher.fetch_object(mapping, &mut cache).await;
+    assert_eq!(cache, Some((idx(piece_index), piece)));
+    assert_eq!(fetched_data.map(hex::encode), Ok(hex::encode(object_data)));
+
+    // - single mapping in a batch, internal cache not used (end of segment)
+    let offset = 0;
+    let object_len = 10_000;
+    let piece_index = ArchivedHistorySegment::NUM_PIECES - 2;
+
+    let mut piece = random_piece();
+
+    write_object_length(vec![&mut piece], offset, object_len, None);
+    let (mapping, object_data) =
+        create_mapping(vec![&piece], piece_index, offset, object_len, None, None);
+    // Passing a PanicPieceGetter as the last piece getter makes sure the ObjectFetcher's piece getters are used
+    let object_fetcher = create_object_fetcher(
+        vec![piece],
+        piece_index,
+        None,
+        Some(Box::new(PanicPieceGetter)),
+    );
+
+    let fetched_data = object_fetcher
+        .fetch_objects(GlobalObjectMapping::from_object(mapping))
+        .await
+        .unwrap();
+    assert_eq!(
+        fetched_data
+            .iter()
+            .map(hex::encode)
+            .collect::<Vec<String>>(),
+        vec![hex::encode(object_data)],
+    );
+
+    // - multiple mappings in a batch, single piece requested once (end of segment)
+    let offset = 0;
+    let object_len = 10;
+    let piece_index = ArchivedHistorySegment::NUM_PIECES - 2;
+
+    let mut piece = random_piece();
+
+    write_object_length(vec![&mut piece], offset, object_len, None);
+    let (mapping1, object_data1) =
+        create_mapping(vec![&piece], piece_index, offset, object_len, None, None);
+
+    let offset = object_len + compact_encoded(object_len).len();
+    let object_len = 20;
+
+    write_object_length(vec![&mut piece], offset, object_len, None);
+    let (mapping2, object_data2) =
+        create_mapping(vec![&piece], piece_index, offset, object_len, None, None);
+
+    // Passing a CountingPieceGetter as the first piece getter counts each request, except for
+    // requests handled by ObjectFetcher::fetch_objects() internal last piece cache.
+    let counter = CountingPieceGetter::default();
+    let object_fetcher = create_object_fetcher(
+        vec![piece],
+        piece_index,
+        Some(Box::new(counter.clone())),
+        Some(Box::new(PanicPieceGetter)),
+    );
+
+    let fetched_data = object_fetcher
+        .fetch_objects(GlobalObjectMapping::from_objects(vec![mapping1, mapping2]))
+        .await
+        .unwrap();
+    assert_eq!(
+        fetched_data
+            .iter()
+            .map(hex::encode)
+            .collect::<Vec<String>>(),
+        vec![hex::encode(object_data1), hex::encode(object_data2)],
+    );
+    assert_eq!(
+        counter.piece_index_counts().await,
+        [(idx(piece_index), 1)].into(),
+    );
+
+    // - multiple mappings in a batch, multiple pieces requested once each (middle of segment)
+    let offset = 0;
+    let object_len = 10;
+    let start_piece_index = ArchivedHistorySegment::NUM_PIECES / 2;
+
+    let mut piece1 = random_piece();
+    let mut piece2 = random_piece();
+
+    write_object_length(vec![&mut piece1], offset, object_len, None);
+    let (mapping1, object_data1) = create_mapping(
+        vec![&piece1],
+        start_piece_index,
+        offset,
+        object_len,
+        None,
+        None,
+    );
+
+    let object_len = 20;
+    let offset = RawRecord::SIZE - object_len / 2;
+
+    write_object_length(vec![&mut piece1], offset, object_len, None);
+    let (mapping2, object_data2) = create_mapping(
+        vec![&piece1, &piece2],
+        start_piece_index,
+        offset,
+        object_len,
+        None,
+        None,
+    );
+
+    let object_len = 50;
+    let offset = RawRecord::SIZE / 2;
+
+    write_object_length(vec![&mut piece2], offset, object_len, None);
+    let (mapping3, object_data3) = create_mapping(
+        vec![&piece2],
+        start_piece_index + 2,
+        offset,
+        object_len,
+        None,
+        None,
+    );
+
+    // Passing a CountingPieceGetter as the first piece getter counts each request, except for
+    // requests handled by ObjectFetcher::fetch_objects() internal last piece cache.
+    let counter = CountingPieceGetter::default();
+    let object_fetcher = create_object_fetcher(
+        vec![piece1, piece2],
+        start_piece_index,
+        Some(Box::new(counter.clone())),
+        Some(Box::new(PanicPieceGetter)),
+    );
+
+    let fetched_data = object_fetcher
+        .fetch_objects(GlobalObjectMapping::from_objects(vec![
+            mapping1, mapping2, mapping3,
+        ]))
+        .await
+        .unwrap();
+    assert_eq!(
+        fetched_data
+            .iter()
+            .map(hex::encode)
+            .collect::<Vec<String>>(),
+        vec![
+            hex::encode(object_data1),
+            hex::encode(object_data2),
+            hex::encode(object_data3)
+        ],
+    );
+    assert_eq!(
+        counter.piece_index_counts().await,
+        [(idx(start_piece_index), 1), (idx(start_piece_index + 2), 1)].into(),
+    );
 }

--- a/shared/subspace-data-retrieval/src/object_fetcher/tests.rs
+++ b/shared/subspace-data-retrieval/src/object_fetcher/tests.rs
@@ -313,7 +313,7 @@ fn create_mapping(
 
     (
         GlobalObject {
-            piece_index: PieceIndex::from(start_piece_index as u64),
+            piece_index: idx(start_piece_index),
             offset: offset as u32,
             hash: blake3_hash(&object_data),
         },
@@ -357,12 +357,7 @@ fn create_object_fetcher(
     let piece_getter = pieces
         .into_iter()
         .enumerate()
-        .map(|(i, piece)| {
-            (
-                PieceIndex::from((start_piece_index + (i * 2)) as u64),
-                piece,
-            )
-        })
+        .map(|(i, piece)| (idx(start_piece_index + (i * 2)), piece))
         .collect();
     ObjectFetcher::new(Arc::new(piece_getter), max_supported_object_length())
 }

--- a/shared/subspace-data-retrieval/src/piece_getter.rs
+++ b/shared/subspace-data-retrieval/src/piece_getter.rs
@@ -135,6 +135,27 @@ where
 }
 
 #[async_trait]
+impl<T> PieceGetter for Box<T>
+where
+    T: PieceGetter + Send + Sync + ?Sized,
+{
+    #[inline]
+    async fn get_piece(&self, piece_index: PieceIndex) -> anyhow::Result<Option<Piece>> {
+        self.as_ref().get_piece(piece_index).await
+    }
+
+    #[inline]
+    async fn get_pieces<'a>(
+        &'a self,
+        piece_indices: Vec<PieceIndex>,
+    ) -> anyhow::Result<
+        Box<dyn Stream<Item = (PieceIndex, anyhow::Result<Option<Piece>>)> + Send + Unpin + 'a>,
+    > {
+        self.as_ref().get_pieces(piece_indices).await
+    }
+}
+
+#[async_trait]
 impl<T> PieceGetter for Option<T>
 where
     T: PieceGetter + Send + Sync,

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -119,7 +119,7 @@ use subspace_runtime_primitives::utility::{
 use subspace_runtime_primitives::{
     AccountId, Balance, BlockNumber, ConsensusEventSegmentSize, FindBlockRewardAddress, Hash,
     HoldIdentifier, Moment, Nonce, Signature, XdmAdjustedWeightToFee, XdmFeeMultipler,
-    MAX_CALL_RECURSION_DEPTH, MIN_REPLICATION_FACTOR, SHANNON, SSC,
+    MAX_BLOCK_LENGTH, MAX_CALL_RECURSION_DEPTH, MIN_REPLICATION_FACTOR, SHANNON, SSC,
 };
 use subspace_test_primitives::DOMAINS_BLOCK_PRUNING_DEPTH;
 
@@ -209,9 +209,6 @@ const NORMAL_DISPATCH_RATIO: Perbill = Perbill::from_percent(75);
 /// The block weight for 2 seconds of compute
 const BLOCK_WEIGHT_FOR_2_SEC: Weight =
     Weight::from_parts(WEIGHT_REF_TIME_PER_SECOND.saturating_mul(2), u64::MAX);
-
-/// Maximum block length for non-`Normal` extrinsic is 5 MiB.
-const MAX_BLOCK_LENGTH: u32 = 5 * 1024 * 1024;
 
 parameter_types! {
     pub const Version: RuntimeVersion = VERSION;


### PR DESCRIPTION
This PR improves object fetcher performance, by keeping the last piece used for each object, and re-using it for the next object in the batch.

It is the simplest possible cache, which fits the AutoDrive access pattern very well. AutoDrive splits files into 64kB chunks, so there can be many objects from the same file in the same piece.

This cache also performs well under load, because it has no locking, and is local to each batch.

We can add other more complicated caches later, if needed. But they will always have  network latency/memory tradeoffs, because we can't keep all recent pieces under heavy load.

#### Related Changes

This PR also removes a dependency from subspace-data-retrieval to Substrate, by duplicating a constant, and adding a static assertion in a crate which imports them both.


### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
