### PR TITLE
Add a timeout to inbound libp2p-kad substreams

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6187,7 +6187,7 @@ dependencies = [
 [[package]]
 name = "libp2p"
 version = "0.54.2"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=04c2e649b1f5482b8c3466b0fdbd1815b3126a48#04c2e649b1f5482b8c3466b0fdbd1815b3126a48"
+source = "git+https://github.com/subspace/rust-libp2p?rev=399c4c7fcba821a7bac2663e090a7b155b08ebe1#399c4c7fcba821a7bac2663e090a7b155b08ebe1"
 dependencies = [
  "bytes",
  "either",
@@ -6224,7 +6224,7 @@ dependencies = [
 [[package]]
 name = "libp2p-allow-block-list"
 version = "0.4.2"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=04c2e649b1f5482b8c3466b0fdbd1815b3126a48#04c2e649b1f5482b8c3466b0fdbd1815b3126a48"
+source = "git+https://github.com/subspace/rust-libp2p?rev=399c4c7fcba821a7bac2663e090a7b155b08ebe1#399c4c7fcba821a7bac2663e090a7b155b08ebe1"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
@@ -6234,7 +6234,7 @@ dependencies = [
 [[package]]
 name = "libp2p-autonat"
 version = "0.13.1"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=04c2e649b1f5482b8c3466b0fdbd1815b3126a48#04c2e649b1f5482b8c3466b0fdbd1815b3126a48"
+source = "git+https://github.com/subspace/rust-libp2p?rev=399c4c7fcba821a7bac2663e090a7b155b08ebe1#399c4c7fcba821a7bac2663e090a7b155b08ebe1"
 dependencies = [
  "async-trait",
  "asynchronous-codec 0.7.0",
@@ -6259,7 +6259,7 @@ dependencies = [
 [[package]]
 name = "libp2p-connection-limits"
 version = "0.4.1"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=04c2e649b1f5482b8c3466b0fdbd1815b3126a48#04c2e649b1f5482b8c3466b0fdbd1815b3126a48"
+source = "git+https://github.com/subspace/rust-libp2p?rev=399c4c7fcba821a7bac2663e090a7b155b08ebe1#399c4c7fcba821a7bac2663e090a7b155b08ebe1"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
@@ -6269,7 +6269,7 @@ dependencies = [
 [[package]]
 name = "libp2p-core"
 version = "0.42.1"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=04c2e649b1f5482b8c3466b0fdbd1815b3126a48#04c2e649b1f5482b8c3466b0fdbd1815b3126a48"
+source = "git+https://github.com/subspace/rust-libp2p?rev=399c4c7fcba821a7bac2663e090a7b155b08ebe1#399c4c7fcba821a7bac2663e090a7b155b08ebe1"
 dependencies = [
  "either",
  "fnv",
@@ -6296,7 +6296,7 @@ dependencies = [
 [[package]]
 name = "libp2p-dns"
 version = "0.42.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=04c2e649b1f5482b8c3466b0fdbd1815b3126a48#04c2e649b1f5482b8c3466b0fdbd1815b3126a48"
+source = "git+https://github.com/subspace/rust-libp2p?rev=399c4c7fcba821a7bac2663e090a7b155b08ebe1#399c4c7fcba821a7bac2663e090a7b155b08ebe1"
 dependencies = [
  "async-trait",
  "futures",
@@ -6311,7 +6311,7 @@ dependencies = [
 [[package]]
 name = "libp2p-gossipsub"
 version = "0.48.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=04c2e649b1f5482b8c3466b0fdbd1815b3126a48#04c2e649b1f5482b8c3466b0fdbd1815b3126a48"
+source = "git+https://github.com/subspace/rust-libp2p?rev=399c4c7fcba821a7bac2663e090a7b155b08ebe1#399c4c7fcba821a7bac2663e090a7b155b08ebe1"
 dependencies = [
  "async-channel 2.3.1",
  "asynchronous-codec 0.7.0",
@@ -6342,7 +6342,7 @@ dependencies = [
 [[package]]
 name = "libp2p-identify"
 version = "0.46.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=04c2e649b1f5482b8c3466b0fdbd1815b3126a48#04c2e649b1f5482b8c3466b0fdbd1815b3126a48"
+source = "git+https://github.com/subspace/rust-libp2p?rev=399c4c7fcba821a7bac2663e090a7b155b08ebe1#399c4c7fcba821a7bac2663e090a7b155b08ebe1"
 dependencies = [
  "asynchronous-codec 0.7.0",
  "either",
@@ -6363,7 +6363,7 @@ dependencies = [
 [[package]]
 name = "libp2p-identity"
 version = "0.2.10"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=04c2e649b1f5482b8c3466b0fdbd1815b3126a48#04c2e649b1f5482b8c3466b0fdbd1815b3126a48"
+source = "git+https://github.com/subspace/rust-libp2p?rev=399c4c7fcba821a7bac2663e090a7b155b08ebe1#399c4c7fcba821a7bac2663e090a7b155b08ebe1"
 dependencies = [
  "bs58",
  "ed25519-dalek",
@@ -6381,7 +6381,7 @@ dependencies = [
 [[package]]
 name = "libp2p-kad"
 version = "0.47.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=04c2e649b1f5482b8c3466b0fdbd1815b3126a48#04c2e649b1f5482b8c3466b0fdbd1815b3126a48"
+source = "git+https://github.com/subspace/rust-libp2p?rev=399c4c7fcba821a7bac2663e090a7b155b08ebe1#399c4c7fcba821a7bac2663e090a7b155b08ebe1"
 dependencies = [
  "arrayvec 0.7.6",
  "asynchronous-codec 0.7.0",
@@ -6409,7 +6409,7 @@ dependencies = [
 [[package]]
 name = "libp2p-mdns"
 version = "0.46.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=04c2e649b1f5482b8c3466b0fdbd1815b3126a48#04c2e649b1f5482b8c3466b0fdbd1815b3126a48"
+source = "git+https://github.com/subspace/rust-libp2p?rev=399c4c7fcba821a7bac2663e090a7b155b08ebe1#399c4c7fcba821a7bac2663e090a7b155b08ebe1"
 dependencies = [
  "data-encoding",
  "futures",
@@ -6428,7 +6428,7 @@ dependencies = [
 [[package]]
 name = "libp2p-metrics"
 version = "0.15.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=04c2e649b1f5482b8c3466b0fdbd1815b3126a48#04c2e649b1f5482b8c3466b0fdbd1815b3126a48"
+source = "git+https://github.com/subspace/rust-libp2p?rev=399c4c7fcba821a7bac2663e090a7b155b08ebe1#399c4c7fcba821a7bac2663e090a7b155b08ebe1"
 dependencies = [
  "futures",
  "libp2p-core",
@@ -6446,7 +6446,7 @@ dependencies = [
 [[package]]
 name = "libp2p-noise"
 version = "0.45.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=04c2e649b1f5482b8c3466b0fdbd1815b3126a48#04c2e649b1f5482b8c3466b0fdbd1815b3126a48"
+source = "git+https://github.com/subspace/rust-libp2p?rev=399c4c7fcba821a7bac2663e090a7b155b08ebe1#399c4c7fcba821a7bac2663e090a7b155b08ebe1"
 dependencies = [
  "asynchronous-codec 0.7.0",
  "bytes",
@@ -6471,7 +6471,7 @@ dependencies = [
 [[package]]
 name = "libp2p-ping"
 version = "0.45.1"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=04c2e649b1f5482b8c3466b0fdbd1815b3126a48#04c2e649b1f5482b8c3466b0fdbd1815b3126a48"
+source = "git+https://github.com/subspace/rust-libp2p?rev=399c4c7fcba821a7bac2663e090a7b155b08ebe1#399c4c7fcba821a7bac2663e090a7b155b08ebe1"
 dependencies = [
  "either",
  "futures",
@@ -6487,7 +6487,7 @@ dependencies = [
 [[package]]
 name = "libp2p-plaintext"
 version = "0.42.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=04c2e649b1f5482b8c3466b0fdbd1815b3126a48#04c2e649b1f5482b8c3466b0fdbd1815b3126a48"
+source = "git+https://github.com/subspace/rust-libp2p?rev=399c4c7fcba821a7bac2663e090a7b155b08ebe1#399c4c7fcba821a7bac2663e090a7b155b08ebe1"
 dependencies = [
  "asynchronous-codec 0.7.0",
  "bytes",
@@ -6502,7 +6502,7 @@ dependencies = [
 [[package]]
 name = "libp2p-quic"
 version = "0.11.2"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=04c2e649b1f5482b8c3466b0fdbd1815b3126a48#04c2e649b1f5482b8c3466b0fdbd1815b3126a48"
+source = "git+https://github.com/subspace/rust-libp2p?rev=399c4c7fcba821a7bac2663e090a7b155b08ebe1#399c4c7fcba821a7bac2663e090a7b155b08ebe1"
 dependencies = [
  "bytes",
  "futures",
@@ -6525,7 +6525,7 @@ dependencies = [
 [[package]]
 name = "libp2p-request-response"
 version = "0.28.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=04c2e649b1f5482b8c3466b0fdbd1815b3126a48#04c2e649b1f5482b8c3466b0fdbd1815b3126a48"
+source = "git+https://github.com/subspace/rust-libp2p?rev=399c4c7fcba821a7bac2663e090a7b155b08ebe1#399c4c7fcba821a7bac2663e090a7b155b08ebe1"
 dependencies = [
  "async-trait",
  "futures",
@@ -6543,7 +6543,7 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm"
 version = "0.45.2"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=04c2e649b1f5482b8c3466b0fdbd1815b3126a48#04c2e649b1f5482b8c3466b0fdbd1815b3126a48"
+source = "git+https://github.com/subspace/rust-libp2p?rev=399c4c7fcba821a7bac2663e090a7b155b08ebe1#399c4c7fcba821a7bac2663e090a7b155b08ebe1"
 dependencies = [
  "async-std",
  "either",
@@ -6566,7 +6566,7 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm-derive"
 version = "0.35.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=04c2e649b1f5482b8c3466b0fdbd1815b3126a48#04c2e649b1f5482b8c3466b0fdbd1815b3126a48"
+source = "git+https://github.com/subspace/rust-libp2p?rev=399c4c7fcba821a7bac2663e090a7b155b08ebe1#399c4c7fcba821a7bac2663e090a7b155b08ebe1"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -6577,7 +6577,7 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm-test"
 version = "0.5.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=04c2e649b1f5482b8c3466b0fdbd1815b3126a48#04c2e649b1f5482b8c3466b0fdbd1815b3126a48"
+source = "git+https://github.com/subspace/rust-libp2p?rev=399c4c7fcba821a7bac2663e090a7b155b08ebe1#399c4c7fcba821a7bac2663e090a7b155b08ebe1"
 dependencies = [
  "async-trait",
  "futures",
@@ -6595,7 +6595,7 @@ dependencies = [
 [[package]]
 name = "libp2p-tcp"
 version = "0.42.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=04c2e649b1f5482b8c3466b0fdbd1815b3126a48#04c2e649b1f5482b8c3466b0fdbd1815b3126a48"
+source = "git+https://github.com/subspace/rust-libp2p?rev=399c4c7fcba821a7bac2663e090a7b155b08ebe1#399c4c7fcba821a7bac2663e090a7b155b08ebe1"
 dependencies = [
  "async-io 2.3.4",
  "futures",
@@ -6612,7 +6612,7 @@ dependencies = [
 [[package]]
 name = "libp2p-tls"
 version = "0.5.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=04c2e649b1f5482b8c3466b0fdbd1815b3126a48#04c2e649b1f5482b8c3466b0fdbd1815b3126a48"
+source = "git+https://github.com/subspace/rust-libp2p?rev=399c4c7fcba821a7bac2663e090a7b155b08ebe1#399c4c7fcba821a7bac2663e090a7b155b08ebe1"
 dependencies = [
  "futures",
  "futures-rustls",
@@ -6630,7 +6630,7 @@ dependencies = [
 [[package]]
 name = "libp2p-upnp"
 version = "0.3.1"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=04c2e649b1f5482b8c3466b0fdbd1815b3126a48#04c2e649b1f5482b8c3466b0fdbd1815b3126a48"
+source = "git+https://github.com/subspace/rust-libp2p?rev=399c4c7fcba821a7bac2663e090a7b155b08ebe1#399c4c7fcba821a7bac2663e090a7b155b08ebe1"
 dependencies = [
  "futures",
  "futures-timer",
@@ -6644,7 +6644,7 @@ dependencies = [
 [[package]]
 name = "libp2p-websocket"
 version = "0.44.1"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=04c2e649b1f5482b8c3466b0fdbd1815b3126a48#04c2e649b1f5482b8c3466b0fdbd1815b3126a48"
+source = "git+https://github.com/subspace/rust-libp2p?rev=399c4c7fcba821a7bac2663e090a7b155b08ebe1#399c4c7fcba821a7bac2663e090a7b155b08ebe1"
 dependencies = [
  "either",
  "futures",
@@ -6664,7 +6664,7 @@ dependencies = [
 [[package]]
 name = "libp2p-yamux"
 version = "0.46.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=04c2e649b1f5482b8c3466b0fdbd1815b3126a48#04c2e649b1f5482b8c3466b0fdbd1815b3126a48"
+source = "git+https://github.com/subspace/rust-libp2p?rev=399c4c7fcba821a7bac2663e090a7b155b08ebe1#399c4c7fcba821a7bac2663e090a7b155b08ebe1"
 dependencies = [
  "either",
  "futures",
@@ -7345,7 +7345,7 @@ checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
 [[package]]
 name = "multistream-select"
 version = "0.13.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=04c2e649b1f5482b8c3466b0fdbd1815b3126a48#04c2e649b1f5482b8c3466b0fdbd1815b3126a48"
+source = "git+https://github.com/subspace/rust-libp2p?rev=399c4c7fcba821a7bac2663e090a7b155b08ebe1#399c4c7fcba821a7bac2663e090a7b155b08ebe1"
 dependencies = [
  "bytes",
  "futures",
@@ -9413,7 +9413,7 @@ dependencies = [
 [[package]]
 name = "quick-protobuf-codec"
 version = "0.3.1"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=04c2e649b1f5482b8c3466b0fdbd1815b3126a48#04c2e649b1f5482b8c3466b0fdbd1815b3126a48"
+source = "git+https://github.com/subspace/rust-libp2p?rev=399c4c7fcba821a7bac2663e090a7b155b08ebe1#399c4c7fcba821a7bac2663e090a7b155b08ebe1"
 dependencies = [
  "asynchronous-codec 0.7.0",
  "bytes",
@@ -10224,7 +10224,7 @@ dependencies = [
 [[package]]
 name = "rw-stream-sink"
 version = "0.4.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=04c2e649b1f5482b8c3466b0fdbd1815b3126a48#04c2e649b1f5482b8c3466b0fdbd1815b3126a48"
+source = "git+https://github.com/subspace/rust-libp2p?rev=399c4c7fcba821a7bac2663e090a7b155b08ebe1#399c4c7fcba821a7bac2663e090a7b155b08ebe1"
 dependencies = [
  "futures",
  "pin-project",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,8 +92,8 @@ hwlocality = "1.0.0-alpha.6"
 jsonrpsee = "0.24.5"
 kzg = { git = "https://github.com/grandinetech/rust-kzg", rev = "6c8fcc623df3d7e8c0f30951a49bfea764f90bf4", default-features = false }
 libc = "0.2.159"
-libp2p = { version = "0.54.2", git = "https://github.com/autonomys/rust-libp2p", rev = "04c2e649b1f5482b8c3466b0fdbd1815b3126a48", default-features = false }
-libp2p-swarm-test = { version = "0.5.0", git = "https://github.com/autonomys/rust-libp2p", rev = "04c2e649b1f5482b8c3466b0fdbd1815b3126a48" }
+libp2p = { version = "0.54.2", git = "https://github.com/subspace/rust-libp2p", rev = "399c4c7fcba821a7bac2663e090a7b155b08ebe1", default-features = false }
+libp2p-swarm-test = { version = "0.5.0", git = "https://github.com/subspace/rust-libp2p", rev = "399c4c7fcba821a7bac2663e090a7b155b08ebe1" }
 libsecp256k1 = "0.7.1"
 log = { version = "0.4.22", default-features = false }
 memmap2 = "0.9.5"
@@ -410,7 +410,18 @@ xcm-procedural = { git = "https://github.com/subspace/polkadot-sdk", rev = "ad62
 # De-duplicate extra copy that comes from Substrate repo
 substrate-bip39 = "0.6.0"
 
+[patch."https://github.com/autonomys/rust-libp2p.git"]
+# Patch away `libp2p` in our dependency tree with the git version.
+# This brings the fixes in our `libp2p` fork into substrate's dependencies.
+#
+# This is a hack: patches to the same repository are rejected by `cargo`. But it considers
+# "subspace/rust-libp2p" and "autonomys/rust-libp2p" to be different repositories, even though
+# they're redirected to the same place by GitHub, so it allows this patch.
+libp2p = { git = "https://github.com/subspace/rust-libp2p", rev = "399c4c7fcba821a7bac2663e090a7b155b08ebe1" }
+libp2p-identity = { git = "https://github.com/subspace/rust-libp2p", rev = "399c4c7fcba821a7bac2663e090a7b155b08ebe1" }
+multistream-select = { git = "https://github.com/subspace/rust-libp2p", rev = "399c4c7fcba821a7bac2663e090a7b155b08ebe1" }
+
 [patch.crates-io]
 # Patch away `libp2p-identity` in our dependency tree with the git version.
-# For details see: https://github.com/autonomys/rust-libp2p/blob/04c2e649b1f5482b8c3466b0fdbd1815b3126a48/Cargo.toml#L140-L145
-libp2p-identity = { git = "https://github.com/autonomys/rust-libp2p", rev = "04c2e649b1f5482b8c3466b0fdbd1815b3126a48" }
+# For details see: https://github.com/subspace/rust-libp2p/blob/399c4c7fcba821a7bac2663e090a7b155b08ebe1/Cargo.toml#L140-L145
+libp2p-identity = { git = "https://github.com/subspace/rust-libp2p", rev = "399c4c7fcba821a7bac2663e090a7b155b08ebe1" }


### PR DESCRIPTION
This PR upgrades:
- ~~the `polkadot-sdk` version in our fork to https://github.com/autonomys/polkadot-sdk/pull/29~~
- the `libp2p` version in our fork to https://github.com/autonomys/rust-libp2p/pull/2

It adds an inbound substream timeout to the kad protocol, which matches the outbound substream timeout. This prevents "substream limit exceeded" errors under load, caused by the outbound side timing out, but the inbound side keeping on waiting.

See PR https://github.com/autonomys/rust-libp2p/pull/2 for full details.

Close #3450.

This code has been tested on multiple operator nodes, and it prevents the substream limit exceeded errors.

#### Note about patching

You usually can't patch one crate version with another version, you have to change the crate fork/source as well:
https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html#the-patch-section

 The patch only works because `cargo` considers `https://github.com/subspace/rust-libp2p` and `https://github.com/autonomys/rust-libp2p` to be different repositories. Because our `polkadot-sdk` fork depends on the autonomys URL, we can patch using the subspace URL.


### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
