### PR TITLE
Ensure minting funds after fallible checks and skip transfer checks on XDM when disabled

### DIFF
--- a/crates/sp-domains/src/lib.rs
+++ b/crates/sp-domains/src/lib.rs
@@ -1622,6 +1622,16 @@ pub enum OperatorRewardSource<Number> {
     Dummy,
 }
 
+pub trait SkipBalanceChecks {
+    fn should_skip_balance_check(chain_id: ChainId) -> bool;
+}
+
+impl SkipBalanceChecks for () {
+    fn should_skip_balance_check(_chain_id: ChainId) -> bool {
+        false
+    }
+}
+
 sp_api::decl_runtime_apis! {
     /// APIs used to access the domains pallet.
     // When updating this version, document new APIs with "Only present in API versions" comments.

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -808,6 +808,7 @@ impl pallet_transporter::Config for Runtime {
     type Sender = Messenger;
     type AccountIdConverter = AccountIdConverter;
     type WeightInfo = pallet_transporter::weights::SubstrateWeight<Runtime>;
+    type SkipBalanceTransferChecks = pallet_domains::DomainsSkipBalanceChecks<Runtime>;
 }
 
 parameter_types! {

--- a/domains/pallets/messenger/src/mock.rs
+++ b/domains/pallets/messenger/src/mock.rs
@@ -180,6 +180,7 @@ macro_rules! impl_runtime {
             type Sender = Messenger;
             type AccountIdConverter = MockAccountIdConverter;
             type WeightInfo = ();
+            type SkipBalanceTransferChecks = ();
         }
 
         pub const USER_ACCOUNT: AccountId = 1;
@@ -213,6 +214,7 @@ impl EndpointHandler<MessageId> for MockEndpoint {
         _src_chain_id: ChainId,
         _message_id: MessageId,
         req: EndpointRequest,
+        _pre_check_result: DispatchResult,
     ) -> EndpointResponse {
         let req = req.payload;
         assert_eq!(req, vec![1, 2, 3, 4]);

--- a/domains/pallets/transporter/src/benchmarking.rs
+++ b/domains/pallets/transporter/src/benchmarking.rs
@@ -77,7 +77,8 @@ mod benchmarks {
             assert_ok!(EndpointHandler(PhantomData::<T>).message(
                 dst_chain_id,
                 message_id,
-                endpoint_req
+                endpoint_req,
+                Ok(())
             ));
         }
     }

--- a/domains/pallets/transporter/src/mock.rs
+++ b/domains/pallets/transporter/src/mock.rs
@@ -171,6 +171,7 @@ impl Config for MockRuntime {
     type Sender = Messenger;
     type AccountIdConverter = MockAccountIdConverter;
     type WeightInfo = ();
+    type SkipBalanceTransferChecks = ();
 }
 
 pub const USER_ACCOUNT: AccountId = 1;

--- a/domains/pallets/transporter/src/tests.rs
+++ b/domains/pallets/transporter/src/tests.rs
@@ -147,6 +147,7 @@ fn submit_transfer(src_chain_id: ChainId, req_payload: Vec<u8>) -> EndpointRespo
             dst_endpoint: Endpoint::Id(SelfEndpointId::get()),
             payload: req_payload,
         },
+        Ok(()),
     )
 }
 

--- a/domains/primitives/messenger/src/endpoint.rs
+++ b/domains/primitives/messenger/src/endpoint.rs
@@ -94,6 +94,8 @@ pub trait EndpointHandler<MessageId> {
         src_chain_id: ChainId,
         message_id: MessageId,
         req: EndpointRequest,
+        // if pre_checks failed, implementation should reject the transfer
+        pre_check_result: DispatchResult,
     ) -> EndpointResponse;
 
     /// Return the maximal possible consume weight of `message`
@@ -122,6 +124,7 @@ impl<MessageId> EndpointHandler<MessageId> for BenchmarkEndpointHandler {
         _src_chain_id: ChainId,
         _message_id: MessageId,
         _req: EndpointRequest,
+        _pre_check_result: DispatchResult,
     ) -> EndpointResponse {
         Ok(Vec::new())
     }

--- a/domains/runtime/auto-id/src/lib.rs
+++ b/domains/runtime/auto-id/src/lib.rs
@@ -470,6 +470,7 @@ impl pallet_transporter::Config for Runtime {
     type Sender = Messenger;
     type AccountIdConverter = domain_runtime_primitives::AccountIdConverter;
     type WeightInfo = pallet_transporter::weights::SubstrateWeight<Runtime>;
+    type SkipBalanceTransferChecks = ();
 }
 
 impl pallet_domain_id::Config for Runtime {}

--- a/domains/runtime/evm/src/lib.rs
+++ b/domains/runtime/evm/src/lib.rs
@@ -617,6 +617,7 @@ impl pallet_transporter::Config for Runtime {
     type Sender = Messenger;
     type AccountIdConverter = domain_runtime_primitives::AccountId20Converter;
     type WeightInfo = pallet_transporter::weights::SubstrateWeight<Runtime>;
+    type SkipBalanceTransferChecks = ();
 }
 
 impl pallet_evm_chain_id::Config for Runtime {}

--- a/domains/test/runtime/auto-id/src/lib.rs
+++ b/domains/test/runtime/auto-id/src/lib.rs
@@ -468,6 +468,7 @@ impl pallet_transporter::Config for Runtime {
     type Sender = Messenger;
     type AccountIdConverter = domain_runtime_primitives::AccountIdConverter;
     type WeightInfo = pallet_transporter::weights::SubstrateWeight<Runtime>;
+    type SkipBalanceTransferChecks = ();
 }
 
 impl pallet_domain_id::Config for Runtime {}

--- a/domains/test/runtime/evm/src/lib.rs
+++ b/domains/test/runtime/evm/src/lib.rs
@@ -655,6 +655,7 @@ impl pallet_transporter::Config for Runtime {
     type Sender = Messenger;
     type AccountIdConverter = domain_runtime_primitives::AccountId20Converter;
     type WeightInfo = pallet_transporter::weights::SubstrateWeight<Runtime>;
+    type SkipBalanceTransferChecks = ();
 }
 
 impl pallet_evm_chain_id::Config for Runtime {}

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -764,6 +764,7 @@ impl pallet_transporter::Config for Runtime {
     type Sender = Messenger;
     type AccountIdConverter = AccountIdConverter;
     type WeightInfo = pallet_transporter::weights::SubstrateWeight<Runtime>;
+    type SkipBalanceTransferChecks = ();
 }
 
 parameter_types! {


### PR DESCRIPTION
PR ensures 
- Funds are minted during XDM transfer after all the fallible checks are done
- Ensure the transfer checks are disabled when Domain balance tracking is disabled
- Ensures pre_checks such as chain not in the allowlist marks the incoming XDM as failed so that src_chain can claimed the rejected transfers

Closes: #3512
Closes:  #3511

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
