### PR TITLE
Fix off-by-one error in snap sync block reconstruction

### DIFF
--- a/crates/subspace-service/src/sync_from_dsn/import_blocks.rs
+++ b/crates/subspace-service/src/sync_from_dsn/import_blocks.rs
@@ -98,19 +98,13 @@ where
             "Checking segment header"
         );
 
-        let last_full_archived_block_number = if last_archived_block_partial {
-            // The genesis block is always fully reconstructed, so we can saturating_sub here
-            NumberFor::<Block>::from(last_archived_maybe_partial_block_number)
-                .saturating_sub(1u32.into())
-        } else {
-            NumberFor::<Block>::from(last_archived_maybe_partial_block_number)
-        };
-
         let info = client.info();
-        // We have already processed the last block that's completely in this segment, or one
-        // higher than it, so it can't change. Resetting the reconstructor loses any partial
-        // blocks, so we only reset based on fully reconstructed blocks.
-        if *last_processed_block_number >= last_full_archived_block_number {
+        let last_archived_maybe_partial_block_number =
+            NumberFor::<Block>::from(last_archived_maybe_partial_block_number);
+        // We have already processed the last block in this segment, or one higher than it,
+        // so it can't change. Resetting the reconstructor loses any partial blocks, so we
+        // only reset if the (possibly partial) last block has been processed.
+        if *last_processed_block_number >= last_archived_maybe_partial_block_number {
             *last_processed_segment_index = segment_index;
             // Reset reconstructor instance
             reconstructor = Arc::new(Mutex::new(Reconstructor::new(erasure_coding.clone())));
@@ -118,8 +112,6 @@ where
         }
         // Just one partial unprocessed block and this was the last segment available, so nothing to
         // import
-        let last_archived_maybe_partial_block_number =
-            NumberFor::<Block>::from(last_archived_maybe_partial_block_number);
         if last_archived_maybe_partial_block_number == *last_processed_block_number + One::one()
             && last_archived_block_partial
             && segment_indices_iter.peek().is_none()


### PR DESCRIPTION
This PR keeps the partial block from the last segment around in the reconstructor, until that block has been processed. (The reconstructor needs the state from two segments to reconstruct a partial block.)

I don't know why this is only triggering on the second-last segment. Maybe we're ending one of the inner loops when we're close to running out of segments, then doing the processed block check again.

I think the previous fix in PR #3506 was the wrong way around - I was confused because the check was originally in reverse order.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
