### PR TITLE
Fix unstable CI by waiting for node to shut down

### DIFF
--- a/domains/client/domain-operator/src/tests.rs
+++ b/domains/client/domain-operator/src/tests.rs
@@ -8172,10 +8172,6 @@ async fn test_current_block_number_used_as_new_account_nonce() {
 
 // This test is unstable on Windows, it likely contains a filesystem race condition between stopping
 // the node `bob`, and restarting that node with the same data directory.
-// TODO:
-// - log both domain-0 paths used by `bob`, check they are the same, or
-// - work out which part of the second path isn't available
-#[cfg(not(windows))]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_domain_node_starting_check() {
     use futures::FutureExt;

--- a/domains/client/domain-operator/src/tests.rs
+++ b/domains/client/domain-operator/src/tests.rs
@@ -6170,8 +6170,8 @@ async fn test_restart_domain_operator() {
     let next_slot = ferdie.next_slot();
 
     // Stop Ferdie and Alice and delete their database lock files
-    ferdie.stop().unwrap();
-    alice.stop().unwrap();
+    ferdie.stop().await.unwrap();
+    alice.stop().await.unwrap();
 
     // Restart Ferdie
     let mut ferdie = MockConsensusNode::run(
@@ -6510,7 +6510,7 @@ async fn test_bad_receipt_chain() {
     produce_blocks!(ferdie, alice, 15).await.unwrap();
 
     // Stop `Bob` so it won't generate fraud proof for the incoming bad ER
-    bob.stop().unwrap();
+    bob.stop().await.unwrap();
 
     // Get a bundle from the txn pool and modify the receipt of the target bundle to an invalid one
     let (slot, mut opaque_bundle) = ferdie.produce_slot_and_wait_for_bundle_submission().await;
@@ -8221,7 +8221,8 @@ async fn test_domain_node_starting_check() {
 
     // Stop `Bob`, produce more domain blocks, then restart `Bob` with the same
     // consensus node should be fine
-    bob.stop().unwrap();
+    bob.stop().await.unwrap();
+
     produce_blocks!(ferdie, alice, 3).await.unwrap();
     assert_eq!(alice.client.info().best_number, 6);
 
@@ -8263,7 +8264,7 @@ async fn test_domain_node_starting_check() {
         BasePath::new(directory.path().join("eve")),
     );
     let alice_base_path = alice.base_path.clone();
-    alice.stop().unwrap();
+    alice.stop().await.unwrap();
     let result = async move {
         std::panic::AssertUnwindSafe(
             domain_test_service::DomainNodeBuilder::new(tokio_handle, alice_base_path)

--- a/domains/test/service/src/domain.rs
+++ b/domains/test/service/src/domain.rs
@@ -42,6 +42,7 @@ use sp_session::SessionKeys;
 use sp_transaction_pool::runtime_api::TaggedTransactionQueue;
 use std::future::Future;
 use std::sync::Arc;
+use std::time::Duration;
 use subspace_runtime_primitives::opaque::Block as CBlock;
 use subspace_runtime_primitives::Nonce;
 use subspace_test_primitives::DOMAINS_BLOCK_PRUNING_DEPTH;
@@ -50,6 +51,7 @@ use substrate_frame_rpc_system::AccountNonceApi;
 use substrate_test_client::{
     BlockchainEventsExt, RpcHandlersExt, RpcTransactionError, RpcTransactionOutput,
 };
+use tokio::time::sleep;
 
 /// The backend type used by the test service.
 pub type Backend = TFullBackend<Block>;
@@ -482,11 +484,20 @@ where
         );
     }
 
-    /// Take and stop the domain node and delete its database lock file
-    pub fn stop(self) -> Result<(), std::io::Error> {
+    /// Take and stop the domain node and delete its database lock file.
+    ///
+    /// Stopping and restarting a node can cause weird race conditions, with errors like:
+    /// "The system cannot find the path specified".
+    /// If this happens, try increasing the wait time in this method.
+    pub async fn stop(self) -> Result<(), std::io::Error> {
         let lock_file_path = self.base_path.path().join("paritydb").join("lock");
         // On Windows, sometimes open files can’t be deleted so `drop` first then delete
         std::mem::drop(self);
+
+        // Give the node time to cleanup, exit, and release the lock file.
+        // TODO: fix the underlying issue or wait for the actual shutdown instead
+        sleep(Duration::from_secs(2)).await;
+
         // The lock file already being deleted is not a fatal test error, so just log it
         if let Err(err) = std::fs::remove_file(lock_file_path) {
             tracing::error!("deleting paritydb lock file failed: {err:?}");

--- a/domains/test/service/src/domain.rs
+++ b/domains/test/service/src/domain.rs
@@ -160,7 +160,15 @@ where
 
         let domain_backend = sc_service::new_db_backend::<Block>(domain_config.db_config())
             .unwrap_or_else(
-                |err| panic!("Failed to create domain backend: {domain_id:?} {role:?} {base_path:?} error: {err:?}")
+                |err| {
+                    tracing::error!("Failed to create domain backend: {domain_id:?} {role:?} {base_path:?} error: {err:?}");
+
+                    // Find out which directory got deleted too soon
+                    for dir_path in base_path.path().ancestors() {
+                        tracing::error!("{dir_path:?} try_exists: {:?}", dir_path.try_exists());
+                    }
+                    panic!("Failed to create domain backend: {domain_id:?} {role:?} {base_path:?} error: {err:?}")
+                }
             );
 
         let BootstrapResult {

--- a/test/subspace-test-service/src/lib.rs
+++ b/test/subspace-test-service/src/lib.rs
@@ -100,6 +100,7 @@ use subspace_test_runtime::{
 };
 use substrate_frame_rpc_system::AccountNonceApi;
 use substrate_test_client::{RpcHandlersExt, RpcTransactionError, RpcTransactionOutput};
+use tokio::time::sleep;
 
 type FraudProofFor<Block, DomainBlock> =
     FraudProof<NumberFor<Block>, <Block as BlockT>::Hash, <DomainBlock as BlockT>::Header, H256>;
@@ -920,11 +921,20 @@ impl MockConsensusNode {
         );
     }
 
-    /// Take and stop the `MockConsensusNode` and delete its database lock file
-    pub fn stop(self) -> Result<(), std::io::Error> {
+    /// Take and stop the `MockConsensusNode` and delete its database lock file.
+    ///
+    /// Stopping and restarting a node can cause weird race conditions, with errors like:
+    /// "The system cannot find the path specified".
+    /// If this happens, try increasing the wait time in this method.
+    pub async fn stop(self) -> Result<(), std::io::Error> {
         let lock_file_path = self.base_path.path().join("paritydb").join("lock");
         // On Windows, sometimes open files can’t be deleted so `drop` first then delete
         std::mem::drop(self);
+
+        // Give the node time to cleanup, exit, and release the lock file.
+        // TODO: fix the underlying issue or wait for the actual shutdown instead
+        sleep(Duration::from_secs(2)).await;
+
         // The lock file already being deleted is not a fatal test error, so just log it
         if let Err(err) = std::fs::remove_file(lock_file_path) {
             tracing::error!("deleting paritydb lock file failed: {err:?}");


### PR DESCRIPTION
The `test_domain_node_starting_check` sometimes fails in CI with an error: "The system cannot find the path specified." This error happens even though all the directories in the node base path are present.

This most often happens on Windows, and when there is more CI load. So it seems like a filesystem race condition.

To avoid this issue, this PR waits for the node to cleanup before restarting it.

This PR also adds extra diagnostics for similar failures.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
