### PR TITLE
Fix pre_dispatch handling for xdm v1 message and enable v1 for test runtimes

### DIFF
--- a/domains/pallets/messenger/src/lib.rs
+++ b/domains/pallets/messenger/src/lib.rs
@@ -1145,7 +1145,7 @@ mod pallet {
             };
 
             if !is_valid_call {
-                log::error!("Unexpected call instead of channel open request: {:?}", msg,);
+                log::error!("Unexpected XDM message: {:?}", msg,);
                 return Err(InvalidTransaction::Call.into());
             }
 
@@ -1168,9 +1168,10 @@ mod pallet {
             should_init_channel: bool,
         ) -> Result<(), TransactionValidityError> {
             if should_init_channel {
-                if let VersionedPayload::V0(Payload::Protocol(RequestResponse::Request(
+                let ConvertedPayload { payload, is_v1: _ } = msg.payload.clone().into_payload_v0();
+                if let Payload::Protocol(RequestResponse::Request(
                     ProtocolMessageRequest::ChannelOpen(params),
-                ))) = msg.payload
+                )) = payload
                 {
                     // channel is being opened without an owner since this is a relay message
                     // from other chain

--- a/domains/test/runtime/auto-id/src/lib.rs
+++ b/domains/test/runtime/auto-id/src/lib.rs
@@ -411,7 +411,7 @@ parameter_types! {
     // TODO update the fee model
     pub const ChannelFeeModel: FeeModel<Balance> = FeeModel{relay_fee: SSC};
     pub const MaxOutgoingMessages: u32 = MAX_OUTGOING_MESSAGES;
-    pub const MessageVersion: pallet_messenger::MessageVersion = pallet_messenger::MessageVersion::V0;
+    pub const MessageVersion: pallet_messenger::MessageVersion = pallet_messenger::MessageVersion::V1;
 }
 
 // ensure the max outgoing messages is not 0.

--- a/domains/test/runtime/evm/src/lib.rs
+++ b/domains/test/runtime/evm/src/lib.rs
@@ -576,7 +576,7 @@ parameter_types! {
     pub const ChannelInitReservePortion: Perbill = Perbill::from_percent(20);
     pub const ChannelFeeModel: FeeModel<Balance> = FeeModel{relay_fee: SSC};
     pub const MaxOutgoingMessages: u32 = MAX_OUTGOING_MESSAGES;
-    pub const MessageVersion: pallet_messenger::MessageVersion = pallet_messenger::MessageVersion::V0;
+    pub const MessageVersion: pallet_messenger::MessageVersion = pallet_messenger::MessageVersion::V1;
 }
 
 // ensure the max outgoing messages is not 0.

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -680,7 +680,7 @@ parameter_types! {
     pub const ChannelInitReservePortion: Perbill = Perbill::from_percent(20);
     pub const ChannelFeeModel: FeeModel<Balance> = FeeModel{relay_fee: SSC};
     pub const MaxOutgoingMessages: u32 = MAX_OUTGOING_MESSAGES;
-    pub const MessageVersion: pallet_messenger::MessageVersion = pallet_messenger::MessageVersion::V0;
+    pub const MessageVersion: pallet_messenger::MessageVersion = pallet_messenger::MessageVersion::V1;
 }
 
 // ensure the max outgoing messages is not 0.


### PR DESCRIPTION
In the recent change to the nonce change in pre_dispatch of XDM, i have missed handling the V1 format. Handled that format in the PR and also enabled V1 format for test runtimes

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
