### PR TITLE
Fix unlock failure due to missing share price

### DIFF
--- a/crates/pallet-domains/src/benchmarking.rs
+++ b/crates/pallet-domains/src/benchmarking.rs
@@ -759,9 +759,16 @@ mod benchmarks {
         do_finalize_domain_epoch_staking::<T>(domain_id)
             .expect("finalize domain staking should success");
 
+        let current_domain_epoch_index = DomainStakingSummary::<T>::get(domain_id)
+            .expect("domain must initialized")
+            .current_epoch_index;
         Withdrawals::<T>::try_mutate(operator_id, nominator.clone(), |maybe_withdrawal| {
             let withdrawal = maybe_withdrawal.as_mut().unwrap();
-            do_convert_previous_epoch_withdrawal::<T>(operator_id, withdrawal)?;
+            do_convert_previous_epoch_withdrawal::<T>(
+                operator_id,
+                withdrawal,
+                current_domain_epoch_index,
+            )?;
             assert_eq!(withdrawal.withdrawals.len() as u32, w);
             Ok::<(), StakingError>(())
         })

--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -754,6 +754,13 @@ mod pallet {
     #[pallet::storage]
     pub type SkipBalanceChecks<T> = StorageValue<_, BTreeSet<DomainId>, ValueQuery>;
 
+    /// TODO: remove after all "missing-share-price" withdrawal is unlocked on Taurus
+    /// Storage that hold a domain epoch, for epoch that happen before it, the share price may
+    /// be missing due to https://github.com/autonomys/subspace/issues/3459, in this case, we
+    /// use the current share price as the default.
+    #[pallet::storage]
+    pub type AllowedDefaultSharePriceEpoch<T> = StorageValue<_, DomainEpoch, OptionQuery>;
+
     #[derive(TypeInfo, Encode, Decode, PalletError, Debug, PartialEq)]
     pub enum BundleError {
         /// Can not find the operator for given operator id.

--- a/crates/pallet-domains/src/staking.rs
+++ b/crates/pallet-domains/src/staking.rs
@@ -910,12 +910,11 @@ pub(crate) fn do_withdraw_stake<T: Config>(
                 // of previous epoch withdrawals from shares to balances above. So just update it instead
                 let new_withdrawal_in_shares = match withdrawal.withdrawal_in_shares.take() {
                     Some(WithdrawalInShares {
-                        domain_epoch,
                         shares,
                         storage_fee_refund,
                         ..
                     }) => WithdrawalInShares {
-                        domain_epoch,
+                        domain_epoch: domain_current_epoch,
                         shares: shares
                             .checked_add(&shares_withdrew)
                             .ok_or(Error::ShareOverflow)?,

--- a/crates/pallet-domains/src/staking_epoch.rs
+++ b/crates/pallet-domains/src/staking_epoch.rs
@@ -394,7 +394,7 @@ pub(crate) fn do_slash_operator<T: Config>(
                         &mut withdrawal,
                         current_domain_epoch_index,
                     ) {
-                        // Share price may be missing if there is withdrawal happen in the same epoch as de-register
+                        // Share price may be missing if there is withdrawal happen in the same epoch as slash
                         Ok(()) | Err(TransitionError::MissingOperatorEpochSharePrice) => {}
                         Err(err) => return Err(err),
                     }

--- a/domains/client/domain-operator/src/bundle_processor.rs
+++ b/domains/client/domain-operator/src/bundle_processor.rs
@@ -300,7 +300,7 @@ where
             {
                 self.client
                     .finalize_block(confirmed_domain_block.1, None, true)?;
-                info!("🔒 Finalized block: {:?}", confirmed_domain_block);
+                tracing::debug!("🔒 Finalized block: {:?}", confirmed_domain_block);
             }
         }
         Ok(())

--- a/domains/client/domain-operator/src/bundle_processor.rs
+++ b/domains/client/domain-operator/src/bundle_processor.rs
@@ -21,7 +21,6 @@ use sp_runtime::{Digest, DigestItem};
 use sp_weights::constants::WEIGHT_REF_TIME_PER_MILLIS;
 use std::sync::Arc;
 use std::time::Instant;
-use tracing::info;
 
 // The slow log threshold for consensus block preprocessing
 const SLOW_PREPROCESS_MILLIS: u64 = 500;

--- a/domains/client/domain-operator/src/bundle_processor.rs
+++ b/domains/client/domain-operator/src/bundle_processor.rs
@@ -299,7 +299,6 @@ where
             {
                 self.client
                     .finalize_block(confirmed_domain_block.1, None, true)?;
-                tracing::debug!("🔒 Finalized block: {:?}", confirmed_domain_block);
             }
         }
         Ok(())


### PR DESCRIPTION
close #3459 

This PR fixes the unlock failure due to missing share price by:
- Add checks to ensure zero-amount deposit and withdrawal will be rejected
- Add check to return error if the share price is missing unexpectedly

### TODO
~~- Add test cases~~
~~- Add migration for Taurus~~

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
