### PR TITLE
Skip marking domain block finalization when the consensus header is missing

### DIFF
--- a/domains/client/domain-operator/src/snap_sync.rs
+++ b/domains/client/domain-operator/src/snap_sync.rs
@@ -305,7 +305,7 @@ where
     )
     .await?;
 
-    let Some(domain_block_header) = domain_block.header.clone() else {
+    let Some(domain_block_header) = domain_block.header else {
         return Err(sp_blockchain::Error::MissingHeader(
             "Can't obtain domain block header for snap sync".to_string(),
         ));


### PR DESCRIPTION
If the consensus node synced through snap sync, when domain is trying to finalize a domain block it would try to get the best_consensus_block - confirmation_depth_k. The resultant may not be available if the consensus snap sync's first imported block is more than the resultant block leading to missing header error.

In such cases, we can skip finalizaing domain block until the next consensus header is available.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
