### PR TITLE
Fix padding and segment header checks in object retrieval tests

### DIFF
--- a/crates/subspace-core-primitives/src/pieces.rs
+++ b/crates/subspace-core-primitives/src/pieces.rs
@@ -173,6 +173,27 @@ impl PieceIndex {
     pub const fn next_source_index(&self) -> PieceIndex {
         PieceIndex::from_source_position(self.source_position() + 1, self.segment_index())
     }
+
+    /// Returns the previous source piece index, if there is one.
+    /// Panics if the piece is not a source piece.
+    #[inline]
+    pub const fn prev_source_index(&self) -> Option<PieceIndex> {
+        if self.source_position() == 0 {
+            // TODO: when Option::map or ? become const, use them here
+            match self.segment_index().checked_sub(SegmentIndex::ONE) {
+                Some(segment_index) => Some(PieceIndex::from_source_position(
+                    RecordedHistorySegment::NUM_RAW_RECORDS as u32 - 1,
+                    segment_index,
+                )),
+                None => None,
+            }
+        } else {
+            Some(PieceIndex::from_source_position(
+                self.source_position() - 1,
+                self.segment_index(),
+            ))
+        }
+    }
 }
 
 /// Piece offset in sector

--- a/crates/subspace-core-primitives/src/segments.rs
+++ b/crates/subspace-core-primitives/src/segments.rs
@@ -130,8 +130,12 @@ impl SegmentIndex {
 
     /// Checked integer subtraction. Computes `self - rhs`, returning `None` if overflow occurred.
     #[inline]
-    pub fn checked_sub(self, rhs: Self) -> Option<Self> {
-        self.0.checked_sub(rhs.0).map(Self)
+    pub const fn checked_sub(self, rhs: Self) -> Option<Self> {
+        // TODO: when Option::map becomes const, use it here
+        match self.0.checked_sub(rhs.0) {
+            Some(segment_index) => Some(Self(segment_index)),
+            None => None,
+        }
     }
 }
 

--- a/shared/subspace-data-retrieval/src/object_fetcher/tests.rs
+++ b/shared/subspace-data-retrieval/src/object_fetcher/tests.rs
@@ -311,7 +311,19 @@ fn create_mapping(
                 start_piece_index,
                 pieces_len,
                 original_len,
-            );
+            )
+            .unwrap_or_else(|| {
+                panic!(
+                    "must have padding when skip_padding is set: \
+                skip_padding: {skip_padding} bytes, \
+                raw_data_after_segment_header: {} bytes, \
+                padding_piece_index: {padding_piece_index}, \
+                start_piece_index: {start_piece_index}, \
+                pieces_len: {pieces_len}, \
+                original_len: {original_len}",
+                    raw_data_after_segment_header.len(),
+                )
+            });
 
             // Delete the padding bytes we want to skip
             let replaced_padding_data = raw_data
@@ -341,32 +353,34 @@ fn create_mapping(
             );
         }
 
-        // If the offset hasn't already skipped the segment header, skip it now
-        if segment_header_piece_index > start_piece_index {
+        // If this is a segment header piece, the offset will have already skipped the segment
+        // header. If it's any other piece, skip it now.
+        if idx(start_piece_index).position() != 0 {
             let original_len = raw_data.len();
 
-            let mut byte_position_in_raw_data = byte_position_in_extract_raw_data(
+            if let Some(mut byte_position_in_raw_data) = byte_position_in_extract_raw_data(
                 segment_header_piece_index,
                 start_piece_index,
                 pieces_len,
                 original_len,
-            );
-            byte_position_in_raw_data -= skip_padding;
+            ) {
+                byte_position_in_raw_data -= skip_padding;
 
-            // Replace the entire piece with just the raw data after the segment header
-            let _replaced_piece_data = raw_data
-                .splice(
-                    // The entire piece range, in bytes
-                    byte_position_in_raw_data..byte_position_in_raw_data + RawRecord::SIZE,
-                    // The remaining data from the piece, excluding the segment header
-                    raw_data_after_segment_header.iter().copied(),
-                )
-                .collect::<Vec<_>>();
+                // Replace the entire piece with just the raw data after the segment header
+                let _replaced_piece_data = raw_data
+                    .splice(
+                        // The entire piece range, in bytes
+                        byte_position_in_raw_data..byte_position_in_raw_data + RawRecord::SIZE,
+                        // The remaining data from the piece, excluding the segment header
+                        raw_data_after_segment_header.iter().copied(),
+                    )
+                    .collect::<Vec<_>>();
 
-            assert_eq!(
-                raw_data.len(),
-                original_len - RawRecord::SIZE + raw_data_after_segment_header.len()
-            );
+                assert_eq!(
+                    raw_data.len(),
+                    original_len - RawRecord::SIZE + raw_data_after_segment_header.len()
+                );
+            }
         }
     }
 
@@ -388,31 +402,32 @@ fn create_mapping(
 }
 
 /// Returns the byte position of a piece in the raw data, after checking it is valid.
+/// Returns `None` if the piece index is not in the supplied pieces.
 fn byte_position_in_extract_raw_data(
     piece_index: usize,
     start_piece_index: usize,
     pieces_len: usize,
     raw_data_len: usize,
-) -> usize {
+) -> Option<usize> {
     let piece_position_in_raw_data = (piece_index - start_piece_index) / 2;
+
+    if piece_position_in_raw_data >= pieces_len {
+        return None;
+    }
+
     assert!(
         piece_position_in_raw_data < max_supported_object_length().div_ceil(RawRecord::SIZE),
-        "{piece_position_in_raw_data} < {}",
+        "object length not supported: {piece_position_in_raw_data} < {}",
         max_supported_object_length().div_ceil(RawRecord::SIZE)
-    );
-    assert!(
-        piece_position_in_raw_data < pieces_len,
-        "{piece_position_in_raw_data} < {}",
-        pieces_len
     );
 
     let byte_position_in_raw_data = piece_position_in_raw_data * RawRecord::SIZE;
     assert!(
         byte_position_in_raw_data < raw_data_len,
-        "{byte_position_in_raw_data} < {raw_data_len}",
+        "byte position not in raw data: {byte_position_in_raw_data} < {raw_data_len}",
     );
 
-    byte_position_in_raw_data
+    Some(byte_position_in_raw_data)
 }
 
 /// Creates an object fetcher from a piece and piece index.

--- a/shared/subspace-logging/src/lib.rs
+++ b/shared/subspace-logging/src/lib.rs
@@ -11,7 +11,8 @@ pub fn init_logger() {
     } else {
         supports_color::on(supports_color::Stream::Stderr).is_some()
     };
-    tracing_subscriber::registry()
+
+    let res = tracing_subscriber::registry()
         .with(
             fmt::layer().with_ansi(enable_color).with_filter(
                 EnvFilter::builder()
@@ -19,5 +20,15 @@ pub fn init_logger() {
                     .from_env_lossy(),
             ),
         )
-        .init();
+        .try_init();
+
+    if let Err(e) = res {
+        // In production, this might be a bug in the logging setup.
+        // In some tests, it is expected.
+        eprintln!(
+            "Failed to initialize logger: {}. \
+            This is expected when running nexttest test functions under `cargo test`.",
+            e
+        );
+    }
 }


### PR DESCRIPTION
This PR fixes two issues in the object retrieval tests:
- the padding piece index calculation is incorrect
- the segment header piece index check is unclear

As part of this change, I added a new method to `PieceIndex` to get the previous source piece index.

I also fixed the `init_logger()` function so it works with `cargo test`. In `cargo nextest`, we need to initialise logging in every test function, because they run independently. In `cargo test`, calling `tracing_subscriber::registry().init()` multiple times in the same process causes a panic.

Now it will log (so we catch multiple log inits in production), but not panic.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
