### PR TITLE
Fix DSN snap sync block import gap errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2883,6 +2883,7 @@ dependencies = [
  "frame-system",
  "futures",
  "futures-timer",
+ "hex",
  "hex-literal",
  "pallet-balances",
  "pallet-domain-sudo",

--- a/crates/sc-domains/src/domain_block_er/receipt_receiver.rs
+++ b/crates/sc-domains/src/domain_block_er/receipt_receiver.rs
@@ -183,15 +183,13 @@ where
         }
 
         // Find the receipt with the maximum votes
-        if let Some(max_receipt_vote) = receipts_hashes.values().max() {
-            if let Some((receipt_hash, _)) = receipts_hashes
-                .iter()
-                .find(|(_, vote)| max_receipt_vote == *vote)
-            {
-                return receipts.get(receipt_hash).cloned();
-            }
-        } else {
-            debug!(target: LOG_TARGET, "Couldn't find last confirmed domain block execution receipt: no receipts.");
+        if let Some((max_voted_receipt_hash, _max_receipt_votes)) = receipts_hashes
+            .into_iter()
+            .max_by_key(|(_receipt_hash, receipt_votes)| *receipt_votes)
+        {
+            // We're about to drop receipts, so removing the receipt saves a clone.
+            // This is always Some, because every receipt has a hash and a vote.
+            return receipts.remove(&max_voted_receipt_hash);
         }
 
         error!(target: LOG_TARGET, "Couldn't find last confirmed domain block execution receipt.");

--- a/crates/sc-domains/src/domain_block_er/receipt_receiver.rs
+++ b/crates/sc-domains/src/domain_block_er/receipt_receiver.rs
@@ -93,8 +93,13 @@ where
     ) -> Option<ExecutionReceiptFor<Block::Header, CBlock, Balance>> {
         let info = self.consensus_client.info();
         let protocol_name = generate_protocol_name(info.genesis_hash, self.fork_id.as_deref());
+        // Used to debug failures
+        let mut peers_not_synced = 0;
+        let mut peer_request_errors = 0;
+        let mut peer_responses = 0;
 
-        debug!(target: LOG_TARGET,
+        debug!(
+            target: LOG_TARGET,
             domain_id=%self.domain_id,
             %protocol_name,
             "Started obtaining last confirmed domain block ER..."
@@ -119,6 +124,9 @@ where
             'peers: for (peer_id, peer_info) in peers_info.iter() {
                 debug!(
                     target: LOG_TARGET,
+                    %peers_not_synced,
+                    %peer_request_errors,
+                    %peer_responses,
                     "Domain block ER request. peer = {peer_id}, info = {:?}",
                     peer_info
                 );
@@ -129,7 +137,16 @@ where
                 }
 
                 if !peer_info.is_synced {
-                    trace!(target: LOG_TARGET, %attempt, %peer_id, "Domain data request skipped (not synced).");
+                    peers_not_synced += 1;
+                    trace!(
+                        target: LOG_TARGET,
+                        %attempt,
+                        %peer_id,
+                        %peers_not_synced,
+                        %peer_request_errors,
+                        %peer_responses,
+                        "Domain data request skipped (not synced).",
+                    );
                     continue 'peers;
                 }
 
@@ -145,10 +162,14 @@ where
                 match response {
                     Ok(response) => {
                         let DomainBlockERResponse::LastConfirmedER(receipt) = response;
+                        peer_responses += 1;
                         trace!(
                             target: LOG_TARGET,
                             %attempt,
-                            "Response from a peer {peer_id}: {receipt:?}"
+                            %peers_not_synced,
+                            %peer_request_errors,
+                            %peer_responses,
+                            "Response from a peer {peer_id}: {receipt:?}",
                         );
 
                         let receipt_hash = KeccakHasher::hash(&receipt.encode());
@@ -160,26 +181,45 @@ where
                             .or_insert(1u32);
                     }
                     Err(error) => {
-                        debug!(target: LOG_TARGET, %attempt, "Domain block ER request failed. peer = {peer_id}: {error}");
+                        peer_request_errors += 1;
+                        debug!(
+                            target: LOG_TARGET,
+                            %attempt,
+                            %peers_not_synced,
+                            %peer_request_errors,
+                            %peer_responses,
+                            "Domain block ER request failed. peer = {peer_id}: {error}",
+                        );
                         continue 'peers;
                     }
                 }
             }
-            debug!(
-                target: LOG_TARGET,
-                domain_id=%self.domain_id,
-                "No synced peers to handle the domain confirmed block info request. Pausing..."
-            );
 
             if peers_hashes.len() >= PEERS_THRESHOLD {
                 break;
             }
 
+            debug!(
+                target: LOG_TARGET,
+                domain_id=%self.domain_id,
+                %peers_not_synced,
+                %peer_request_errors,
+                %peer_responses,
+                "No synced peers to handle the domain confirmed block info request. Pausing..."
+            );
             sleep(REQUEST_PAUSE).await;
         }
 
         if peers_hashes.len() < PEERS_THRESHOLD {
-            debug!(target: LOG_TARGET, peers=%peers_hashes.len(), "Couldn't pass peer threshold for receipts.");
+            debug!(
+                target: LOG_TARGET,
+                peers=%peers_hashes.len(),
+                %PEERS_THRESHOLD,
+                %peers_not_synced,
+                %peer_request_errors,
+                %peer_responses,
+                "Couldn't pass peer threshold for receipts, trying snap sync anyway.",
+            );
         }
 
         // Find the receipt with the maximum votes
@@ -192,7 +232,13 @@ where
             return receipts.remove(&max_voted_receipt_hash);
         }
 
-        error!(target: LOG_TARGET, "Couldn't find last confirmed domain block execution receipt.");
+        error!(
+            target: LOG_TARGET,
+            %peers_not_synced,
+            %peer_request_errors,
+            %peer_responses,
+            "Couldn't find last confirmed domain block execution receipt: no receipts.",
+        );
         None
     }
 }

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/shared/network.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/shared/network.rs
@@ -226,8 +226,8 @@ where
                 }
                 .in_current_span()
             }),
-            SegmentHeaderBySegmentIndexesRequestHandler::create(move |_, req| {
-                debug!(?req, "Segment headers request received.");
+            SegmentHeaderBySegmentIndexesRequestHandler::create(move |peer_id, req| {
+                debug!(%peer_id, ?req, "Segment headers request received.");
 
                 let node_client = node_client.clone();
 
@@ -238,16 +238,23 @@ where
 
                             if segment_indexes.len() > SEGMENT_HEADERS_LIMIT as usize {
                                 debug!(
-                                    "segment_indexes length exceed the limit: {} ",
-                                    segment_indexes.len()
+                                    %peer_id,
+                                    segment_indexes_count = %segment_indexes.len(),
+                                    %SEGMENT_HEADERS_LIMIT,
+                                    first_segment_index = ?segment_indexes.first(),
+                                    last_segment_index = ?segment_indexes.last(),
+                                    "segment_indexes length exceed the limit",
                                 );
 
                                 return None;
                             }
 
                             debug!(
-                                segment_indexes_count = ?segment_indexes.len(),
-                                "Segment headers request received."
+                                %peer_id,
+                                segment_indexes_count = %segment_indexes.len(),
+                                first_segment_index = ?segment_indexes.first(),
+                                last_segment_index = ?segment_indexes.last(),
+                                "Segment headers request received.",
                             );
 
                             node_client.segment_headers(segment_indexes).await
@@ -255,8 +262,10 @@ where
                         SegmentHeaderRequest::LastSegmentHeaders { mut limit } => {
                             if limit > SEGMENT_HEADERS_LIMIT {
                                 debug!(
+                                    %peer_id,
                                     %limit,
-                                    "Segment header number exceeded the limit."
+                                    %SEGMENT_HEADERS_LIMIT,
+                                    "Segment header number exceeded the limit.",
                                 );
 
                                 limit = SEGMENT_HEADERS_LIMIT;

--- a/crates/subspace-service/src/sync_from_dsn.rs
+++ b/crates/subspace-service/src/sync_from_dsn.rs
@@ -316,7 +316,7 @@ where
 
         info!(target: LOG_TARGET, ?reason, "Received notification to sync from DSN");
         // TODO: Maybe handle failed block imports, additional helpful logging
-        let import_froms_from_dsn_fut = import_blocks_from_dsn(
+        let import_blocks_from_dsn_fut = import_blocks_from_dsn(
             &segment_headers_store,
             &segment_header_downloader,
             client,
@@ -347,7 +347,7 @@ where
         };
 
         select! {
-            result = import_froms_from_dsn_fut.fuse() => {
+            result = import_blocks_from_dsn_fut.fuse() => {
                 if let Err(error) = result {
                     warn!(target: LOG_TARGET, %error, "Error when syncing blocks from DSN");
                 }

--- a/crates/subspace-service/src/sync_from_dsn/import_blocks.rs
+++ b/crates/subspace-service/src/sync_from_dsn/import_blocks.rs
@@ -160,9 +160,9 @@ where
                     .block(
                         client
                             .hash(block_number)?
-                            .expect("Block before best block number must always be found; qed"),
+                            .expect("Genesis block hash must always be found; qed"),
                     )?
-                    .expect("Block before best block number must always be found; qed");
+                    .expect("Genesis block data must always be found; qed");
 
                 if encode_block(signed_block) != block_bytes {
                     return Err(Error::Other(
@@ -177,6 +177,7 @@ where
             // insignificant. Feel free to address this in case you have a good strategy, but it
             // seems like complexity is not worth it.
             while block_number.saturating_sub(best_block_number) >= QUEUED_BLOCKS_LIMIT.into() {
+                let just_queued_blocks_count = blocks_to_import.len();
                 if !blocks_to_import.is_empty() {
                     // This vector is quite large (~150kB), so replacing it with an uninitialized
                     // vector with the correct capacity is faster than cloning and clearing it.
@@ -194,6 +195,8 @@ where
                     target: LOG_TARGET,
                     %block_number,
                     %best_block_number,
+                    %just_queued_blocks_count,
+                    %QUEUED_BLOCKS_LIMIT,
                     "Number of importing blocks reached queue limit, waiting before retrying"
                 );
                 tokio::time::sleep(WAIT_FOR_BLOCKS_TO_IMPORT).await;

--- a/crates/subspace-service/src/sync_from_dsn/import_blocks.rs
+++ b/crates/subspace-service/src/sync_from_dsn/import_blocks.rs
@@ -186,7 +186,7 @@ where
             let signed_block =
                 decode_block::<Block>(&block_bytes).map_err(|error| error.to_string())?;
 
-            *last_processed_block_number = last_archived_block_number;
+            *last_processed_block_number = block_number;
 
             // No need to import blocks that are already present, if block is not present it might
             // correspond to a short fork, so we need to import it even if we already have another

--- a/crates/subspace-service/src/sync_from_dsn/segment_header_downloader.rs
+++ b/crates/subspace-service/src/sync_from_dsn/segment_header_downloader.rs
@@ -383,7 +383,14 @@ impl<'a> SegmentHeaderDownloader<'a> {
 
             match request_result {
                 Ok(SegmentHeaderResponse { segment_headers }) => {
-                    trace!(target: LOG_TARGET, %peer_id, ?segment_indexes, "Segment header request succeeded");
+                    trace!(
+                        target: LOG_TARGET,
+                        %peer_id,
+                        segment_indexes_count = %segment_indexes.len(),
+                        first_segment_index = ?segment_indexes.first(),
+                        last_segment_index = ?segment_indexes.last(),
+                        "Segment header request succeeded",
+                    );
 
                     if !self.is_segment_headers_response_valid(
                         peer_id,
@@ -398,7 +405,15 @@ impl<'a> SegmentHeaderDownloader<'a> {
                     return Ok((peer_id, segment_headers));
                 }
                 Err(error) => {
-                    debug!(target: LOG_TARGET, %peer_id, ?segment_indexes, ?error, "Segment header request failed");
+                    debug!(
+                        target: LOG_TARGET,
+                        %peer_id,
+                        ?error,
+                        segment_indexes_count = %segment_indexes.len(),
+                        first_segment_index = ?segment_indexes.first(),
+                        last_segment_index = ?segment_indexes.last(),
+                        "Segment header request failed",
+                    );
                 }
             };
         }

--- a/domains/client/domain-operator/Cargo.toml
+++ b/domains/client/domain-operator/Cargo.toml
@@ -12,6 +12,7 @@ domain-block-preprocessor.workspace = true
 domain-runtime-primitives.workspace = true
 futures.workspace = true
 futures-timer.workspace = true
+hex.workspace = true
 parking_lot.workspace = true
 sc-client-api.workspace = true
 sc-consensus.workspace = true

--- a/domains/client/domain-operator/src/snap_sync.rs
+++ b/domains/client/domain-operator/src/snap_sync.rs
@@ -188,7 +188,7 @@ async fn get_last_confirmed_block<Block: BlockT>(
                     target: LOG_TARGET,
                     %block_number,
                     "Sync worker handle result: {:?}",
-                    block_response_inner_result
+                    block_response_inner_result.as_ref().map(|(block_data, protocol_name)| (hex::encode(block_data), protocol_name))
                 );
 
                 match block_response_inner_result {


### PR DESCRIPTION
The DSN snap sync block reconstruction code contains some errors that almost cancel each other out:
- the last processed block is set to the last (usually) partial block in the segment, not the block that was just processed
- the archiver reset check uses the last (usually) partial block in the segment, not the last full block in the segment

This PR also fixes some incorrect and verbose log messages, which made this issue trickier to debug.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
