### PR TITLE
Ignore rustsec advisories for wasmtime

### DIFF
--- a/.github/workflows/rustsec-audit.yml
+++ b/.github/workflows/rustsec-audit.yml
@@ -22,4 +22,6 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           # TODO: Remove first once Substrate upgrades litep2p and we no longer have rustls 0.20.9 in our dependencies
           # TODO: Remove second once Substrate upgrades litep2p and sc-network and we no longer have ring 0.16 in our dependencies
-          ignore: RUSTSEC-2024-0336, RUSTSEC-2025-0009
+          # TODO: Remove third once Substrate upgrades wasmtime and we no longer have wasmtime <= 9 in our dependencies
+          # TODO: Remove fourth once Substrate upgrades wasmtime and we no longer have wasmtime <= 23 in our dependencies
+          ignore: RUSTSEC-2024-0336, RUSTSEC-2025-0009, RUSTSEC-2023-0091, RUSTSEC-2024-0438


### PR DESCRIPTION
[RUSTSEC-2023-0091](https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-gw5p-q8mj-p7gh) can be ignored because:
* `polkadot-sdk` disables the [`wasm-simd` feature](https://github.com/search?q=repo%3Aparitytech%2Fpolkadot-sdk%20%20wasm_simd&type=code) at execution time, and
* we use [`target-cpu=mvp`](https://github.com/autonomys/polkadot-sdk/blob/ad62cc9ef87e5c004b1432bbc4ad7c3ef2980ec6/substrate/utils/wasm-builder/src/wasm_project.rs#L841) at compile time

[RUSTSEC-2024-0438](https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-c2f5-jxjv-2hh8) can be ignored because we don't run untrusted code - runtimes are only deployed with the sudo multisig.

Original CI output here:
https://github.com/autonomys/subspace/pull/3506/checks?check_run_id=41693893084

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
