### PR TITLE
Fix retrieving multi-piece objects ending in the final segment piece

### DIFF
--- a/shared/subspace-data-retrieval/src/object_fetcher/tests.rs
+++ b/shared/subspace-data-retrieval/src/object_fetcher/tests.rs
@@ -459,6 +459,7 @@ fn max_object_length_constant() {
     );
 }
 
+/// This test covers objects that are in a single piece with no segment padding.
 #[tokio::test(flavor = "multi_thread")]
 async fn get_single_piece_object_no_padding() {
     init_logger();
@@ -620,6 +621,8 @@ async fn get_multi_piece_object_no_padding() {
     assert_eq!(fetched_data.map(hex::encode), Ok(hex::encode(object_data)));
 }
 
+/// This test covers objects that are in the last piece of a segment, with potential segment
+/// padding.
 #[tokio::test(flavor = "multi_thread")]
 async fn get_single_piece_object_potential_padding() {
     init_logger();
@@ -826,6 +829,8 @@ async fn get_multi_piece_object_potential_padding() {
     assert_eq!(fetched_data.map(hex::encode), Ok(hex::encode(object_data)));
 }
 
+/// This test covers objects that are split across multiple segments, including padding and segment
+/// headers. They all have their lengths outside the padding.
 #[tokio::test(flavor = "multi_thread")]
 async fn get_multi_piece_object_length_outside_padding() {
     init_logger();
@@ -1040,6 +1045,8 @@ async fn get_multi_piece_object_length_outside_padding() {
     assert_eq!(fetched_data.map(hex::encode), Ok(hex::encode(object_data)));
 }
 
+/// This test covers objects that are split across multiple segments, including padding and
+/// segment headers. They all have their lengths overlapping the padding.
 #[tokio::test(flavor = "multi_thread")]
 async fn get_multi_piece_object_length_overlaps_padding() {
     init_logger();
@@ -1174,6 +1181,7 @@ async fn get_multi_piece_object_length_overlaps_padding() {
     assert_eq!(fetched_data.map(hex::encode), Ok(hex::encode(object_data)));
 }
 
+/// Does the last piece cache work as expected?
 #[tokio::test(flavor = "multi_thread")]
 async fn last_piece_cache_works() {
     init_logger();


### PR DESCRIPTION
This PR removes an incorrect assertion and fixes padding calculations when fetching:
- a multi-piece object
- which ends in the final piece of a segment
- but is shorter than the entire piece

This case wasn't covered by the tests, so I also added tests for:
- multi-piece objects without padding anywhere in a segment (including ending part of the way through the last piece)
- multi-piece objects with potential padding (including full and partial last piece data)

cc @clostao - feel free to test a gateway build with this PR.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
