### PR TITLE
Stop removing XDM weights too early, avoid 4 clones for each XDM message

### DIFF
--- a/domains/pallets/messenger/src/lib.rs
+++ b/domains/pallets/messenger/src/lib.rs
@@ -331,7 +331,7 @@ mod pallet {
     #[pallet::storage]
     #[pallet::getter(fn message_weight_tags)]
     pub(super) type MessageWeightTags<T: Config> =
-        StorageValue<_, crate::messages::MessageWeightTags, OptionQuery>;
+        StorageValue<_, crate::messages::MessageWeightTags, ValueQuery>;
 
     /// An allowlist of chains that can open channel with this chain.
     #[pallet::storage]


### PR DESCRIPTION
### Bug Fix

Previously the messaging code could remove a weight tag before the corresponding inbox response was removed.

Instead, this PR checks for the loop exit condition first, then removes the tag (and fee).

### Performance Fix

Currently, each XDM message clones the entire `MessageWeightTags` storage 4 times:
- inbox add
- inbox remove
- outbox add
- outbox remove

If the number of pending XDM messages is large (for example, it is currently 90,000), this uses a lot of CPU and memory.

This PR rewrites the code to:
- use a `ValueQuery` rather than an `OptionQuery`, automatically substituting empty `BTreeMap`s for a missing storage value
- avoid cloning the entire storage when modifying the inbox or outbox `BTreeMap`s
- removing all the items in the same closure, where possible

Partial fix for #3483.

#### Migration Not Needed

These code changes don't need a migration, because the underlying storage format is the same. We're just changing how we query it (and avoiding cloning the query outcome).

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
