### PR TITLE
Skip domain balance check for domain 0 on Taurus

### DIFF
--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -14,6 +14,7 @@ mod bundle_storage_fund;
 pub mod domain_registry;
 pub mod extensions;
 pub mod migration_v2_to_v3;
+pub mod migrations;
 pub mod runtime_registry;
 mod staking;
 mod staking_epoch;
@@ -173,7 +174,7 @@ impl<O: Into<Result<RawOrigin, O>> + From<RawOrigin>> EnsureOrigin<O> for Ensure
 }
 
 /// The current storage version.
-const STORAGE_VERSION: StorageVersion = StorageVersion::new(3);
+const STORAGE_VERSION: StorageVersion = StorageVersion::new(4);
 
 /// The number of bundle of a particular domain to be included in the block is probabilistic
 /// and based on the consensus chain slot probability and domain bundle slot probability, usually
@@ -749,6 +750,11 @@ mod pallet {
     #[pallet::storage]
     pub type EvmDomainContractCreationAllowedByCalls<T: Config> =
         StorageMap<_, Identity, DomainId, EvmDomainContractCreationAllowedByCall, ValueQuery>;
+
+    /// TODO: remove once https://github.com/autonomys/subspace/issues/3466 is resolved
+    /// Storage that hold a list of all domains for which balance checks are ignored.
+    #[pallet::storage]
+    pub type SkipBalanceChecks<T> = StorageValue<_, BTreeSet<DomainId>, ValueQuery>;
 
     #[derive(TypeInfo, Encode, Decode, PalletError, Debug, PartialEq)]
     pub enum BundleError {

--- a/crates/pallet-domains/src/migrations.rs
+++ b/crates/pallet-domains/src/migrations.rs
@@ -1,0 +1,44 @@
+//! Migration module for pallet-domains
+//!
+//! TODO: remove this module after it has been deployed to Taurus.
+
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+use crate::{Config, Pallet};
+#[cfg(not(feature = "std"))]
+use alloc::collections::BTreeSet;
+use frame_support::migrations::VersionedMigration;
+use frame_support::traits::UncheckedOnRuntimeUpgrade;
+use frame_support::weights::Weight;
+#[cfg(feature = "std")]
+use std::collections::BTreeSet;
+
+pub type VersionCheckedMigrateDomainsV3ToV4<T> = VersionedMigration<
+    3,
+    4,
+    VersionUncheckedMigrateV3ToV4<T>,
+    Pallet<T>,
+    <T as frame_system::Config>::DbWeight,
+>;
+
+pub struct VersionUncheckedMigrateV3ToV4<T>(sp_std::marker::PhantomData<T>);
+impl<T: Config> UncheckedOnRuntimeUpgrade for VersionUncheckedMigrateV3ToV4<T> {
+    fn on_runtime_upgrade() -> Weight {
+        domain_balance_check_migration_migration::migrate_domain_balance_check::<T>()
+    }
+}
+
+mod domain_balance_check_migration_migration {
+    use super::{BTreeSet, Config};
+    use crate::SkipBalanceChecks;
+    use frame_support::pallet_prelude::Weight;
+    use sp_core::Get;
+    use sp_domains::DomainId;
+
+    pub(super) fn migrate_domain_balance_check<T: Config>() -> Weight {
+        // 0 read and 1 write
+        let list = BTreeSet::from([DomainId::new(0)]);
+        SkipBalanceChecks::<T>::put(list);
+        T::DbWeight::get().reads_writes(0, 1)
+    }
+}

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -1102,12 +1102,8 @@ pub type Executive = frame_executive::Executive<
     frame_system::ChainContext<Runtime>,
     Runtime,
     AllPalletsWithSystem,
-    (
-        // TODO: remove once migration has been deployed to Taurus and Mainnet
-        pallet_messenger::migrations::VersionCheckedMigrateDomainsV0ToV1<Runtime>,
-        // TODO: remove once migration has been deployed to Taurus
-        pallet_domains::migration_v2_to_v3::VersionCheckedMigrateDomainsV2ToV3<Runtime>,
-    ),
+    // TODO: remove once migration has been deployed to Taurus
+    pallet_domains::migrations::VersionCheckedMigrateDomainsV3ToV4<Runtime>,
 >;
 
 impl pallet_subspace::extensions::MaybeSubspaceCall<Runtime> for RuntimeCall {


### PR DESCRIPTION
In our recent Consensus upgrade, we commented out this piece of code for Consensus on Taurus due to the issue - https://github.com/autonomys/subspace/issues/3466

I want to ensure we do not miss this during the next upgrade to Taurus accidentally stopping domain block production.
Until, the above issue is resolved, I would be more comfortable if we skip this check for domain 0.

This will be removed as before phase 2 launch.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
