### PR TITLE
Improve segment downloading performance during DSN sync

### DIFF
--- a/crates/sc-domains/src/domain_block_er/receipt_receiver.rs
+++ b/crates/sc-domains/src/domain_block_er/receipt_receiver.rs
@@ -22,8 +22,8 @@ use std::time::Duration;
 use tokio::time::sleep;
 use tracing::{debug, error, trace};
 
-const REQUEST_PAUSE: Duration = Duration::from_secs(5);
-const ATTEMPTS_NUMBER: u32 = 10;
+const REQUEST_PAUSE: Duration = Duration::from_secs(15);
+const ATTEMPTS_NUMBER: u32 = 20;
 const PEERS_THRESHOLD: usize = 20;
 
 /// Last confirmed domain block info error.

--- a/crates/subspace-service/src/sync_from_dsn/import_blocks.rs
+++ b/crates/subspace-service/src/sync_from_dsn/import_blocks.rs
@@ -31,7 +31,7 @@ const WAIT_FOR_BLOCKS_TO_IMPORT: Duration = Duration::from_secs(1);
 #[allow(clippy::too_many_arguments)]
 pub(super) async fn import_blocks_from_dsn<Block, AS, Client, PG, IQS>(
     segment_headers_store: &SegmentHeadersStore<AS>,
-    segment_header_downloader: &SegmentHeaderDownloader<'_>,
+    segment_header_downloader: &SegmentHeaderDownloader,
     client: &Client,
     piece_getter: &PG,
     import_queue_service: &mut IQS,

--- a/crates/subspace-service/src/sync_from_dsn/segment_header_downloader.rs
+++ b/crates/subspace-service/src/sync_from_dsn/segment_header_downloader.rs
@@ -62,12 +62,11 @@ impl<'a> SegmentHeaderDownloader<'a> {
             "Downloading segment headers"
         );
 
-        let Some(new_segment_headers_count) = last_segment_header
+        let new_segment_headers_count = last_segment_header
             .segment_index()
             .checked_sub(last_known_segment_index)
-        else {
-            return Ok(Vec::new());
-        };
+            .expect("just checked last_segment_header is greater; qed");
+
         let mut new_segment_headers =
             Vec::with_capacity(u64::from(new_segment_headers_count) as usize);
         new_segment_headers.push(last_segment_header);

--- a/domains/client/domain-operator/src/snap_sync.rs
+++ b/domains/client/domain-operator/src/snap_sync.rs
@@ -520,5 +520,7 @@ where
         sleep(loop_pause).await;
     }
 
-    Err(sp_blockchain::Error::Backend("All retries failed".into()))
+    Err(sp_blockchain::Error::Backend(
+        "All connected peer retries failed".into(),
+    ))
 }


### PR DESCRIPTION
This is an alternative take on solving the same problem as https://github.com/autonomys/subspace/pull/3501.

It addresses the issue the way I suggested in the PR, minimizing waiting time and preferring already connected peers for downloading of segment headers.

I hope it is also easier to read. I tend to create longer functions that encapsulate the full workflow step by step the same way I'd describe it with words.

For example extraction of `get_random_peers` in https://github.com/autonomys/subspace/pull/3501 was hiding the fact that there are two different use cases for calling `Node::get_closest_peers()` that when abstracted away result in worse performance.

First 3 commits are taken from https://github.com/autonomys/subspace/pull/3501 directly.

I was able to Snap sync mainnet with this PR on first attempt.

Second attempt failed with this though, which is very bad, something much be seriously wrong, but unrelated to the changes in this PR:
> 2025-05-08T13:21:14.643502Z ERROR Consensus: subspace_service: Snap sync exited with a fatal error error=Snap sync error: Failed to download segment pieces: Not enough (125/128) pieces for segment 522

Even first node when tried to re-downloading newer segment headers after finishing Snap sync failed to connect to anyone at all too most for 17 attempts straight (and then found a single node on attempts 18/19):
> 2025-05-08T13:27:04.485796Z DEBUG Consensus: consensus_sync: Segment headers consensus requires some peers, will retry peer_count=0 required_peers=4 retry_attempt=17

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
