### PR TITLE
merge queue checks equal priority to main

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,7 +9,7 @@ on:
   merge_group:
 
 concurrency:
-  group: rust-${{ github.workflow }}-${{ github.ref }}
+  group: rust-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
In GitHub Actions, merge group checks are prioritized lower than checks on the main branch by default. To ensure they have equal priority, configure dynamic concurrency groups.

### Code contributor checklist:
* [X] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
