### PR TITLE
adjust domain type specific args format

### DIFF
--- a/crates/subspace-node/src/commands/run/domain.rs
+++ b/crates/subspace-node/src/commands/run/domain.rs
@@ -142,8 +142,8 @@ pub(super) struct DomainOptions {
     /// Domain type specific arguments.
     ///
     /// The command-line arguments provided first will be passed to the embedded consensus node,
-    /// while the arguments provided after `--` will be passed to domain node and
-    /// arguments provided after `--` will be passed to specific domain type configuration.
+    /// while the arguments provided after the first `--` will be passed to domain node and
+    /// arguments provided after the second `--` will be passed to specific domain type configuration.
     ///
     /// subspace-node [consensus-chain-args] -- [domain-args] -- [domain-type-args]
     #[clap(raw = true)]

--- a/crates/subspace-node/src/commands/run/domain.rs
+++ b/crates/subspace-node/src/commands/run/domain.rs
@@ -139,9 +139,15 @@ pub(super) struct DomainOptions {
     #[clap(flatten)]
     pub trie_cache_params: TrieCacheParams,
 
-    /// Additional args for domain.
+    /// Domain type specific arguments.
+    ///
+    /// The command-line arguments provided first will be passed to the embedded consensus node,
+    /// while the arguments provided after `--` will be passed to domain node and
+    /// arguments provided after `--` will be passed to specific domain type configuration.
+    ///
+    /// subspace-node [consensus-chain-args] -- [domain-args] -- [domain-type-args]
     #[clap(raw = true)]
-    additional_args: Vec<String>,
+    domain_type_args: Vec<String>,
 }
 
 /// Parameters to define the pruning mode
@@ -177,7 +183,7 @@ pub(super) struct DomainConfiguration {
     pub(super) domain_config: Configuration,
     pub(super) domain_id: DomainId,
     pub(super) operator_id: Option<OperatorId>,
-    pub(super) additional_args: Vec<String>,
+    pub(super) domain_type_args: Vec<String>,
 }
 
 pub(super) fn create_domain_configuration(
@@ -197,7 +203,7 @@ pub(super) fn create_domain_configuration(
         pool_config,
         runtime_params,
         trie_cache_params,
-        additional_args,
+        domain_type_args,
     } = domain_options;
 
     let domain_id;
@@ -423,7 +429,7 @@ pub(super) fn create_domain_configuration(
         domain_config: Configuration::from(domain_config),
         domain_id,
         operator_id,
-        additional_args,
+        domain_type_args,
     })
 }
 
@@ -464,7 +470,7 @@ where
         mut domain_config,
         domain_id,
         operator_id,
-        additional_args,
+        domain_type_args,
     } = domain_configuration;
 
     // Replace storage in the chain spec with correct one for this particular domain
@@ -542,7 +548,7 @@ where
                 >,
             >::new(
                 Some(domain_config.base_path.path()),
-                additional_args.into_iter(),
+                domain_type_args.into_iter(),
             );
 
             let domain_params = domain_service::DomainParams {

--- a/domains/client/eth-service/src/provider.rs
+++ b/domains/client/eth-service/src/provider.rs
@@ -27,6 +27,7 @@ use sp_core::traits::SpawnEssentialNamed;
 use sp_core::H256;
 use sp_inherents::CreateInherentDataProviders;
 use sp_runtime::traits::Block as BlockT;
+use std::env;
 use std::error::Error;
 use std::fmt::{Debug, Display};
 use std::marker::PhantomData;
@@ -43,7 +44,7 @@ pub struct EthProvider<CT, EC> {
 
 impl<CT, EC> EthProvider<CT, EC> {
     pub fn new(base_path: Option<&Path>, eth_cli: impl Iterator<Item = String>) -> Self {
-        let eth_config = EthConfiguration::parse_from(eth_cli);
+        let eth_config = EthConfiguration::parse_from(env::args().take(1).chain(eth_cli));
         Self::with_configuration(base_path, eth_config)
     }
 


### PR DESCRIPTION
Previously, clap assumes executable name at the beginning of the arguments while parsing the raw arguments. Unfortunately, we did not adjust this for domain type specific arguments and as a result required users who want to override default domain type arguments as 
```
./target/debug/subspace-node run --dev  -- --domain-id 0 --operator-id 0 -- -- --eth-log-block-cache 100000 
```

Ideally, what we want is something like this
```
./target/debug/subspace-node run --dev  -- --domain-id 0 --operator-id 0 -- --eth-log-block-cache 100000 
```
Without the extra `--` which is a placeholder for executable name as clap expects at the time of parsing.

Adjusted the cli parsing to ensure placeholder is not required and can start the node while overriding domain specific args as pointed above

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
