### PR TITLE
fix: cache not detected when farmer is run in cluster mode

### DIFF
--- a/crates/subspace-farmer/src/cluster/controller.rs
+++ b/crates/subspace-farmer/src/cluster/controller.rs
@@ -8,6 +8,7 @@
 
 pub mod caches;
 pub mod farms;
+mod stream_map;
 
 use crate::cluster::cache::{ClusterCacheReadPieceRequest, ClusterCacheReadPiecesRequest};
 use crate::cluster::nats_client::{

--- a/crates/subspace-farmer/src/cluster/controller/caches.rs
+++ b/crates/subspace-farmer/src/cluster/controller/caches.rs
@@ -248,7 +248,7 @@ async fn collect_piece_caches(
             warn!(
                 %error,
                 %cluster_cache_id,
-                "Failed to request farmer farm details"
+                "Failed to request cache details"
             )
         })?
         .map(

--- a/crates/subspace-farmer/src/cluster/controller/caches.rs
+++ b/crates/subspace-farmer/src/cluster/controller/caches.rs
@@ -9,6 +9,7 @@ use crate::cluster::cache::{
     ClusterCacheDetailsRequest, ClusterCacheId, ClusterCacheIdentifyBroadcast, ClusterPieceCache,
     ClusterPieceCacheDetails,
 };
+use crate::cluster::controller::stream_map::StreamMap;
 use crate::cluster::controller::ClusterControllerCacheIdentifyBroadcast;
 use crate::cluster::nats_client::NatsClient;
 use crate::farm::PieceCache;
@@ -23,7 +24,6 @@ use std::pin::{pin, Pin};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::time::MissedTickBehavior;
-use tokio_stream::StreamMap;
 use tracing::{debug, info, trace, warn};
 
 const SCHEDULE_REINITIALIZATION_DELAY: Duration = Duration::from_secs(3);
@@ -104,7 +104,7 @@ pub async fn maintain_caches(
 ) -> anyhow::Result<()> {
     let mut known_caches = KnownCaches::new(identification_broadcast_interval);
 
-    let mut piece_caches_to_add = StreamMap::<ClusterCacheId, _>::new().fuse();
+    let mut piece_caches_to_add = StreamMap::default();
 
     let mut scheduled_reinitialization_for = None;
     let mut cache_reinitialization =
@@ -177,19 +177,15 @@ pub async fn maintain_caches(
                         %cluster_cache_id,
                         "Received identification for already known cache"
                     );
-                } else if piece_caches_to_add.get_ref().contains_key(&cluster_cache_id) {
-                    debug!(
-                        %cluster_cache_id,
-                        "Received identification for new cache, which is already in progress"
-                    );
-                } else {
+                } else if piece_caches_to_add.add_if_not_in_progress(cluster_cache_id, Box::pin(collect_piece_caches(cluster_cache_id, nats_client))) {
                     debug!(
                         %cluster_cache_id,
                         "Received identification for new cache, collecting piece caches"
                     );
-                    piece_caches_to_add.get_mut().insert(
-                        cluster_cache_id,
-                        Box::pin(collect_piece_caches(cluster_cache_id, nats_client).into_stream()),
+                } else {
+                    debug!(
+                        %cluster_cache_id,
+                        "Received identification for new cache, which is already in progress"
                     );
                 }
             }

--- a/crates/subspace-farmer/src/cluster/controller/farms.rs
+++ b/crates/subspace-farmer/src/cluster/controller/farms.rs
@@ -4,9 +4,7 @@
 //! about which pieces are plotted in which sectors of which farm up to date. Implementation
 //! automatically handles dynamic farm addition and removal, etc.
 
-mod stream_map;
-
-use crate::cluster::controller::farms::stream_map::StreamMap;
+use crate::cluster::controller::stream_map::StreamMap;
 use crate::cluster::controller::ClusterControllerFarmerIdentifyBroadcast;
 use crate::cluster::farmer::{
     ClusterFarm, ClusterFarmerFarmDetails, ClusterFarmerFarmDetailsRequest, ClusterFarmerId,

--- a/crates/subspace-farmer/src/cluster/controller/stream_map.rs
+++ b/crates/subspace-farmer/src/cluster/controller/stream_map.rs
@@ -112,7 +112,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::cluster::controller::farms::stream_map::StreamMap;
+    use crate::cluster::controller::stream_map::StreamMap;
     use futures::stream::FusedStream;
     use futures::StreamExt;
     use std::task::Context;


### PR DESCRIPTION
close: #3481 

Since Tokio's `StreamMap` doesn't implement the `futures::Fused` trait, it gets marked as terminated after being polled once in a `futures::select!`. This issue was already fixed in `farms`, but was overlooked in `caches`. It's now resolved by reusing the custom `StreamMap`.

The meaningful fix is in 3d653cbf268ab6cec8f866cbade0c8f97d1c7c8b.

Tested on the local cluster.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
