### PR TITLE
chore: remove unnecessary mut (part 2)

### DIFF
--- a/crates/sc-domains/src/domain_block_er/execution_receipt_protocol.rs
+++ b/crates/sc-domains/src/domain_block_er/execution_receipt_protocol.rs
@@ -162,7 +162,7 @@ where
     }
 
     fn handle_request(
-        &mut self,
+        &self,
         payload: Vec<u8>,
         pending_response: oneshot::Sender<OutgoingResponse>,
         peer: &PeerId,

--- a/crates/sc-subspace-block-relay/src/consensus/relay.rs
+++ b/crates/sc-subspace-block-relay/src/consensus/relay.rs
@@ -336,7 +336,7 @@ where
     }
 
     /// Handles the received request from the client side
-    async fn process_incoming_request(&mut self, request: IncomingRequest) {
+    async fn process_incoming_request(&self, request: IncomingRequest) {
         // Drop the request in case of errors and let the client time out.
         // This is the behavior of the current substrate block handler.
         let IncomingRequest {
@@ -392,7 +392,7 @@ where
 
     /// Handles the initial request from the client
     fn on_initial_request(
-        &mut self,
+        &self,
         initial_request: InitialRequest<Block>,
     ) -> Result<InitialResponse<Block, TxHash<Pool>>, RelayError> {
         let block_hash = self.block_hash(&initial_request.from_block)?;
@@ -422,7 +422,7 @@ where
 
     /// Handles the protocol message from the client
     fn on_protocol_message(
-        &mut self,
+        &self,
         msg: ProtocolMessage<Block, TxHash<Pool>>,
     ) -> Result<Vec<u8>, RelayError> {
         let response = match msg {
@@ -436,7 +436,7 @@ where
 
     /// Handles the full download request from the client
     fn on_full_download_request(
-        &mut self,
+        &self,
         full_download_request: FullDownloadRequest<Block>,
     ) -> Result<FullDownloadResponse<Block>, RelayError> {
         let block_request = full_download_request.0;

--- a/crates/sp-domains-fraud-proof/src/tests.rs
+++ b/crates/sp-domains-fraud-proof/src/tests.rs
@@ -36,7 +36,7 @@ pub fn generate_eth_domain_sc_extrinsic(tx: EthereumTransaction) -> EvmUnchecked
 
 async fn benchmark_bundle_with_evm_tx(
     tx_to_create: u32,
-    mut alice: EvmDomainNode,
+    alice: EvmDomainNode,
     mut ferdie: MockConsensusNode,
 ) -> (Vec<Vec<u8>>, StorageProof) {
     let account_infos = (0..tx_to_create)
@@ -250,7 +250,7 @@ async fn storage_change_of_the_same_runtime_instance_should_perserved_cross_runt
     );
 
     // Run Alice (a evm domain authority node)
-    let mut alice = domain_test_service::DomainNodeBuilder::new(
+    let alice = domain_test_service::DomainNodeBuilder::new(
         tokio_handle.clone(),
         BasePath::new(directory.path().join("alice")),
     )
@@ -443,7 +443,7 @@ async fn check_bundle_validity_runtime_api_should_work() {
     );
 
     // Run Alice (a evm domain authority node)
-    let mut alice = domain_test_service::DomainNodeBuilder::new(
+    let alice = domain_test_service::DomainNodeBuilder::new(
         tokio_handle.clone(),
         BasePath::new(directory.path().join("alice")),
     )
@@ -600,7 +600,7 @@ async fn test_evm_domain_block_fee() {
     );
 
     // Run Alice (a evm domain authority node)
-    let mut alice = domain_test_service::DomainNodeBuilder::new(
+    let alice = domain_test_service::DomainNodeBuilder::new(
         tokio_handle.clone(),
         BasePath::new(directory.path().join("alice")),
     )

--- a/crates/subspace-networking/src/node.rs
+++ b/crates/subspace-networking/src/node.rs
@@ -703,7 +703,7 @@ impl NodeRequestsBatchHandle {
     ///
     /// Optional addresses will be used for dialing if connection to peer isn't established yet.
     pub async fn send_generic_request<Request>(
-        &mut self,
+        &self,
         peer_id: PeerId,
         addresses: Vec<Multiaddr>,
         request: Request,

--- a/crates/subspace-networking/src/node_runner.rs
+++ b/crates/subspace-networking/src/node_runner.rs
@@ -558,7 +558,7 @@ impl NodeRunner {
                     shared.handlers.connected_peer.call_simple(&peer_id);
                 }
 
-                if let Some(metrics) = self.metrics.as_mut() {
+                if let Some(metrics) = self.metrics.as_ref() {
                     metrics.inc_established_connections()
                 }
             }
@@ -601,7 +601,7 @@ impl NodeRunner {
                     shared.handlers.disconnected_peer.call_simple(&peer_id);
                 }
 
-                if let Some(metrics) = self.metrics.as_mut() {
+                if let Some(metrics) = self.metrics.as_ref() {
                     metrics.dec_established_connections()
                 };
             }

--- a/crates/subspace-networking/src/protocols/request_response/handlers/generic_request_handler.rs
+++ b/crates/subspace-networking/src/protocols/request_response/handlers/generic_request_handler.rs
@@ -67,7 +67,7 @@ impl<Request: GenericRequest> GenericRequestHandler<Request> {
 
     /// Invokes external protocol handler.
     async fn handle_request(
-        &mut self,
+        &self,
         peer: PeerId,
         payload: Vec<u8>,
     ) -> Result<Vec<u8>, RequestHandlerError> {

--- a/crates/subspace-networking/src/utils.rs
+++ b/crates/subspace-networking/src/utils.rs
@@ -43,11 +43,11 @@ impl SubspaceMetrics {
         }
     }
 
-    pub(crate) fn inc_established_connections(&mut self) {
+    pub(crate) fn inc_established_connections(&self) {
         self.established_connections.inc();
     }
 
-    pub(crate) fn dec_established_connections(&mut self) {
+    pub(crate) fn dec_established_connections(&self) {
         self.established_connections.dec();
     }
 }

--- a/crates/subspace-networking/src/utils/piece_provider.rs
+++ b/crates/subspace-networking/src/utils/piece_provider.rs
@@ -144,7 +144,7 @@ where
     pub async fn get_piece_from_cache(&self, piece_index: PieceIndex) -> Option<Piece> {
         let key = RecordKey::from(piece_index.to_multihash());
 
-        let mut request_batch = self.node.get_requests_batch_handle().await;
+        let request_batch = self.node.get_requests_batch_handle().await;
         let mut get_providers_stream = request_batch
             .get_providers(key.clone())
             .await
@@ -320,7 +320,7 @@ where
         // Random walk key
         let key = PeerId::random();
 
-        let mut request_batch = self.node.get_requests_batch_handle().await;
+        let request_batch = self.node.get_requests_batch_handle().await;
         let mut get_closest_peers_stream = request_batch
             .get_closest_peers(key.into())
             .await

--- a/crates/subspace-service/src/metrics.rs
+++ b/crates/subspace-service/src/metrics.rs
@@ -57,7 +57,7 @@ where
         }
     }
 
-    fn update_block_metrics(&mut self, incoming_block: BlockImportNotification<Block>) {
+    fn update_block_metrics(&self, incoming_block: BlockImportNotification<Block>) {
         let extrinsics = self
             .client
             .block_body(incoming_block.hash)

--- a/domains/client/domain-operator/src/tests.rs
+++ b/domains/client/domain-operator/src/tests.rs
@@ -274,7 +274,7 @@ async fn setup_evm_test_accounts(
     private_evm: bool,
     evm_owner: impl Into<Option<Sr25519Keyring>>,
 ) -> (TempDir, MockConsensusNode, EvmDomainNode, Vec<AccountInfo>) {
-    let (directory, mut ferdie, mut alice) =
+    let (directory, mut ferdie, alice) =
         setup_evm_test_nodes(ferdie_key, private_evm, evm_owner).await;
 
     produce_blocks!(ferdie, alice, 3).await.unwrap();
@@ -361,7 +361,7 @@ async fn open_xdm_channel(ferdie: &mut MockConsensusNode, alice: &mut EvmDomainN
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_private_evm_domain_create_contracts_with_allow_list_default() {
-    let (_directory, mut ferdie, mut alice, account_infos) =
+    let (_directory, mut ferdie, alice, account_infos) =
         setup_evm_test_accounts(Sr25519Alice, true, None).await;
 
     let gas_price = alice
@@ -488,7 +488,7 @@ async fn test_private_evm_domain_create_contracts_with_allow_list_default() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_public_evm_domain_create_contracts() {
-    let (_directory, mut ferdie, mut alice, account_infos) =
+    let (_directory, mut ferdie, alice, account_infos) =
         setup_evm_test_accounts(Sr25519Alice, false, None).await;
 
     let gas_price = alice
@@ -615,7 +615,7 @@ async fn test_public_evm_domain_create_contracts() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_evm_domain_create_contracts_with_allow_list_reject_all() {
-    let (_directory, mut ferdie, mut alice, account_infos) =
+    let (_directory, mut ferdie, alice, account_infos) =
         setup_evm_test_accounts(Sr25519Alice, true, Ferdie).await;
 
     let gas_price = alice
@@ -848,7 +848,7 @@ async fn test_evm_domain_create_contracts_with_allow_list_reject_all() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_evm_domain_create_contracts_with_allow_list_single() {
-    let (_directory, mut ferdie, mut alice, account_infos) =
+    let (_directory, mut ferdie, alice, account_infos) =
         setup_evm_test_accounts(Sr25519Alice, true, Ferdie).await;
 
     let gas_price = alice
@@ -1081,7 +1081,7 @@ async fn test_evm_domain_create_contracts_with_allow_list_single() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_evm_domain_create_contracts_with_allow_list_multiple() {
-    let (_directory, mut ferdie, mut alice, account_infos) =
+    let (_directory, mut ferdie, alice, account_infos) =
         setup_evm_test_accounts(Sr25519Alice, true, Ferdie).await;
 
     // Multiple accounts in the allow list
@@ -1265,7 +1265,7 @@ async fn test_evm_domain_create_contracts_with_allow_list_multiple() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_evm_domain_gas_estimates() {
-    let (_directory, mut ferdie, mut alice, account_infos) =
+    let (_directory, mut ferdie, alice, account_infos) =
         setup_evm_test_accounts(Sr25519Alice, false, None).await;
 
     let test_estimate_gas = |evm_call, is_estimate| {
@@ -2095,7 +2095,7 @@ async fn test_domain_tx_propagate() -> Result<(), tokio::time::error::Elapsed> {
         setup_evm_test_nodes(Ferdie, false, None).timeout().await?;
 
     // Run Bob (a evm domain full node)
-    let mut bob = domain_test_service::DomainNodeBuilder::new(
+    let bob = domain_test_service::DomainNodeBuilder::new(
         tokio::runtime::Handle::current(),
         BasePath::new(directory.path().join("bob")),
     )
@@ -2264,7 +2264,7 @@ async fn test_executor_inherent_timestamp_is_set() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_bad_invalid_bundle_fraud_proof_is_rejected() {
-    let (_directory, mut ferdie, mut alice) = setup_evm_test_nodes(Ferdie, false, None).await;
+    let (_directory, mut ferdie, alice) = setup_evm_test_nodes(Ferdie, false, None).await;
 
     let fraud_proof_generator = FraudProofGenerator::new(
         alice.client.clone(),
@@ -2484,8 +2484,7 @@ async fn test_bad_invalid_bundle_fraud_proof_is_rejected() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_bad_fraud_proof_is_rejected() {
-    let (_directory, mut ferdie, mut alice) =
-        setup_evm_test_nodes(Ferdie, true, Sr25519Alice).await;
+    let (_directory, mut ferdie, alice) = setup_evm_test_nodes(Ferdie, true, Sr25519Alice).await;
 
     let fraud_proof_generator = FraudProofGenerator::new(
         alice.client.clone(),
@@ -2604,7 +2603,7 @@ async fn test_bad_invalid_state_transition_proof_is_rejected() {
     );
 
     // Run Alice (a evm domain authority node)
-    let mut alice = domain_test_service::DomainNodeBuilder::new(
+    let alice = domain_test_service::DomainNodeBuilder::new(
         tokio_handle.clone(),
         BasePath::new(directory.path().join("alice")),
     )
@@ -2859,7 +2858,7 @@ async fn test_invalid_state_transition_proof_creation_and_verification(
     );
 
     // Run Alice (a evm domain authority node)
-    let mut alice = domain_test_service::DomainNodeBuilder::new(
+    let alice = domain_test_service::DomainNodeBuilder::new(
         tokio_handle.clone(),
         BasePath::new(directory.path().join("alice")),
     )
@@ -3032,7 +3031,7 @@ async fn test_true_invalid_bundles_inherent_extrinsic_proof_creation_and_verific
     );
 
     // Run Alice (a evm domain authority node)
-    let mut alice = domain_test_service::DomainNodeBuilder::new(
+    let alice = domain_test_service::DomainNodeBuilder::new(
         tokio_handle.clone(),
         BasePath::new(directory.path().join("alice")),
     )
@@ -3173,7 +3172,7 @@ async fn test_false_invalid_bundles_inherent_extrinsic_proof_creation_and_verifi
     );
 
     // Run Alice (a evm domain authority node)
-    let mut alice = domain_test_service::DomainNodeBuilder::new(
+    let alice = domain_test_service::DomainNodeBuilder::new(
         tokio_handle.clone(),
         BasePath::new(directory.path().join("alice")),
     )
@@ -3283,7 +3282,7 @@ async fn test_true_invalid_bundles_undecodeable_tx_proof_creation_and_verificati
     );
 
     // Run Alice (a evm domain authority node)
-    let mut alice = domain_test_service::DomainNodeBuilder::new(
+    let alice = domain_test_service::DomainNodeBuilder::new(
         tokio_handle.clone(),
         BasePath::new(directory.path().join("alice")),
     )
@@ -3422,7 +3421,7 @@ async fn test_false_invalid_bundles_undecodeable_tx_proof_creation_and_verificat
     );
 
     // Run Alice (a evm domain authority node)
-    let mut alice = domain_test_service::DomainNodeBuilder::new(
+    let alice = domain_test_service::DomainNodeBuilder::new(
         tokio_handle.clone(),
         BasePath::new(directory.path().join("alice")),
     )
@@ -3684,7 +3683,7 @@ async fn test_true_invalid_bundles_illegal_extrinsic_proof_creation_and_verifica
     );
 
     // Run Alice (a evm domain authority node)
-    let mut alice = domain_test_service::DomainNodeBuilder::new(
+    let alice = domain_test_service::DomainNodeBuilder::new(
         tokio_handle.clone(),
         BasePath::new(directory.path().join("alice")),
     )
@@ -3845,7 +3844,7 @@ async fn test_false_invalid_bundles_illegal_extrinsic_proof_creation_and_verific
     );
 
     // Run Alice (a evm domain authority node)
-    let mut alice = domain_test_service::DomainNodeBuilder::new(
+    let alice = domain_test_service::DomainNodeBuilder::new(
         tokio_handle.clone(),
         BasePath::new(directory.path().join("alice")),
     )
@@ -3975,7 +3974,7 @@ async fn test_true_invalid_bundle_weight_proof_creation_and_verification() {
     );
 
     // Run Alice (a evm domain authority node)
-    let mut alice = domain_test_service::DomainNodeBuilder::new(
+    let alice = domain_test_service::DomainNodeBuilder::new(
         tokio_handle.clone(),
         BasePath::new(directory.path().join("alice")),
     )
@@ -4092,7 +4091,7 @@ async fn test_false_invalid_bundle_weight_proof_creation_and_verification() {
     );
 
     // Run Alice (a evm domain authority node)
-    let mut alice = domain_test_service::DomainNodeBuilder::new(
+    let alice = domain_test_service::DomainNodeBuilder::new(
         tokio_handle.clone(),
         BasePath::new(directory.path().join("alice")),
     )
@@ -4200,7 +4199,7 @@ async fn test_false_invalid_bundles_non_exist_extrinsic_proof_creation_and_verif
     );
 
     // Run Alice (a evm domain authority node)
-    let mut alice = domain_test_service::DomainNodeBuilder::new(
+    let alice = domain_test_service::DomainNodeBuilder::new(
         tokio_handle.clone(),
         BasePath::new(directory.path().join("alice")),
     )
@@ -4388,7 +4387,7 @@ async fn test_invalid_transfers_fraud_proof() {
     );
 
     // Run Alice (a evm domain authority node)
-    let mut alice = domain_test_service::DomainNodeBuilder::new(
+    let alice = domain_test_service::DomainNodeBuilder::new(
         tokio_handle.clone(),
         BasePath::new(directory.path().join("alice")),
     )
@@ -4487,7 +4486,7 @@ async fn test_invalid_domain_block_hash_proof_creation() {
     );
 
     // Run Alice (a evm domain authority node)
-    let mut alice = domain_test_service::DomainNodeBuilder::new(
+    let alice = domain_test_service::DomainNodeBuilder::new(
         tokio_handle.clone(),
         BasePath::new(directory.path().join("alice")),
     )
@@ -4581,7 +4580,7 @@ async fn test_invalid_domain_extrinsics_root_proof_creation() {
     );
 
     // Run Alice (a evm domain authority node)
-    let mut alice = domain_test_service::DomainNodeBuilder::new(
+    let alice = domain_test_service::DomainNodeBuilder::new(
         tokio_handle.clone(),
         BasePath::new(directory.path().join("alice")),
     )
@@ -4675,7 +4674,7 @@ async fn test_domain_block_builder_include_ext_with_failed_execution() {
     );
 
     // Run Alice (a evm domain authority node)
-    let mut alice = domain_test_service::DomainNodeBuilder::new(
+    let alice = domain_test_service::DomainNodeBuilder::new(
         tokio_handle.clone(),
         BasePath::new(directory.path().join("alice")),
     )
@@ -4758,7 +4757,7 @@ async fn test_domain_block_builder_include_ext_with_failed_predispatch() {
     );
 
     // Run Alice (a evm domain authority node)
-    let mut alice = domain_test_service::DomainNodeBuilder::new(
+    let alice = domain_test_service::DomainNodeBuilder::new(
         tokio_handle.clone(),
         BasePath::new(directory.path().join("alice")),
     )
@@ -4862,7 +4861,7 @@ async fn test_valid_bundle_proof_generation_and_verification() {
     );
 
     // Run Alice (a evm domain authority node)
-    let mut alice = domain_test_service::DomainNodeBuilder::new(
+    let alice = domain_test_service::DomainNodeBuilder::new(
         tokio_handle.clone(),
         BasePath::new(directory.path().join("alice")),
     )
@@ -5941,7 +5940,7 @@ async fn test_xdm_between_domains_should_work() {
     );
 
     // Run Alice (a system domain authority node)
-    let mut alice = domain_test_service::DomainNodeBuilder::new(
+    let alice = domain_test_service::DomainNodeBuilder::new(
         tokio_handle.clone(),
         BasePath::new(directory.path().join("alice")),
     )
@@ -5949,7 +5948,7 @@ async fn test_xdm_between_domains_should_work() {
     .await;
 
     // Run Bob (a auto-id domain authority node)
-    let mut bob = domain_test_service::DomainNodeBuilder::new(
+    let bob = domain_test_service::DomainNodeBuilder::new(
         tokio_handle.clone(),
         BasePath::new(directory.path().join("bob")),
     )
@@ -6215,7 +6214,7 @@ async fn test_domain_transaction_fee_and_operator_reward() {
     );
 
     // Run Alice (a evm domain authority node)
-    let mut alice = domain_test_service::DomainNodeBuilder::new(
+    let alice = domain_test_service::DomainNodeBuilder::new(
         tokio_handle.clone(),
         BasePath::new(directory.path().join("alice")),
     )
@@ -6290,7 +6289,7 @@ async fn test_multiple_consensus_blocks_derive_similar_domain_block() {
     );
 
     // Run Alice (a evm domain authority node)
-    let mut alice = domain_test_service::DomainNodeBuilder::new(
+    let alice = domain_test_service::DomainNodeBuilder::new(
         tokio_handle.clone(),
         BasePath::new(directory.path().join("alice")),
     )
@@ -6420,7 +6419,7 @@ async fn test_skip_empty_bundle_production() {
     );
 
     // Run Alice (a evm domain authority node) with `skip_empty_bundle_production` set to `true`
-    let mut alice = domain_test_service::DomainNodeBuilder::new(
+    let alice = domain_test_service::DomainNodeBuilder::new(
         tokio_handle.clone(),
         BasePath::new(directory.path().join("alice")),
     )
@@ -7497,7 +7496,7 @@ async fn test_custom_api_storage_root_match_upstream_root() {
     );
 
     // Run Alice (a evm domain authority node)
-    let mut alice = domain_test_service::DomainNodeBuilder::new(
+    let alice = domain_test_service::DomainNodeBuilder::new(
         tokio_handle.clone(),
         BasePath::new(directory.path().join("alice")),
     )
@@ -8059,7 +8058,7 @@ async fn test_current_block_number_used_as_new_account_nonce() {
     );
 
     // Run Alice (a evm domain authority node)
-    let mut alice = domain_test_service::DomainNodeBuilder::new(
+    let alice = domain_test_service::DomainNodeBuilder::new(
         tokio_handle.clone(),
         BasePath::new(directory.path().join("alice")),
     )
@@ -8067,7 +8066,7 @@ async fn test_current_block_number_used_as_new_account_nonce() {
     .await;
 
     // Run Bob (a auto-id domain authority node)
-    let mut bob = domain_test_service::DomainNodeBuilder::new(
+    let bob = domain_test_service::DomainNodeBuilder::new(
         tokio_handle.clone(),
         BasePath::new(directory.path().join("bob")),
     )

--- a/domains/test/service/src/domain.rs
+++ b/domains/test/service/src/domain.rs
@@ -325,7 +325,7 @@ where
     }
 
     /// Sends a signed system.remark extrinsic to the pool containing the current account nonce.
-    pub async fn send_system_remark(&mut self) {
+    pub async fn send_system_remark(&self) {
         let nonce = self.account_nonce();
         let _ = self
             .construct_and_send_extrinsic(frame_system::Call::remark {
@@ -337,7 +337,7 @@ where
 
     /// Construct a signed extrinsic with the current nonce of the node account and send it to this node.
     pub async fn construct_and_send_extrinsic(
-        &mut self,
+        &self,
         function: impl Into<<Runtime as frame_system::Config>::RuntimeCall>,
     ) -> Result<RpcTransactionOutput, RpcTransactionError> {
         self.construct_and_send_extrinsic_with(self.account_nonce(), 0.into(), function)
@@ -364,7 +364,7 @@ where
 
     /// Construct a signed extrinsic.
     pub fn construct_extrinsic(
-        &mut self,
+        &self,
         nonce: u32,
         function: impl Into<<Runtime as frame_system::Config>::RuntimeCall>,
     ) -> UncheckedExtrinsicFor<Runtime> {
@@ -380,7 +380,7 @@ where
 
     /// Construct a signed extrinsic with the given transaction tip.
     pub fn construct_extrinsic_with_tip(
-        &mut self,
+        &self,
         nonce: u32,
         tip: BalanceOf<Runtime>,
         function: impl Into<<Runtime as frame_system::Config>::RuntimeCall>,
@@ -437,7 +437,7 @@ where
 
     /// Construct an unsigned extrinsic and send it to this node.
     pub async fn construct_and_send_unsigned_extrinsic(
-        &mut self,
+        &self,
         function: impl Into<<Runtime as frame_system::Config>::RuntimeCall>,
     ) -> Result<RpcTransactionOutput, RpcTransactionError> {
         let extrinsic = self.construct_unsigned_extrinsic(function);

--- a/test/subspace-test-service/src/lib.rs
+++ b/test/subspace-test-service/src/lib.rs
@@ -763,7 +763,7 @@ impl MockConsensusNode {
 
     /// Subscribe the block importing notification
     pub fn block_importing_notification_stream(
-        &mut self,
+        &self,
     ) -> TracingUnboundedReceiver<(NumberFor<Block>, mpsc::Sender<()>)> {
         self.block_import.block_importing_notification_stream()
     }
@@ -1002,7 +1002,7 @@ impl MockConsensusNode {
 
     /// Import block
     async fn import_block(
-        &mut self,
+        &self,
         block: Block,
         storage_changes: Option<StorageChanges>,
     ) -> Result<<Block as BlockT>::Hash, Box<dyn Error>> {
@@ -1143,7 +1143,7 @@ impl MockConsensusNode {
 
     /// Construct an extrinsic.
     pub fn construct_extrinsic(
-        &mut self,
+        &self,
         nonce: u32,
         function: impl Into<<Runtime as frame_system::Config>::RuntimeCall>,
     ) -> UncheckedExtrinsic {
@@ -1160,7 +1160,7 @@ impl MockConsensusNode {
 
     /// Construct and send extrinsic through rpc
     pub async fn construct_and_send_extrinsic_with(
-        &mut self,
+        &self,
         function: impl Into<<Runtime as frame_system::Config>::RuntimeCall>,
     ) -> Result<RpcTransactionOutput, RpcTransactionError> {
         let nonce = self.account_nonce();
@@ -1170,7 +1170,7 @@ impl MockConsensusNode {
 
     /// Get the nonce of the given account
     pub async fn send_extrinsic(
-        &mut self,
+        &self,
         extrinsic: impl Into<OpaqueExtrinsic>,
     ) -> Result<RpcTransactionOutput, RpcTransactionError> {
         self.rpc_handlers.send_transaction(extrinsic.into()).await
@@ -1253,7 +1253,7 @@ impl<Client, Block: BlockT> MockBlockImport<Client, Block> {
 
     // Subscribe the block importing notification
     fn block_importing_notification_stream(
-        &mut self,
+        &self,
     ) -> TracingUnboundedReceiver<(NumberFor<Block>, mpsc::Sender<()>)> {
         let (tx, rx) = tracing_unbounded("subspace_new_slot_notification_stream", 100);
         self.block_importing_notification_subscribers


### PR DESCRIPTION
Recently in the 2024 edition, `let_chains` has been stabilized, so I wanted to upgrade.

But I ran into some errors—some of them were caused by unnecessary `&mut` due to the changes in how RPIT (return position impl trait) captures lifetimes.

So I took a closer look at the whole repo, and as it turns out, there are quite a few of them :)

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
