### PR TITLE
Fix usage of the wrong type alias

### DIFF
--- a/crates/subspace-core-primitives/src/segments.rs
+++ b/crates/subspace-core-primitives/src/segments.rs
@@ -353,7 +353,7 @@ impl LastArchivedBlock {
     }
 
     /// Sets new number of partially archived bytes.
-    pub fn set_partial_archived(&mut self, new_partial: BlockNumber) {
+    pub fn set_partial_archived(&mut self, new_partial: u32) {
         self.archived_progress.set_partial(new_partial);
     }
 


### PR DESCRIPTION
Happens to be the same type, but semantically wrong since argument represents bytes, not block number.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
