### PR TITLE
Account the `chain_rewards` against the domain balance bookkeeping check

### DIFF
--- a/crates/sp-domains/src/lib.rs
+++ b/crates/sp-domains/src/lib.rs
@@ -276,7 +276,7 @@ pub struct BlockFees<Balance> {
 
 impl<Balance> BlockFees<Balance>
 where
-    Balance: CheckedAdd,
+    Balance: CheckedAdd + Zero,
 {
     pub fn new(
         domain_execution_fee: Balance,
@@ -294,9 +294,14 @@ where
 
     /// Returns the total fees that was collected and burned on the Domain.
     pub fn total_fees(&self) -> Option<Balance> {
+        let total_chain_reward = self
+            .chain_rewards
+            .values()
+            .try_fold(Zero::zero(), |acc: Balance, cr| acc.checked_add(cr))?;
         self.consensus_storage_fee
             .checked_add(&self.domain_execution_fee)
             .and_then(|balance| balance.checked_add(&self.burned_balance))
+            .and_then(|balance| balance.checked_add(&total_chain_reward))
     }
 }
 

--- a/domains/runtime/auto-id/src/lib.rs
+++ b/domains/runtime/auto-id/src/lib.rs
@@ -340,8 +340,6 @@ impl sp_messenger::OnXDMRewards<Balance> for OnXDMRewards {
         BlockFees::note_domain_execution_fee(rewards)
     }
     fn on_chain_protocol_fees(chain_id: ChainId, fees: Balance) {
-        // note the burned balance from this chain
-        BlockFees::note_burned_balance(fees);
         // note the chain rewards
         BlockFees::note_chain_rewards(chain_id, fees);
     }

--- a/domains/runtime/evm/src/lib.rs
+++ b/domains/runtime/evm/src/lib.rs
@@ -487,8 +487,6 @@ impl sp_messenger::OnXDMRewards<Balance> for OnXDMRewards {
     }
 
     fn on_chain_protocol_fees(chain_id: ChainId, fees: Balance) {
-        // note the burned balance from this chain
-        BlockFees::note_burned_balance(fees);
         // note the chain rewards
         BlockFees::note_chain_rewards(chain_id, fees);
     }

--- a/domains/test/runtime/auto-id/src/lib.rs
+++ b/domains/test/runtime/auto-id/src/lib.rs
@@ -333,8 +333,6 @@ impl sp_messenger::OnXDMRewards<Balance> for OnXDMRewards {
         BlockFees::note_domain_execution_fee(rewards)
     }
     fn on_chain_protocol_fees(chain_id: ChainId, fees: Balance) {
-        // note the burned balance from this chain
-        BlockFees::note_burned_balance(fees);
         // note the chain rewards
         BlockFees::note_chain_rewards(chain_id, fees);
     }

--- a/domains/test/runtime/evm/src/lib.rs
+++ b/domains/test/runtime/evm/src/lib.rs
@@ -521,8 +521,6 @@ impl sp_messenger::OnXDMRewards<Balance> for OnXDMRewards {
         BlockFees::note_domain_execution_fee(rewards)
     }
     fn on_chain_protocol_fees(chain_id: ChainId, fees: Balance) {
-        // note the burned balance from this chain
-        BlockFees::note_burned_balance(fees);
         // note the chain rewards
         BlockFees::note_chain_rewards(chain_id, fees);
     }


### PR DESCRIPTION
close #3468 

This PR fixes #3468 by:
- Not note the `chain_rewards` as burned balance
- Include the `chain_rewards` in `total_fees` which will be checked against the domain balance bookkeeping check

This PR also adds a test that reproduces the issue and ensures it is fixed, the test will fail in the main branch but pass with this PR.

### Compatibility with Taurus (no action needed ATM)

This fix includes changes in both the consensus runtime and domain runtime thus need to upgrade both runtimes to fix the issue in Taurus completely.

But we don't need to take extra care about the order and timing of the upgrading because:
- `chain_rewards` is always zero on Taurus thus the issue is not triggered, `chain_rewards` is only set to non-zero if the consensus chain is not in the EVM domain's channel allowlist, which is not the case in Taurus
- If some malicious operator submits a bad ER with non-zero `chain_rewards` it will be pruned by FP very soon

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
