### PR TITLE
Use helpful type alias

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2862,6 +2862,7 @@ dependencies = [
  "sp-mmr-primitives",
  "sp-runtime",
  "sp-subspace-mmr",
+ "subspace-runtime-primitives",
  "tracing",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12426,7 +12426,6 @@ dependencies = [
  "subspace-core-primitives",
  "subspace-kzg",
  "subspace-proof-of-space",
- "subspace-runtime-primitives",
  "subspace-verification",
  "thiserror 2.0.12",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12426,6 +12426,7 @@ dependencies = [
  "subspace-core-primitives",
  "subspace-kzg",
  "subspace-proof-of-space",
+ "subspace-runtime-primitives",
  "subspace-verification",
  "thiserror 2.0.12",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2783,6 +2783,7 @@ dependencies = [
  "sp-inherents",
  "sp-runtime",
  "sp-state-machine",
+ "subspace-runtime-primitives",
  "tracing",
 ]
 
@@ -11221,6 +11222,7 @@ dependencies = [
  "sp-runtime",
  "strum_macros 0.26.4",
  "subspace-core-primitives",
+ "subspace-runtime-primitives",
  "substrate-prometheus-endpoint",
  "thiserror 2.0.12",
  "tracing",

--- a/crates/pallet-subspace/src/mock.rs
+++ b/crates/pallet-subspace/src/mock.rs
@@ -11,7 +11,6 @@ use sp_consensus_subspace::digests::{CompatibleDigestItem, PreDigest, PreDigestP
 use sp_consensus_subspace::{KzgExtension, PosExtension, PotExtension, SignedVote, Vote};
 use sp_io::TestExternalities;
 use sp_runtime::testing::{Digest, DigestItem, TestXt};
-use sp_runtime::traits::Block as BlockT;
 use sp_runtime::BuildStorage;
 use std::marker::PhantomData;
 use std::num::{NonZeroU32, NonZeroU64, NonZeroUsize};
@@ -38,7 +37,7 @@ use subspace_farmer_components::FarmerProtocolInfo;
 use subspace_kzg::Kzg;
 use subspace_proof_of_space::shim::ShimTable;
 use subspace_proof_of_space::{Table, TableGenerator};
-use subspace_runtime_primitives::ConsensusEventSegmentSize;
+use subspace_runtime_primitives::{BlockHashFor, ConsensusEventSegmentSize};
 use subspace_verification::is_within_solution_range;
 
 type PosTable = ShimTable;
@@ -287,7 +286,7 @@ pub fn create_archived_segment() -> &'static NewArchivedSegment {
 pub fn create_signed_vote(
     keypair: &Keypair,
     height: u64,
-    parent_hash: <Block as BlockT>::Hash,
+    parent_hash: BlockHashFor<Block>,
     slot: Slot,
     proof_of_time: PotOutput,
     future_proof_of_time: PotOutput,
@@ -295,7 +294,7 @@ pub fn create_signed_vote(
     reward_address: <Test as frame_system::Config>::AccountId,
     solution_range: SolutionRange,
     vote_solution_range: SolutionRange,
-) -> SignedVote<u64, <Block as BlockT>::Hash, <Test as frame_system::Config>::AccountId> {
+) -> SignedVote<u64, BlockHashFor<Block>, <Test as frame_system::Config>::AccountId> {
     let kzg = kzg_instance();
     let erasure_coding = erasure_coding_instance();
     let reward_signing_context = schnorrkel::signing_context(REWARD_SIGNING_CONTEXT);
@@ -391,7 +390,7 @@ pub fn create_signed_vote(
             continue;
         }
 
-        let vote = Vote::<u64, <Block as BlockT>::Hash, _>::V0 {
+        let vote = Vote::<u64, BlockHashFor<Block>, _>::V0 {
             height,
             parent_hash,
             slot,

--- a/crates/sc-consensus-subspace/src/block_import.rs
+++ b/crates/sc-consensus-subspace/src/block_import.rs
@@ -297,7 +297,7 @@ where
     Client::Api: BlockBuilderApi<Block> + SubspaceApi<Block, PublicKey> + ApiExt<Block>,
     CIDP: CreateInherentDataProviders<Block, ()> + Send + Sync + 'static,
     AS: AuxStore + Send + Sync + 'static,
-    BlockNumber: From<<Block::Header as HeaderT>::Number>,
+    BlockNumber: From<NumberFor<Block>>,
 {
     /// Produce a Subspace block-import object to be used later on in the construction of an import-queue.
     pub fn new(
@@ -552,7 +552,7 @@ where
     Client::Api: BlockBuilderApi<Block> + SubspaceApi<Block, PublicKey> + ApiExt<Block>,
     CIDP: CreateInherentDataProviders<Block, ()> + Send + Sync + 'static,
     AS: AuxStore + Send + Sync + 'static,
-    BlockNumber: From<<Block::Header as HeaderT>::Number>,
+    BlockNumber: From<NumberFor<Block>>,
 {
     type Error = Error<Block::Header>;
 

--- a/crates/sc-consensus-subspace/src/slot_worker.rs
+++ b/crates/sc-consensus-subspace/src/slot_worker.rs
@@ -313,7 +313,7 @@ where
     BS: BackoffAuthoringBlocksStrategy<NumberFor<Block>> + Send + Sync,
     Error: std::error::Error + Send + From<ConsensusError> + 'static,
     AS: AuxStore + Send + Sync + 'static,
-    BlockNumber: From<<Block::Header as Header>::Number>,
+    BlockNumber: From<NumberFor<Block>>,
 {
     type BlockImport = BoxBlockImport<Block>;
     type SyncOracle = SubspaceSyncOracle<SO>;
@@ -757,7 +757,7 @@ where
     BS: BackoffAuthoringBlocksStrategy<NumberFor<Block>> + Send + Sync,
     Error: std::error::Error + Send + From<ConsensusError> + 'static,
     AS: AuxStore + Send + Sync + 'static,
-    BlockNumber: From<<Block::Header as Header>::Number>,
+    BlockNumber: From<NumberFor<Block>>,
 {
     /// Create new Subspace slot worker
     pub fn new(

--- a/crates/sc-subspace-block-relay/Cargo.toml
+++ b/crates/sc-subspace-block-relay/Cargo.toml
@@ -27,6 +27,7 @@ sc-transaction-pool-api.workspace = true
 sp-runtime = { workspace = true, features = ["std"] }
 strum_macros.workspace = true
 subspace-core-primitives = { workspace = true, features = ["std"] }
+subspace-runtime-primitives = { workspace = true, features = ["std"] }
 substrate-prometheus-endpoint.workspace = true
 thiserror.workspace = true
 tracing = { workspace = true, features = ["std"] }

--- a/crates/sc-subspace-block-relay/src/consensus/types.rs
+++ b/crates/sc-subspace-block-relay/src/consensus/types.rs
@@ -20,10 +20,9 @@ use sc_network_common::sync::message::{BlockAttributes, BlockData, BlockRequest}
 use sp_runtime::generic::BlockId;
 use sp_runtime::traits::{Block as BlockT, NumberFor};
 use sp_runtime::Justifications;
-use subspace_runtime_primitives::ExtrinsicFor;
+use subspace_runtime_primitives::{BlockHashFor, ExtrinsicFor};
 use substrate_prometheus_endpoint::{PrometheusError, Registry};
 
-pub(crate) type BlockHash<Block> = <Block as BlockT>::Hash;
 pub(crate) type BlockHeader<Block> = <Block as BlockT>::Header;
 
 const STATUS_LABEL: &str = "status";
@@ -75,7 +74,7 @@ pub(crate) struct InitialRequest<Block: BlockT> {
 #[derive(Encode, Decode)]
 pub(crate) struct InitialResponse<Block: BlockT, TxHash> {
     ///  Hash of the block being downloaded.
-    pub(crate) block_hash: BlockHash<Block>,
+    pub(crate) block_hash: BlockHashFor<Block>,
 
     /// The partial block, without the extrinsics.
     pub(crate) partial_block: PartialBlock<Block>,
@@ -100,7 +99,7 @@ pub(crate) enum ProtocolInitialRequest {
 #[derive(From, Encode, Decode)]
 pub(crate) enum ProtocolInitialResponse<Block: BlockT, TxHash> {
     #[codec(index = 0)]
-    CompactBlock(CompactBlockInitialResponse<BlockHash<Block>, TxHash, ExtrinsicFor<Block>>),
+    CompactBlock(CompactBlockInitialResponse<BlockHashFor<Block>, TxHash, ExtrinsicFor<Block>>),
     // New protocol goes here:
     // #[codec(index = 1)]
 }
@@ -109,16 +108,16 @@ pub(crate) enum ProtocolInitialResponse<Block: BlockT, TxHash> {
 #[derive(From, Encode, Decode)]
 pub(crate) enum ProtocolMessage<Block: BlockT, TxHash> {
     #[codec(index = 0)]
-    CompactBlock(CompactBlockHandshake<BlockHash<Block>, TxHash>),
+    CompactBlock(CompactBlockHandshake<BlockHashFor<Block>, TxHash>),
     // New protocol goes here:
     // #[codec(index = 1)]
 }
 
-impl<Block: BlockT, TxHash> From<CompactBlockHandshake<BlockHash<Block>, TxHash>>
+impl<Block: BlockT, TxHash> From<CompactBlockHandshake<BlockHashFor<Block>, TxHash>>
     for ConsensusRequest<Block, TxHash>
 {
     fn from(
-        inner: CompactBlockHandshake<BlockHash<Block>, TxHash>,
+        inner: CompactBlockHandshake<BlockHashFor<Block>, TxHash>,
     ) -> ConsensusRequest<Block, TxHash> {
         ConsensusRequest::ProtocolMessageV0(ProtocolMessage::CompactBlock(inner))
     }
@@ -142,9 +141,9 @@ pub(crate) struct FullDownloadResponse<Block: BlockT>(pub(crate) Vec<BlockData<B
 /// are handled by the protocol.
 #[derive(Encode, Decode)]
 pub(crate) struct PartialBlock<Block: BlockT> {
-    pub(crate) parent_hash: BlockHash<Block>,
+    pub(crate) parent_hash: BlockHashFor<Block>,
     pub(crate) block_number: NumberFor<Block>,
-    pub(crate) block_header_hash: BlockHash<Block>,
+    pub(crate) block_header_hash: BlockHashFor<Block>,
     pub(crate) header: Option<BlockHeader<Block>>,
     pub(crate) indexed_body: Option<Vec<Vec<u8>>>,
     pub(crate) justifications: Option<Justifications>,

--- a/crates/sc-subspace-block-relay/src/consensus/types.rs
+++ b/crates/sc-subspace-block-relay/src/consensus/types.rs
@@ -20,10 +20,8 @@ use sc_network_common::sync::message::{BlockAttributes, BlockData, BlockRequest}
 use sp_runtime::generic::BlockId;
 use sp_runtime::traits::{Block as BlockT, NumberFor};
 use sp_runtime::Justifications;
-use subspace_runtime_primitives::{BlockHashFor, ExtrinsicFor};
+use subspace_runtime_primitives::{BlockHashFor, ExtrinsicFor, HeaderFor};
 use substrate_prometheus_endpoint::{PrometheusError, Registry};
-
-pub(crate) type BlockHeader<Block> = <Block as BlockT>::Header;
 
 const STATUS_LABEL: &str = "status";
 const STATUS_SUCCESS: &str = "success";
@@ -144,7 +142,7 @@ pub(crate) struct PartialBlock<Block: BlockT> {
     pub(crate) parent_hash: BlockHashFor<Block>,
     pub(crate) block_number: NumberFor<Block>,
     pub(crate) block_header_hash: BlockHashFor<Block>,
-    pub(crate) header: Option<BlockHeader<Block>>,
+    pub(crate) header: Option<HeaderFor<Block>>,
     pub(crate) indexed_body: Option<Vec<Vec<u8>>>,
     pub(crate) justifications: Option<Justifications>,
 }

--- a/crates/sc-subspace-block-relay/src/consensus/types.rs
+++ b/crates/sc-subspace-block-relay/src/consensus/types.rs
@@ -20,11 +20,11 @@ use sc_network_common::sync::message::{BlockAttributes, BlockData, BlockRequest}
 use sp_runtime::generic::BlockId;
 use sp_runtime::traits::{Block as BlockT, NumberFor};
 use sp_runtime::Justifications;
+use subspace_runtime_primitives::ExtrinsicFor;
 use substrate_prometheus_endpoint::{PrometheusError, Registry};
 
 pub(crate) type BlockHash<Block> = <Block as BlockT>::Hash;
 pub(crate) type BlockHeader<Block> = <Block as BlockT>::Header;
-pub(crate) type Extrinsic<Block> = <Block as BlockT>::Extrinsic;
 
 const STATUS_LABEL: &str = "status";
 const STATUS_SUCCESS: &str = "success";
@@ -100,7 +100,7 @@ pub(crate) enum ProtocolInitialRequest {
 #[derive(From, Encode, Decode)]
 pub(crate) enum ProtocolInitialResponse<Block: BlockT, TxHash> {
     #[codec(index = 0)]
-    CompactBlock(CompactBlockInitialResponse<BlockHash<Block>, TxHash, Extrinsic<Block>>),
+    CompactBlock(CompactBlockInitialResponse<BlockHash<Block>, TxHash, ExtrinsicFor<Block>>),
     // New protocol goes here:
     // #[codec(index = 1)]
 }
@@ -152,7 +152,7 @@ pub(crate) struct PartialBlock<Block: BlockT> {
 
 impl<Block: BlockT> PartialBlock<Block> {
     /// Builds the full block data.
-    pub(crate) fn block_data(self, body: Option<Vec<Extrinsic<Block>>>) -> BlockData<Block> {
+    pub(crate) fn block_data(self, body: Option<Vec<ExtrinsicFor<Block>>>) -> BlockData<Block> {
         BlockData::<Block> {
             hash: self.block_header_hash,
             header: self.header,

--- a/crates/sp-consensus-subspace/Cargo.toml
+++ b/crates/sp-consensus-subspace/Cargo.toml
@@ -32,7 +32,6 @@ sp-timestamp.workspace = true
 subspace-core-primitives.workspace = true
 subspace-kzg = { workspace = true, optional = true }
 subspace-proof-of-space.workspace = true
-subspace-runtime-primitives.workspace = true
 subspace-verification.workspace = true
 thiserror.workspace = true
 
@@ -60,7 +59,6 @@ std = [
     "subspace-proof-of-space/std",
     "subspace-verification/kzg",
     "subspace-verification/std",
-    "subspace-runtime-primitives/std",
     "thiserror/std",
 ]
 

--- a/crates/sp-consensus-subspace/Cargo.toml
+++ b/crates/sp-consensus-subspace/Cargo.toml
@@ -60,6 +60,7 @@ std = [
     "subspace-proof-of-space/std",
     "subspace-verification/kzg",
     "subspace-verification/std",
+    "subspace-runtime-primitives/std",
     "thiserror/std",
 ]
 

--- a/crates/sp-consensus-subspace/Cargo.toml
+++ b/crates/sp-consensus-subspace/Cargo.toml
@@ -32,6 +32,7 @@ sp-timestamp.workspace = true
 subspace-core-primitives.workspace = true
 subspace-kzg = { workspace = true, optional = true }
 subspace-proof-of-space.workspace = true
+subspace-runtime-primitives.workspace = true
 subspace-verification.workspace = true
 thiserror.workspace = true
 

--- a/crates/sp-consensus-subspace/src/lib.rs
+++ b/crates/sp-consensus-subspace/src/lib.rs
@@ -19,7 +19,7 @@ use scale_info::TypeInfo;
 use sp_consensus_slots::{Slot, SlotDuration};
 use sp_core::H256;
 use sp_io::hashing;
-use sp_runtime::traits::Header as HeaderT;
+use sp_runtime::traits::NumberFor;
 use sp_runtime::{ConsensusEngineId, Justification};
 use sp_runtime_interface::pass_by::PassBy;
 use sp_runtime_interface::{pass_by, runtime_interface};
@@ -39,7 +39,6 @@ use subspace_proof_of_space::shim::ShimTable;
 use subspace_proof_of_space::PosTableType;
 #[cfg(feature = "std")]
 use subspace_proof_of_space::Table;
-use subspace_runtime_primitives::HeaderFor;
 use subspace_verification::VerifySolutionParams;
 
 /// The `ConsensusEngineId` of Subspace.
@@ -586,7 +585,7 @@ sp_api::decl_runtime_apis! {
         /// acceptable for block authoring. Only useful in an offchain context.
         fn submit_vote_extrinsic(
             signed_vote: SignedVote<
-                <HeaderFor<Block> as HeaderT>::Number,
+                NumberFor<Block>,
                 Block::Hash,
                 RewardAddress,
             >,

--- a/crates/sp-consensus-subspace/src/lib.rs
+++ b/crates/sp-consensus-subspace/src/lib.rs
@@ -19,7 +19,7 @@ use scale_info::TypeInfo;
 use sp_consensus_slots::{Slot, SlotDuration};
 use sp_core::H256;
 use sp_io::hashing;
-use sp_runtime::traits::{Block as BlockT, Header as HeaderT};
+use sp_runtime::traits::Header as HeaderT;
 use sp_runtime::{ConsensusEngineId, Justification};
 use sp_runtime_interface::pass_by::PassBy;
 use sp_runtime_interface::{pass_by, runtime_interface};
@@ -39,6 +39,7 @@ use subspace_proof_of_space::shim::ShimTable;
 use subspace_proof_of_space::PosTableType;
 #[cfg(feature = "std")]
 use subspace_proof_of_space::Table;
+use subspace_runtime_primitives::HeaderFor;
 use subspace_verification::VerifySolutionParams;
 
 /// The `ConsensusEngineId` of Subspace.
@@ -585,7 +586,7 @@ sp_api::decl_runtime_apis! {
         /// acceptable for block authoring. Only useful in an offchain context.
         fn submit_vote_extrinsic(
             signed_vote: SignedVote<
-                <<Block as BlockT>::Header as HeaderT>::Number,
+                <HeaderFor<Block> as HeaderT>::Number,
                 Block::Hash,
                 RewardAddress,
             >,

--- a/crates/sp-domains/src/core_api.rs
+++ b/crates/sp-domains/src/core_api.rs
@@ -8,18 +8,18 @@ use domain_runtime_primitives::{
     opaque, Balance, CheckExtrinsicsValidityError, DecodeExtrinsicError,
 };
 use sp_runtime::generic::Era;
-use sp_runtime::traits::{Block as BlockT, NumberFor};
+use sp_runtime::traits::NumberFor;
 use sp_runtime::Digest;
 use sp_weights::Weight;
 use subspace_core_primitives::U256;
-use subspace_runtime_primitives::Moment;
+use subspace_runtime_primitives::{ExtrinsicFor, Moment};
 
 sp_api::decl_runtime_apis! {
     /// Base API that every domain runtime must implement.
     pub trait DomainCoreApi {
         /// Extracts the optional signer per extrinsic.
         fn extract_signer(
-            extrinsics: Vec<<Block as BlockT>::Extrinsic>,
+            extrinsics: Vec<ExtrinsicFor<Block>>,
         ) -> Vec<(Option<opaque::AccountId>, Block::Extrinsic)>;
 
         fn is_within_tx_range(

--- a/crates/sp-domains/src/lib.rs
+++ b/crates/sp-domains/src/lib.rs
@@ -44,7 +44,7 @@ use sp_core::sr25519::vrf::{VrfPreOutput, VrfProof};
 use sp_core::H256;
 use sp_runtime::generic::OpaqueDigestItemId;
 use sp_runtime::traits::{
-    BlakeTwo256, Block as BlockT, CheckedAdd, Hash as HashT, Header as HeaderT, NumberFor, Zero,
+    BlakeTwo256, CheckedAdd, Hash as HashT, Header as HeaderT, NumberFor, Zero,
 };
 use sp_runtime::{Digest, DigestItem, OpaqueExtrinsic, Percent};
 use sp_runtime_interface::pass_by;
@@ -60,7 +60,7 @@ use subspace_core_primitives::hashes::{blake3_hash, Blake3Hash};
 use subspace_core_primitives::pot::PotOutput;
 use subspace_core_primitives::solutions::bidirectional_distance;
 use subspace_core_primitives::{Randomness, U256};
-use subspace_runtime_primitives::{Balance, Moment};
+use subspace_runtime_primitives::{Balance, BlockHashFor, Moment};
 
 /// Key type for Operator.
 pub const KEY_TYPE: KeyTypeId = KeyTypeId(*b"oper");
@@ -484,7 +484,7 @@ pub type OpaqueBundle<Number, Hash, DomainHeader, Balance> =
 
 /// List of [`OpaqueBundle`].
 pub type OpaqueBundles<Block, DomainHeader, Balance> =
-    Vec<OpaqueBundle<NumberFor<Block>, <Block as BlockT>::Hash, DomainHeader, Balance>>;
+    Vec<OpaqueBundle<NumberFor<Block>, BlockHashFor<Block>, DomainHeader, Balance>>;
 
 impl<Extrinsic: Encode, Number, Hash, DomainHeader: HeaderT, Balance>
     Bundle<Extrinsic, Number, Hash, DomainHeader, Balance>
@@ -1524,7 +1524,7 @@ impl OnDomainInstantiated for () {
 
 pub type ExecutionReceiptFor<DomainHeader, CBlock, Balance> = ExecutionReceipt<
     NumberFor<CBlock>,
-    <CBlock as BlockT>::Hash,
+    BlockHashFor<CBlock>,
     <DomainHeader as HeaderT>::Number,
     <DomainHeader as HeaderT>::Hash,
     Balance,

--- a/crates/subspace-fake-runtime-api/src/lib.rs
+++ b/crates/subspace-fake-runtime-api/src/lib.rs
@@ -19,7 +19,7 @@ use sp_messenger::messages::{
     BlockMessagesWithStorageKey, ChainId, ChannelId, CrossDomainMessage, MessageId, MessageKey,
 };
 use sp_messenger::{ChannelNonce, XdmId};
-use sp_runtime::traits::{Block as BlockT, NumberFor};
+use sp_runtime::traits::NumberFor;
 use sp_runtime::transaction_validity::{TransactionSource, TransactionValidity};
 use sp_runtime::{ApplyExtrinsicResult, ExtrinsicInclusionMode};
 use sp_subspace_mmr::ConsensusChainMmrLeafProof;
@@ -33,7 +33,7 @@ use subspace_core_primitives::segments::{
 use subspace_core_primitives::{PublicKey, Randomness, U256};
 use subspace_runtime_primitives::opaque::Block;
 use subspace_runtime_primitives::{
-    AccountId, Balance, BlockHashFor, BlockNumber, ExtrinsicFor, Moment, Nonce,
+    AccountId, Balance, BlockHashFor, BlockNumber, ExtrinsicFor, HeaderFor, Moment, Nonce,
 };
 
 mod mmr {
@@ -56,7 +56,7 @@ sp_api::impl_runtime_apis! {
             unreachable!()
         }
 
-        fn initialize_block(_header: &<Block as BlockT>::Header) -> ExtrinsicInclusionMode {
+        fn initialize_block(_header: &HeaderFor<Block>) -> ExtrinsicInclusionMode {
             unreachable!()
         }
     }
@@ -80,7 +80,7 @@ sp_api::impl_runtime_apis! {
             unreachable!()
         }
 
-        fn finalize_block() -> <Block as BlockT>::Header {
+        fn finalize_block() -> HeaderFor<Block> {
             unreachable!()
         }
 
@@ -107,7 +107,7 @@ sp_api::impl_runtime_apis! {
     }
 
     impl sp_offchain::OffchainWorkerApi<Block> for Runtime {
-        fn offchain_worker(_header: &<Block as BlockT>::Header) {
+        fn offchain_worker(_header: &HeaderFor<Block>) {
             unreachable!()
         }
     }

--- a/crates/subspace-fake-runtime-api/src/lib.rs
+++ b/crates/subspace-fake-runtime-api/src/lib.rs
@@ -32,7 +32,7 @@ use subspace_core_primitives::segments::{
 };
 use subspace_core_primitives::{PublicKey, Randomness, U256};
 use subspace_runtime_primitives::opaque::Block;
-use subspace_runtime_primitives::{AccountId, Balance, BlockNumber, Moment, Nonce};
+use subspace_runtime_primitives::{AccountId, Balance, BlockNumber, ExtrinsicFor, Moment, Nonce};
 
 mod mmr {
     pub use pallet_mmr::primitives::*;
@@ -74,7 +74,7 @@ sp_api::impl_runtime_apis! {
     }
 
     impl sp_block_builder::BlockBuilder<Block> for Runtime {
-        fn apply_extrinsic(_extrinsic: <Block as BlockT>::Extrinsic) -> ApplyExtrinsicResult {
+        fn apply_extrinsic(_extrinsic: ExtrinsicFor<Block>) -> ApplyExtrinsicResult {
             unreachable!()
         }
 
@@ -82,7 +82,7 @@ sp_api::impl_runtime_apis! {
             unreachable!()
         }
 
-        fn inherent_extrinsics(_data: sp_inherents::InherentData) -> Vec<<Block as BlockT>::Extrinsic> {
+        fn inherent_extrinsics(_data: sp_inherents::InherentData) -> Vec<ExtrinsicFor<Block>> {
             unreachable!()
         }
 
@@ -97,7 +97,7 @@ sp_api::impl_runtime_apis! {
     impl sp_transaction_pool::runtime_api::TaggedTransactionQueue<Block> for Runtime {
         fn validate_transaction(
             _source: TransactionSource,
-            _tx: <Block as BlockT>::Extrinsic,
+            _tx: ExtrinsicFor<Block>,
             _block_hash: <Block as BlockT>::Hash,
         ) -> TransactionValidity {
             unreachable!()
@@ -143,11 +143,11 @@ sp_api::impl_runtime_apis! {
             unreachable!()
         }
 
-        fn extract_segment_headers(_ext: &<Block as BlockT>::Extrinsic) -> Option<Vec<SegmentHeader >> {
+        fn extract_segment_headers(_ext: &ExtrinsicFor<Block>) -> Option<Vec<SegmentHeader >> {
             unreachable!()
         }
 
-        fn is_inherent(_ext: &<Block as BlockT>::Extrinsic) -> bool {
+        fn is_inherent(_ext: &ExtrinsicFor<Block>) -> bool {
             unreachable!()
         }
 
@@ -179,7 +179,7 @@ sp_api::impl_runtime_apis! {
 
         fn extract_successful_bundles(
             _domain_id: DomainId,
-            _extrinsics: Vec<<Block as BlockT>::Extrinsic>,
+            _extrinsics: Vec<ExtrinsicFor<Block>>,
         ) -> sp_domains::OpaqueBundles<Block, DomainHeader, Balance> {
             unreachable!()
         }
@@ -319,13 +319,13 @@ sp_api::impl_runtime_apis! {
 
     impl pallet_transaction_payment_rpc_runtime_api::TransactionPaymentApi<Block, Balance> for Runtime {
         fn query_info(
-            _uxt: <Block as BlockT>::Extrinsic,
+            _uxt: ExtrinsicFor<Block>,
             _len: u32,
         ) -> pallet_transaction_payment_rpc_runtime_api::RuntimeDispatchInfo<Balance> {
             unreachable!()
         }
         fn query_fee_details(
-            _uxt: <Block as BlockT>::Extrinsic,
+            _uxt: ExtrinsicFor<Block>,
             _len: u32,
         ) -> pallet_transaction_payment::FeeDetails<Balance> {
             unreachable!()
@@ -340,12 +340,12 @@ sp_api::impl_runtime_apis! {
 
     impl sp_messenger::MessengerApi<Block, BlockNumber, <Block as BlockT>::Hash> for Runtime {
         fn is_xdm_mmr_proof_valid(
-            _ext: &<Block as BlockT>::Extrinsic
+            _ext: &ExtrinsicFor<Block>
         ) -> Option<bool> {
             unreachable!()
         }
 
-        fn extract_xdm_mmr_proof(_ext: &<Block as BlockT>::Extrinsic) -> Option<ConsensusChainMmrLeafProof<BlockNumber, <Block as BlockT>::Hash, sp_core::H256>> {
+        fn extract_xdm_mmr_proof(_ext: &ExtrinsicFor<Block>) -> Option<ConsensusChainMmrLeafProof<BlockNumber, <Block as BlockT>::Hash, sp_core::H256>> {
             unreachable!()
         }
 
@@ -365,7 +365,7 @@ sp_api::impl_runtime_apis! {
             unreachable!()
         }
 
-        fn xdm_id(_ext: &<Block as BlockT>::Extrinsic) -> Option<XdmId> {
+        fn xdm_id(_ext: &ExtrinsicFor<Block>) -> Option<XdmId> {
             unreachable!()
         }
 
@@ -379,11 +379,11 @@ sp_api::impl_runtime_apis! {
             unreachable!()
         }
 
-        fn outbox_message_unsigned(_msg: CrossDomainMessage<NumberFor<Block>, <Block as BlockT>::Hash, <Block as BlockT>::Hash>) -> Option<<Block as BlockT>::Extrinsic> {
+        fn outbox_message_unsigned(_msg: CrossDomainMessage<NumberFor<Block>, <Block as BlockT>::Hash, <Block as BlockT>::Hash>) -> Option<ExtrinsicFor<Block>> {
             unreachable!()
         }
 
-        fn inbox_response_message_unsigned(_msg: CrossDomainMessage<NumberFor<Block>, <Block as BlockT>::Hash, <Block as BlockT>::Hash>) -> Option<<Block as BlockT>::Extrinsic> {
+        fn inbox_response_message_unsigned(_msg: CrossDomainMessage<NumberFor<Block>, <Block as BlockT>::Hash, <Block as BlockT>::Hash>) -> Option<ExtrinsicFor<Block>> {
             unreachable!()
         }
 

--- a/crates/subspace-fake-runtime-api/src/lib.rs
+++ b/crates/subspace-fake-runtime-api/src/lib.rs
@@ -32,7 +32,9 @@ use subspace_core_primitives::segments::{
 };
 use subspace_core_primitives::{PublicKey, Randomness, U256};
 use subspace_runtime_primitives::opaque::Block;
-use subspace_runtime_primitives::{AccountId, Balance, BlockNumber, ExtrinsicFor, Moment, Nonce};
+use subspace_runtime_primitives::{
+    AccountId, Balance, BlockHashFor, BlockNumber, ExtrinsicFor, Moment, Nonce,
+};
 
 mod mmr {
     pub use pallet_mmr::primitives::*;
@@ -98,7 +100,7 @@ sp_api::impl_runtime_apis! {
         fn validate_transaction(
             _source: TransactionSource,
             _tx: ExtrinsicFor<Block>,
-            _block_hash: <Block as BlockT>::Hash,
+            _block_hash: BlockHashFor<Block>,
         ) -> TransactionValidity {
             unreachable!()
         }
@@ -126,7 +128,7 @@ sp_api::impl_runtime_apis! {
         }
 
         fn submit_vote_extrinsic(
-            _signed_vote: SignedVote<NumberFor<Block>, <Block as BlockT>::Hash, PublicKey>,
+            _signed_vote: SignedVote<NumberFor<Block>, BlockHashFor<Block>, PublicKey>,
         ) {
             unreachable!()
         }
@@ -166,13 +168,13 @@ sp_api::impl_runtime_apis! {
 
     impl sp_domains::DomainsApi<Block, DomainHeader> for Runtime {
         fn submit_bundle_unsigned(
-            _opaque_bundle: sp_domains::OpaqueBundle<NumberFor<Block>, <Block as BlockT>::Hash, DomainHeader, Balance>,
+            _opaque_bundle: sp_domains::OpaqueBundle<NumberFor<Block>, BlockHashFor<Block>, DomainHeader, Balance>,
         ) {
             unreachable!()
         }
 
         fn submit_receipt_unsigned(
-            _singleton_receipt: sp_domains::SealedSingletonReceipt<NumberFor<Block>, <Block as BlockT>::Hash, DomainHeader, Balance>,
+            _singleton_receipt: sp_domains::SealedSingletonReceipt<NumberFor<Block>, BlockHashFor<Block>, DomainHeader, Balance>,
         ) {
             unreachable!()
         }
@@ -338,14 +340,14 @@ sp_api::impl_runtime_apis! {
         }
     }
 
-    impl sp_messenger::MessengerApi<Block, BlockNumber, <Block as BlockT>::Hash> for Runtime {
+    impl sp_messenger::MessengerApi<Block, BlockNumber, BlockHashFor<Block>> for Runtime {
         fn is_xdm_mmr_proof_valid(
             _ext: &ExtrinsicFor<Block>
         ) -> Option<bool> {
             unreachable!()
         }
 
-        fn extract_xdm_mmr_proof(_ext: &ExtrinsicFor<Block>) -> Option<ConsensusChainMmrLeafProof<BlockNumber, <Block as BlockT>::Hash, sp_core::H256>> {
+        fn extract_xdm_mmr_proof(_ext: &ExtrinsicFor<Block>) -> Option<ConsensusChainMmrLeafProof<BlockNumber, BlockHashFor<Block>, sp_core::H256>> {
             unreachable!()
         }
 
@@ -374,16 +376,16 @@ sp_api::impl_runtime_apis! {
         }
     }
 
-    impl sp_messenger::RelayerApi<Block, BlockNumber, BlockNumber, <Block as BlockT>::Hash> for Runtime {
+    impl sp_messenger::RelayerApi<Block, BlockNumber, BlockNumber, BlockHashFor<Block>> for Runtime {
         fn block_messages() -> BlockMessagesWithStorageKey {
             unreachable!()
         }
 
-        fn outbox_message_unsigned(_msg: CrossDomainMessage<NumberFor<Block>, <Block as BlockT>::Hash, <Block as BlockT>::Hash>) -> Option<ExtrinsicFor<Block>> {
+        fn outbox_message_unsigned(_msg: CrossDomainMessage<NumberFor<Block>, BlockHashFor<Block>, BlockHashFor<Block>>) -> Option<ExtrinsicFor<Block>> {
             unreachable!()
         }
 
-        fn inbox_response_message_unsigned(_msg: CrossDomainMessage<NumberFor<Block>, <Block as BlockT>::Hash, <Block as BlockT>::Hash>) -> Option<ExtrinsicFor<Block>> {
+        fn inbox_response_message_unsigned(_msg: CrossDomainMessage<NumberFor<Block>, BlockHashFor<Block>, BlockHashFor<Block>>) -> Option<ExtrinsicFor<Block>> {
             unreachable!()
         }
 
@@ -409,7 +411,7 @@ sp_api::impl_runtime_apis! {
     }
 
     impl sp_domains_fraud_proof::FraudProofApi<Block, DomainHeader> for Runtime {
-        fn submit_fraud_proof_unsigned(_fraud_proof: FraudProof<NumberFor<Block>, <Block as BlockT>::Hash, DomainHeader, H256>) {
+        fn submit_fraud_proof_unsigned(_fraud_proof: FraudProof<NumberFor<Block>, BlockHashFor<Block>, DomainHeader, H256>) {
             unreachable!()
         }
 

--- a/crates/subspace-malicious-operator/src/malicious_bundle_producer.rs
+++ b/crates/subspace-malicious-operator/src/malicious_bundle_producer.rs
@@ -30,7 +30,7 @@ use std::sync::Arc;
 use subspace_core_primitives::pot::PotOutput;
 use subspace_runtime::{DisablePallets, Runtime, RuntimeCall, SignedExtra, UncheckedExtrinsic};
 use subspace_runtime_primitives::opaque::Block as CBlock;
-use subspace_runtime_primitives::{AccountId, Balance, Nonce};
+use subspace_runtime_primitives::{AccountId, Balance, BlockHashFor, Nonce};
 
 const MALICIOUS_OPR_STAKE_MULTIPLIER: Balance = 3;
 
@@ -98,7 +98,7 @@ where
         + 'static,
     Client::Api: BlockBuilder<DomainBlock>
         + DomainCoreApi<DomainBlock>
-        + MessengerApi<DomainBlock, NumberFor<CBlock>, <CBlock as BlockT>::Hash>
+        + MessengerApi<DomainBlock, NumberFor<CBlock>, BlockHashFor<CBlock>>
         + TaggedTransactionQueue<DomainBlock>,
     CClient: HeaderBackend<CBlock> + ProvideRuntimeApi<CBlock> + 'static,
     CClient::Api: DomainsApi<CBlock, <DomainBlock as BlockT>::Header>
@@ -106,7 +106,7 @@ where
         + AccountNonceApi<CBlock, AccountId, Nonce>,
     TransactionPool: sc_transaction_pool_api::TransactionPool<
             Block = DomainBlock,
-            Hash = <DomainBlock as BlockT>::Hash,
+            Hash = BlockHashFor<DomainBlock>,
         > + 'static,
 {
     pub fn new(

--- a/crates/subspace-malicious-operator/src/malicious_bundle_producer.rs
+++ b/crates/subspace-malicious-operator/src/malicious_bundle_producer.rs
@@ -22,7 +22,7 @@ use sp_domains::{BundleProducerElectionApi, DomainId, DomainsApi, OperatorId, Op
 use sp_keyring::Sr25519Keyring;
 use sp_keystore::{Keystore, KeystorePtr};
 use sp_messenger::MessengerApi;
-use sp_runtime::traits::{Block as BlockT, NumberFor};
+use sp_runtime::traits::NumberFor;
 use sp_runtime::{generic, RuntimeAppPublic};
 use sp_transaction_pool::runtime_api::TaggedTransactionQueue;
 use std::error::Error;
@@ -30,7 +30,7 @@ use std::sync::Arc;
 use subspace_core_primitives::pot::PotOutput;
 use subspace_runtime::{DisablePallets, Runtime, RuntimeCall, SignedExtra, UncheckedExtrinsic};
 use subspace_runtime_primitives::opaque::Block as CBlock;
-use subspace_runtime_primitives::{AccountId, Balance, BlockHashFor, Nonce};
+use subspace_runtime_primitives::{AccountId, Balance, BlockHashFor, HeaderFor, Nonce};
 
 const MALICIOUS_OPR_STAKE_MULTIPLIER: Balance = 3;
 
@@ -101,7 +101,7 @@ where
         + MessengerApi<DomainBlock, NumberFor<CBlock>, BlockHashFor<CBlock>>
         + TaggedTransactionQueue<DomainBlock>,
     CClient: HeaderBackend<CBlock> + ProvideRuntimeApi<CBlock> + 'static,
-    CClient::Api: DomainsApi<CBlock, <DomainBlock as BlockT>::Header>
+    CClient::Api: DomainsApi<CBlock, HeaderFor<DomainBlock>>
         + BundleProducerElectionApi<CBlock, Balance>
         + AccountNonceApi<CBlock, AccountId, Nonce>,
     TransactionPool: sc_transaction_pool_api::TransactionPool<

--- a/crates/subspace-malicious-operator/src/malicious_domain_instance_starter.rs
+++ b/crates/subspace-malicious-operator/src/malicious_domain_instance_starter.rs
@@ -24,11 +24,10 @@ use sp_core::crypto::AccountId32;
 use sp_core::traits::SpawnEssentialNamed;
 use sp_domains::{DomainInstanceData, RuntimeType};
 use sp_keystore::KeystorePtr;
-use sp_runtime::traits::Block as BlockT;
 use std::sync::Arc;
 use subspace_runtime::RuntimeApi as CRuntimeApi;
 use subspace_runtime_primitives::opaque::Block as CBlock;
-use subspace_runtime_primitives::{AccountId, DOMAINS_BLOCK_PRUNING_DEPTH};
+use subspace_runtime_primitives::{AccountId, HeaderFor, DOMAINS_BLOCK_PRUNING_DEPTH};
 use subspace_service::FullClient as CFullClient;
 
 /// `DomainInstanceStarter` used to start a domain instance node based on the given
@@ -155,7 +154,7 @@ impl DomainInstanceStarter {
                     maybe_operator_id: None,
                     confirmation_depth_k: chain_constants.confirmation_depth_k(),
                     consensus_chain_sync_params: None::<
-                        ConsensusChainSyncParams<_, <DomainBlock as BlockT>::Header>,
+                        ConsensusChainSyncParams<_, HeaderFor<DomainBlock>>,
                     >,
                     challenge_period: DOMAINS_BLOCK_PRUNING_DEPTH,
                     domain_backend,
@@ -218,7 +217,7 @@ impl DomainInstanceStarter {
                     maybe_operator_id: None,
                     confirmation_depth_k: chain_constants.confirmation_depth_k(),
                     consensus_chain_sync_params: None::<
-                        ConsensusChainSyncParams<_, <DomainBlock as BlockT>::Header>,
+                        ConsensusChainSyncParams<_, HeaderFor<DomainBlock>>,
                     >,
                     challenge_period: DOMAINS_BLOCK_PRUNING_DEPTH,
                     domain_backend,

--- a/crates/subspace-node/src/commands/run/domain.rs
+++ b/crates/subspace-node/src/commands/run/domain.rs
@@ -33,13 +33,14 @@ use sp_blockchain::HeaderBackend;
 use sp_consensus_subspace::SubspaceApi;
 use sp_core::crypto::{AccountId32, SecretString};
 use sp_domains::{DomainId, DomainInstanceData, OperatorId, RuntimeType};
-use sp_runtime::traits::Block as BlockT;
 use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use subspace_runtime::RuntimeApi as CRuntimeApi;
 use subspace_runtime_primitives::opaque::Block as CBlock;
-use subspace_runtime_primitives::{DOMAINS_BLOCK_PRUNING_DEPTH, DOMAINS_PRUNING_DEPTH_MULTIPLIER};
+use subspace_runtime_primitives::{
+    HeaderFor, DOMAINS_BLOCK_PRUNING_DEPTH, DOMAINS_PRUNING_DEPTH_MULTIPLIER,
+};
 use subspace_service::FullClient as CFullClient;
 use tokio::sync::broadcast::Receiver;
 use tokio_stream::wrappers::errors::BroadcastStreamRecvError;
@@ -453,9 +454,7 @@ pub(super) async fn run_domain(
     bootstrap_result: BootstrapResult<CBlock>,
     domain_configuration: DomainConfiguration,
     domain_start_options: DomainStartOptions,
-    consensus_chain_sync_params: Option<
-        ConsensusChainSyncParams<CBlock, <DomainBlock as BlockT>::Header>,
-    >,
+    consensus_chain_sync_params: Option<ConsensusChainSyncParams<CBlock, HeaderFor<DomainBlock>>>,
 ) -> Result<(), Error> {
     let BootstrapResult {
         domain_instance_data,

--- a/crates/subspace-runtime-primitives/src/lib.rs
+++ b/crates/subspace-runtime-primitives/src/lib.rs
@@ -93,6 +93,9 @@ pub type Moment = u64;
 /// Type alias for extrinsics.
 pub type ExtrinsicFor<Block> = <Block as BlockT>::Extrinsic;
 
+/// Type alias for block hash.
+pub type BlockHashFor<Block> = <Block as BlockT>::Hash;
+
 parameter_types! {
     /// Event segments are disabled on the consensus chain.
     pub const ConsensusEventSegmentSize: u32 = 0;

--- a/crates/subspace-runtime-primitives/src/lib.rs
+++ b/crates/subspace-runtime-primitives/src/lib.rs
@@ -96,6 +96,9 @@ pub type ExtrinsicFor<Block> = <Block as BlockT>::Extrinsic;
 /// Type alias for block hash.
 pub type BlockHashFor<Block> = <Block as BlockT>::Hash;
 
+/// Type alias for block header.
+pub type HeaderFor<Block> = <Block as BlockT>::Header;
+
 parameter_types! {
     /// Event segments are disabled on the consensus chain.
     pub const ConsensusEventSegmentSize: u32 = 0;

--- a/crates/subspace-runtime-primitives/src/lib.rs
+++ b/crates/subspace-runtime-primitives/src/lib.rs
@@ -24,7 +24,7 @@ use pallet_transaction_payment::{
 use parity_scale_codec::{Codec, Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
 use sp_core::parameter_types;
-use sp_runtime::traits::{Bounded, IdentifyAccount, Verify};
+use sp_runtime::traits::{Block as BlockT, Bounded, IdentifyAccount, Verify};
 use sp_runtime::{FixedPointNumber, MultiSignature, Perbill, Perquintill};
 pub use subspace_core_primitives::BlockNumber;
 
@@ -89,6 +89,9 @@ pub type Hash = sp_core::H256;
 
 /// Type used for expressing timestamp.
 pub type Moment = u64;
+
+/// Type alias for extrinsics.
+pub type ExtrinsicFor<Block> = <Block as BlockT>::Extrinsic;
 
 parameter_types! {
     /// Event segments are disabled on the consensus chain.

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -77,8 +77,7 @@ use sp_messenger::{ChannelNonce, XdmId};
 use sp_messenger_host_functions::{get_storage_key, StorageKeyRequest};
 use sp_mmr_primitives::EncodableOpaqueLeaf;
 use sp_runtime::traits::{
-    AccountIdConversion, AccountIdLookup, BlakeTwo256, Block as BlockT, ConstU128, Keccak256,
-    NumberFor,
+    AccountIdConversion, AccountIdLookup, BlakeTwo256, ConstU128, Keccak256, NumberFor,
 };
 use sp_runtime::transaction_validity::{TransactionSource, TransactionValidity};
 use sp_runtime::type_with_default::TypeWithDefault;
@@ -105,10 +104,11 @@ use subspace_runtime_primitives::utility::{
 };
 use subspace_runtime_primitives::{
     maximum_normal_block_length, AccountId, Balance, BlockHashFor, BlockNumber,
-    ConsensusEventSegmentSize, ExtrinsicFor, FindBlockRewardAddress, Hash, HoldIdentifier, Moment,
-    Nonce, Signature, SlowAdjustingFeeUpdate, TargetBlockFullness, XdmAdjustedWeightToFee,
-    XdmFeeMultipler, BLOCK_WEIGHT_FOR_2_SEC, DOMAINS_BLOCK_PRUNING_DEPTH, MAX_BLOCK_LENGTH,
-    MIN_REPLICATION_FACTOR, NORMAL_DISPATCH_RATIO, SHANNON, SLOT_PROBABILITY, SSC,
+    ConsensusEventSegmentSize, ExtrinsicFor, FindBlockRewardAddress, Hash, HeaderFor,
+    HoldIdentifier, Moment, Nonce, Signature, SlowAdjustingFeeUpdate, TargetBlockFullness,
+    XdmAdjustedWeightToFee, XdmFeeMultipler, BLOCK_WEIGHT_FOR_2_SEC, DOMAINS_BLOCK_PRUNING_DEPTH,
+    MAX_BLOCK_LENGTH, MIN_REPLICATION_FACTOR, NORMAL_DISPATCH_RATIO, SHANNON, SLOT_PROBABILITY,
+    SSC,
 };
 
 sp_runtime::impl_opaque_keys! {
@@ -1279,7 +1279,7 @@ impl_runtime_apis! {
             Executive::execute_block(block);
         }
 
-        fn initialize_block(header: &<Block as BlockT>::Header) -> ExtrinsicInclusionMode {
+        fn initialize_block(header: &HeaderFor<Block>) -> ExtrinsicInclusionMode {
             Executive::initialize_block(header)
         }
     }
@@ -1303,7 +1303,7 @@ impl_runtime_apis! {
             Executive::apply_extrinsic(extrinsic)
         }
 
-        fn finalize_block() -> <Block as BlockT>::Header {
+        fn finalize_block() -> HeaderFor<Block> {
             Executive::finalize_block()
         }
 
@@ -1330,7 +1330,7 @@ impl_runtime_apis! {
     }
 
     impl sp_offchain::OffchainWorkerApi<Block> for Runtime {
-        fn offchain_worker(header: &<Block as BlockT>::Header) {
+        fn offchain_worker(header: &HeaderFor<Block>) {
             Executive::offchain_worker(header)
         }
     }

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -104,11 +104,11 @@ use subspace_runtime_primitives::utility::{
     DefaultNonceProvider, MaybeMultisigCall, MaybeNestedCall, MaybeUtilityCall,
 };
 use subspace_runtime_primitives::{
-    maximum_normal_block_length, AccountId, Balance, BlockNumber, ConsensusEventSegmentSize,
-    ExtrinsicFor, FindBlockRewardAddress, Hash, HoldIdentifier, Moment, Nonce, Signature,
-    SlowAdjustingFeeUpdate, TargetBlockFullness, XdmAdjustedWeightToFee, XdmFeeMultipler,
-    BLOCK_WEIGHT_FOR_2_SEC, DOMAINS_BLOCK_PRUNING_DEPTH, MAX_BLOCK_LENGTH, MIN_REPLICATION_FACTOR,
-    NORMAL_DISPATCH_RATIO, SHANNON, SLOT_PROBABILITY, SSC,
+    maximum_normal_block_length, AccountId, Balance, BlockHashFor, BlockNumber,
+    ConsensusEventSegmentSize, ExtrinsicFor, FindBlockRewardAddress, Hash, HoldIdentifier, Moment,
+    Nonce, Signature, SlowAdjustingFeeUpdate, TargetBlockFullness, XdmAdjustedWeightToFee,
+    XdmFeeMultipler, BLOCK_WEIGHT_FOR_2_SEC, DOMAINS_BLOCK_PRUNING_DEPTH, MAX_BLOCK_LENGTH,
+    MIN_REPLICATION_FACTOR, NORMAL_DISPATCH_RATIO, SHANNON, SLOT_PROBABILITY, SSC,
 };
 
 sp_runtime::impl_opaque_keys! {
@@ -1323,7 +1323,7 @@ impl_runtime_apis! {
         fn validate_transaction(
             source: TransactionSource,
             tx: ExtrinsicFor<Block>,
-            block_hash: <Block as BlockT>::Hash,
+            block_hash: BlockHashFor<Block>,
         ) -> TransactionValidity {
             Executive::validate_transaction(source, tx, block_hash)
         }
@@ -1351,7 +1351,7 @@ impl_runtime_apis! {
         }
 
         fn submit_vote_extrinsic(
-            signed_vote: SignedVote<NumberFor<Block>, <Block as BlockT>::Hash, PublicKey>,
+            signed_vote: SignedVote<NumberFor<Block>, BlockHashFor<Block>, PublicKey>,
         ) {
             let SignedVote { vote, signature } = signed_vote;
             let Vote::V0 {
@@ -1424,13 +1424,13 @@ impl_runtime_apis! {
 
     impl sp_domains::DomainsApi<Block, DomainHeader> for Runtime {
         fn submit_bundle_unsigned(
-            opaque_bundle: sp_domains::OpaqueBundle<NumberFor<Block>, <Block as BlockT>::Hash, DomainHeader, Balance>,
+            opaque_bundle: sp_domains::OpaqueBundle<NumberFor<Block>, BlockHashFor<Block>, DomainHeader, Balance>,
         ) {
             Domains::submit_bundle_unsigned(opaque_bundle)
         }
 
         fn submit_receipt_unsigned(
-            singleton_receipt: sp_domains::SealedSingletonReceipt<NumberFor<Block>, <Block as BlockT>::Hash, DomainHeader, Balance>,
+            singleton_receipt: sp_domains::SealedSingletonReceipt<NumberFor<Block>, BlockHashFor<Block>, DomainHeader, Balance>,
         ) {
             Domains::submit_receipt_unsigned(singleton_receipt)
         }
@@ -1602,14 +1602,14 @@ impl_runtime_apis! {
         }
     }
 
-    impl sp_messenger::MessengerApi<Block, BlockNumber, <Block as BlockT>::Hash> for Runtime {
+    impl sp_messenger::MessengerApi<Block, BlockNumber, BlockHashFor<Block>> for Runtime {
         fn is_xdm_mmr_proof_valid(
             ext: &ExtrinsicFor<Block>
         ) -> Option<bool> {
             is_xdm_mmr_proof_valid(ext)
         }
 
-        fn extract_xdm_mmr_proof(ext: &ExtrinsicFor<Block>) -> Option<ConsensusChainMmrLeafProof<BlockNumber, <Block as BlockT>::Hash, sp_core::H256>> {
+        fn extract_xdm_mmr_proof(ext: &ExtrinsicFor<Block>) -> Option<ConsensusChainMmrLeafProof<BlockNumber, BlockHashFor<Block>, sp_core::H256>> {
             match &ext.function {
                 RuntimeCall::Messenger(pallet_messenger::Call::relay_message { msg })
                 | RuntimeCall::Messenger(pallet_messenger::Call::relay_message_response { msg }) => {
@@ -1652,16 +1652,16 @@ impl_runtime_apis! {
         }
     }
 
-    impl sp_messenger::RelayerApi<Block, BlockNumber, BlockNumber, <Block as BlockT>::Hash> for Runtime {
+    impl sp_messenger::RelayerApi<Block, BlockNumber, BlockNumber, BlockHashFor<Block>> for Runtime {
         fn block_messages() -> BlockMessagesWithStorageKey {
             Messenger::get_block_messages()
         }
 
-        fn outbox_message_unsigned(msg: CrossDomainMessage<NumberFor<Block>, <Block as BlockT>::Hash, <Block as BlockT>::Hash>) -> Option<ExtrinsicFor<Block>> {
+        fn outbox_message_unsigned(msg: CrossDomainMessage<NumberFor<Block>, BlockHashFor<Block>, BlockHashFor<Block>>) -> Option<ExtrinsicFor<Block>> {
             Messenger::outbox_message_unsigned(msg)
         }
 
-        fn inbox_response_message_unsigned(msg: CrossDomainMessage<NumberFor<Block>, <Block as BlockT>::Hash, <Block as BlockT>::Hash>) -> Option<ExtrinsicFor<Block>> {
+        fn inbox_response_message_unsigned(msg: CrossDomainMessage<NumberFor<Block>, BlockHashFor<Block>, BlockHashFor<Block>>) -> Option<ExtrinsicFor<Block>> {
             Messenger::inbox_response_message_unsigned(msg)
         }
 
@@ -1687,7 +1687,7 @@ impl_runtime_apis! {
     }
 
     impl sp_domains_fraud_proof::FraudProofApi<Block, DomainHeader> for Runtime {
-        fn submit_fraud_proof_unsigned(fraud_proof: FraudProof<NumberFor<Block>, <Block as BlockT>::Hash, DomainHeader, H256>) {
+        fn submit_fraud_proof_unsigned(fraud_proof: FraudProof<NumberFor<Block>, BlockHashFor<Block>, DomainHeader, H256>) {
             Domains::submit_fraud_proof_unsigned(fraud_proof)
         }
 

--- a/crates/subspace-service/src/lib.rs
+++ b/crates/subspace-service/src/lib.rs
@@ -120,7 +120,7 @@ use subspace_networking::libp2p::multiaddr::Protocol;
 use subspace_networking::utils::piece_provider::PieceProvider;
 use subspace_proof_of_space::Table;
 use subspace_runtime_primitives::opaque::Block;
-use subspace_runtime_primitives::{AccountId, Balance, Hash, Nonce};
+use subspace_runtime_primitives::{AccountId, Balance, BlockHashFor, Hash, Nonce};
 use tokio::sync::broadcast;
 use tracing::{debug, error, info, Instrument};
 pub use utils::wait_for_block_import;
@@ -488,7 +488,7 @@ where
         + BundleProducerElectionApi<Block, Balance>
         + ObjectsApi<Block>
         + MmrApi<Block, H256, NumberFor<Block>>
-        + MessengerApi<Block, NumberFor<Block>, <Block as BlockT>::Hash>,
+        + MessengerApi<Block, NumberFor<Block>, BlockHashFor<Block>>,
 {
     let telemetry = config
         .telemetry_endpoints
@@ -688,7 +688,7 @@ where
         + FraudProofApi<Block, DomainHeader>
         + SubspaceApi<Block, PublicKey>
         + MmrApi<Block, H256, NumberFor<Block>>
-        + MessengerApi<Block, NumberFor<Block>, <Block as BlockT>::Hash>,
+        + MessengerApi<Block, NumberFor<Block>, BlockHashFor<Block>>,
 {
     /// Task manager.
     pub task_manager: TaskManager,
@@ -754,7 +754,7 @@ where
         + FraudProofApi<Block, DomainHeader>
         + ObjectsApi<Block>
         + MmrApi<Block, Hash, BlockNumber>
-        + MessengerApi<Block, NumberFor<Block>, <Block as BlockT>::Hash>,
+        + MessengerApi<Block, NumberFor<Block>, BlockHashFor<Block>>,
 {
     let PartialComponents {
         client,
@@ -927,7 +927,7 @@ where
 
     // enable domain block ER request handler
     let (handler, protocol_config) = DomainBlockERRequestHandler::new::<
-        NetworkWorker<Block, <Block as BlockT>::Hash>,
+        NetworkWorker<Block, BlockHashFor<Block>>,
     >(fork_id, client.clone(), num_peer_hint);
     task_manager.spawn_handle().spawn(
         "domain-block-er-request-handler",
@@ -939,7 +939,7 @@ where
     if let Some(offchain_storage) = backend.offchain_storage() {
         // Allow both outgoing and incoming requests.
         let (handler, protocol_config) =
-            MmrRequestHandler::new::<NetworkWorker<Block, <Block as BlockT>::Hash>>(
+            MmrRequestHandler::new::<NetworkWorker<Block, BlockHashFor<Block>>>(
                 &config.base.protocol_id(),
                 fork_id,
                 client.clone(),

--- a/crates/subspace-service/src/mmr/request_handler.rs
+++ b/crates/subspace-service/src/mmr/request_handler.rs
@@ -38,6 +38,7 @@ use std::marker::PhantomData;
 use std::sync::Arc;
 use std::time::Duration;
 use subspace_core_primitives::BlockNumber;
+use subspace_runtime_primitives::BlockHashFor;
 use tracing::{debug, error, trace};
 
 const MAX_NUMBER_OF_SAME_REQUESTS_PER_PEER: usize = 2;
@@ -157,7 +158,7 @@ where
         offchain_storage: OS,
     ) -> (Self, NB::RequestResponseProtocolConfig)
     where
-        NB: NetworkBackend<Block, <Block as BlockT>::Hash>,
+        NB: NetworkBackend<Block, BlockHashFor<Block>>,
     {
         // Reserve enough request slots for one request per peer when we are at the maximum
         // number of peers.

--- a/crates/subspace-service/src/sync_from_dsn/import_blocks.rs
+++ b/crates/subspace-service/src/sync_from_dsn/import_blocks.rs
@@ -36,7 +36,7 @@ pub(super) async fn import_blocks_from_dsn<Block, AS, Client, PG, IQS>(
     piece_getter: &PG,
     import_queue_service: &mut IQS,
     last_processed_segment_index: &mut SegmentIndex,
-    last_processed_block_number: &mut <Block::Header as Header>::Number,
+    last_processed_block_number: &mut NumberFor<Block>,
     erasure_coding: &ErasureCoding,
 ) -> Result<u64, Error>
 where

--- a/domains/client/block-builder/Cargo.toml
+++ b/domains/client/block-builder/Cargo.toml
@@ -28,5 +28,5 @@ sp-externalities.workspace = true
 sp-inherents.workspace = true
 sp-runtime.workspace = true
 sp-state-machine.workspace = true
-subspace-runtime-primitives.workspace = true
+subspace-runtime-primitives = { workspace = true, features = ["std"] }
 tracing.workspace = true

--- a/domains/client/block-builder/Cargo.toml
+++ b/domains/client/block-builder/Cargo.toml
@@ -28,4 +28,5 @@ sp-externalities.workspace = true
 sp-inherents.workspace = true
 sp-runtime.workspace = true
 sp-state-machine.workspace = true
+subspace-runtime-primitives.workspace = true
 tracing.workspace = true

--- a/domains/client/block-builder/src/custom_api.rs
+++ b/domains/client/block-builder/src/custom_api.rs
@@ -17,6 +17,7 @@ use std::borrow::Cow;
 use std::collections::HashMap;
 use std::marker::PhantomData;
 use std::sync::Arc;
+use subspace_runtime_primitives::ExtrinsicFor;
 
 type TrieBackendStorageFor<State, Block> =
     <State as StateBackend<HashingFor<Block>>>::TrieBackendStorage;
@@ -332,7 +333,7 @@ where
 
     pub(crate) fn apply_extrinsic(
         &self,
-        extrinsic: <Block as BlockT>::Extrinsic,
+        extrinsic: ExtrinsicFor<Block>,
         backend: &TrieDeltaBackendFor<Backend::State, Block>,
         overlayed_changes: &mut OverlayedChanges<HashingFor<Block>>,
     ) -> Result<ApplyExtrinsicResult, sp_blockchain::Error> {
@@ -363,7 +364,7 @@ where
         inherent: InherentData,
         backend: &TrieDeltaBackendFor<Backend::State, Block>,
         overlayed_changes: &mut OverlayedChanges<HashingFor<Block>>,
-    ) -> Result<Vec<<Block as BlockT>::Extrinsic>, sp_blockchain::Error> {
+    ) -> Result<Vec<ExtrinsicFor<Block>>, sp_blockchain::Error> {
         let call_data = inherent.encode();
         self.call_function(
             "BlockBuilder_inherent_extrinsics",

--- a/domains/client/block-preprocessor/src/lib.rs
+++ b/domains/client/block-preprocessor/src/lib.rs
@@ -42,9 +42,9 @@ use std::collections::VecDeque;
 use std::marker::PhantomData;
 use std::sync::Arc;
 use subspace_core_primitives::{Randomness, U256};
-use subspace_runtime_primitives::Balance;
+use subspace_runtime_primitives::{Balance, ExtrinsicFor};
 
-type DomainBlockElements<CBlock> = (Vec<<CBlock as BlockT>::Extrinsic>, Randomness);
+type DomainBlockElements<CBlock> = (Vec<ExtrinsicFor<CBlock>>, Randomness);
 
 /// A wrapper indicating a valid bundle contents, or an invalid bundle reason.
 enum BundleValidity<Extrinsic> {

--- a/domains/client/block-preprocessor/src/stateless_runtime.rs
+++ b/domains/client/block-preprocessor/src/stateless_runtime.rs
@@ -24,7 +24,7 @@ use std::borrow::Cow;
 use std::marker::PhantomData;
 use std::sync::Arc;
 use subspace_core_primitives::{BlockHash, BlockNumber, U256};
-use subspace_runtime_primitives::Moment;
+use subspace_runtime_primitives::{ExtrinsicFor, Moment};
 
 /// Stateless runtime api based on the runtime code and partial state if provided.
 ///
@@ -150,7 +150,7 @@ impl<CBlock, Block, Executor> FetchRuntimeCode for StatelessRuntime<CBlock, Bloc
     }
 }
 
-pub type ExtractSignerResult<Block> = Vec<(Option<AccountId>, <Block as BlockT>::Extrinsic)>;
+pub type ExtractSignerResult<Block> = Vec<(Option<AccountId>, ExtrinsicFor<Block>)>;
 
 impl<CBlock, Block, Executor> StatelessRuntime<CBlock, Block, Executor>
 where

--- a/domains/client/domain-operator/src/aux_schema.rs
+++ b/domains/client/domain-operator/src/aux_schema.rs
@@ -12,7 +12,7 @@ use sp_runtime::Saturating;
 use std::collections::BTreeSet;
 use std::sync::Arc;
 use subspace_core_primitives::BlockNumber;
-use subspace_runtime_primitives::DOMAINS_PRUNING_DEPTH_MULTIPLIER;
+use subspace_runtime_primitives::{BlockHashFor, DOMAINS_PRUNING_DEPTH_MULTIPLIER};
 
 const EXECUTION_RECEIPT: &[u8] = b"execution_receipt";
 const EXECUTION_RECEIPT_START: &[u8] = b"execution_receipt_start";
@@ -166,7 +166,7 @@ where
 }
 
 type MaybeTrackedDomainHashes<Block, CBlock> =
-    Option<BTreeSet<(<Block as BlockT>::Hash, <CBlock as BlockT>::Hash)>>;
+    Option<BTreeSet<(BlockHashFor<Block>, BlockHashFor<CBlock>)>>;
 
 fn get_tracked_domain_hash_keys<Backend, Block, CBlock>(
     backend: &Backend,

--- a/domains/client/domain-operator/src/domain_block_processor.rs
+++ b/domains/client/domain-operator/src/domain_block_processor.rs
@@ -971,10 +971,11 @@ mod tests {
     use super::*;
     use domain_test_service::evm_domain_test_runtime::Block;
     use sp_domains::{InboxedBundle, InvalidBundleType};
+    use subspace_runtime_primitives::BlockHashFor;
     use subspace_test_runtime::Block as CBlock;
 
     fn create_test_execution_receipt(
-        inboxed_bundles: Vec<InboxedBundle<<Block as BlockT>::Hash>>,
+        inboxed_bundles: Vec<InboxedBundle<BlockHashFor<Block>>>,
     ) -> ExecutionReceiptFor<Block, CBlock>
     where
         Block: BlockT,

--- a/domains/client/domain-operator/src/domain_bundle_producer.rs
+++ b/domains/client/domain-operator/src/domain_bundle_producer.rs
@@ -21,29 +21,18 @@ use sp_runtime::traits::{Block as BlockT, NumberFor, Zero};
 use sp_runtime::{RuntimeAppPublic, Saturating};
 use sp_transaction_pool::runtime_api::TaggedTransactionQueue;
 use std::sync::Arc;
-use subspace_runtime_primitives::{Balance, BlockHashFor, ExtrinsicFor};
+use subspace_runtime_primitives::{Balance, BlockHashFor, ExtrinsicFor, HeaderFor};
 use tracing::info;
-
-/// Type alias for block header.
-pub type HeaderFor<Block> = <Block as BlockT>::Header;
 
 /// Type alias for bundle header.
 pub type BundleHeaderFor<Block, CBlock> =
     BundleHeader<NumberFor<CBlock>, BlockHashFor<CBlock>, HeaderFor<Block>, Balance>;
 
-type OpaqueBundle<Block, CBlock> = sp_domains::OpaqueBundle<
-    NumberFor<CBlock>,
-    BlockHashFor<CBlock>,
-    <Block as BlockT>::Header,
-    Balance,
->;
+type OpaqueBundle<Block, CBlock> =
+    sp_domains::OpaqueBundle<NumberFor<CBlock>, BlockHashFor<CBlock>, HeaderFor<Block>, Balance>;
 
-type SealedSingletonReceiptFor<Block, CBlock> = SealedSingletonReceipt<
-    NumberFor<CBlock>,
-    BlockHashFor<CBlock>,
-    <Block as BlockT>::Header,
-    Balance,
->;
+type SealedSingletonReceiptFor<Block, CBlock> =
+    SealedSingletonReceipt<NumberFor<CBlock>, BlockHashFor<CBlock>, HeaderFor<Block>, Balance>;
 
 pub enum DomainProposal<Block: BlockT, CBlock: BlockT> {
     Bundle(OpaqueBundle<Block, CBlock>),

--- a/domains/client/domain-operator/src/domain_bundle_producer.rs
+++ b/domains/client/domain-operator/src/domain_bundle_producer.rs
@@ -21,7 +21,7 @@ use sp_runtime::traits::{Block as BlockT, NumberFor, Zero};
 use sp_runtime::{RuntimeAppPublic, Saturating};
 use sp_transaction_pool::runtime_api::TaggedTransactionQueue;
 use std::sync::Arc;
-use subspace_runtime_primitives::Balance;
+use subspace_runtime_primitives::{Balance, ExtrinsicFor};
 use tracing::info;
 
 /// Type alias for block hash.
@@ -33,9 +33,6 @@ pub type HeaderFor<Block> = <Block as BlockT>::Header;
 /// Type alias for bundle header.
 pub type BundleHeaderFor<Block, CBlock> =
     BundleHeader<NumberFor<CBlock>, BlockHashFor<CBlock>, HeaderFor<Block>, Balance>;
-
-/// Type alias for extrinsics.
-pub type ExtrinsicFor<Block> = <Block as BlockT>::Extrinsic;
 
 type OpaqueBundle<Block, CBlock> = sp_domains::OpaqueBundle<
     NumberFor<CBlock>,

--- a/domains/client/domain-operator/src/domain_bundle_producer.rs
+++ b/domains/client/domain-operator/src/domain_bundle_producer.rs
@@ -21,11 +21,8 @@ use sp_runtime::traits::{Block as BlockT, NumberFor, Zero};
 use sp_runtime::{RuntimeAppPublic, Saturating};
 use sp_transaction_pool::runtime_api::TaggedTransactionQueue;
 use std::sync::Arc;
-use subspace_runtime_primitives::{Balance, ExtrinsicFor};
+use subspace_runtime_primitives::{Balance, BlockHashFor, ExtrinsicFor};
 use tracing::info;
-
-/// Type alias for block hash.
-pub type BlockHashFor<Block> = <Block as BlockT>::Hash;
 
 /// Type alias for block header.
 pub type HeaderFor<Block> = <Block as BlockT>::Header;
@@ -36,14 +33,14 @@ pub type BundleHeaderFor<Block, CBlock> =
 
 type OpaqueBundle<Block, CBlock> = sp_domains::OpaqueBundle<
     NumberFor<CBlock>,
-    <CBlock as BlockT>::Hash,
+    BlockHashFor<CBlock>,
     <Block as BlockT>::Header,
     Balance,
 >;
 
 type SealedSingletonReceiptFor<Block, CBlock> = SealedSingletonReceipt<
     NumberFor<CBlock>,
-    <CBlock as BlockT>::Hash,
+    BlockHashFor<CBlock>,
     <Block as BlockT>::Header,
     Balance,
 >;

--- a/domains/client/domain-operator/src/domain_bundle_proposer.rs
+++ b/domains/client/domain-operator/src/domain_bundle_proposer.rs
@@ -22,7 +22,7 @@ use std::marker::PhantomData;
 use std::sync::Arc;
 use std::time;
 use subspace_core_primitives::U256;
-use subspace_runtime_primitives::Balance;
+use subspace_runtime_primitives::{Balance, ExtrinsicFor};
 
 /// If the bundle utilization is below `BUNDLE_UTILIZATION_THRESHOLD` we will attempt to push
 /// at most `MAX_SKIPPED_TRANSACTIONS` number of transactions before quitting for real.
@@ -87,7 +87,7 @@ impl<Block: BlockT, Client, CBlock: BlockT, CClient, TransactionPool> Clone
 
 pub(super) type ProposeBundleOutput<Block, CBlock> = (
     BundleHeader<NumberFor<CBlock>, <CBlock as BlockT>::Hash, <Block as BlockT>::Header, Balance>,
-    Vec<<Block as BlockT>::Extrinsic>,
+    Vec<ExtrinsicFor<Block>>,
 );
 
 impl<Block, Client, CBlock, CClient, TransactionPool>

--- a/domains/client/domain-operator/src/domain_bundle_proposer.rs
+++ b/domains/client/domain-operator/src/domain_bundle_proposer.rs
@@ -22,7 +22,7 @@ use std::marker::PhantomData;
 use std::sync::Arc;
 use std::time;
 use subspace_core_primitives::U256;
-use subspace_runtime_primitives::{Balance, BlockHashFor, ExtrinsicFor};
+use subspace_runtime_primitives::{Balance, BlockHashFor, ExtrinsicFor, HeaderFor};
 
 /// If the bundle utilization is below `BUNDLE_UTILIZATION_THRESHOLD` we will attempt to push
 /// at most `MAX_SKIPPED_TRANSACTIONS` number of transactions before quitting for real.
@@ -86,7 +86,7 @@ impl<Block: BlockT, Client, CBlock: BlockT, CClient, TransactionPool> Clone
 }
 
 pub(super) type ProposeBundleOutput<Block, CBlock> = (
-    BundleHeader<NumberFor<CBlock>, BlockHashFor<CBlock>, <Block as BlockT>::Header, Balance>,
+    BundleHeader<NumberFor<CBlock>, BlockHashFor<CBlock>, HeaderFor<Block>, Balance>,
     Vec<ExtrinsicFor<Block>>,
 );
 

--- a/domains/client/domain-operator/src/domain_bundle_proposer.rs
+++ b/domains/client/domain-operator/src/domain_bundle_proposer.rs
@@ -22,7 +22,7 @@ use std::marker::PhantomData;
 use std::sync::Arc;
 use std::time;
 use subspace_core_primitives::U256;
-use subspace_runtime_primitives::{Balance, ExtrinsicFor};
+use subspace_runtime_primitives::{Balance, BlockHashFor, ExtrinsicFor};
 
 /// If the bundle utilization is below `BUNDLE_UTILIZATION_THRESHOLD` we will attempt to push
 /// at most `MAX_SKIPPED_TRANSACTIONS` number of transactions before quitting for real.
@@ -86,7 +86,7 @@ impl<Block: BlockT, Client, CBlock: BlockT, CClient, TransactionPool> Clone
 }
 
 pub(super) type ProposeBundleOutput<Block, CBlock> = (
-    BundleHeader<NumberFor<CBlock>, <CBlock as BlockT>::Hash, <Block as BlockT>::Header, Balance>,
+    BundleHeader<NumberFor<CBlock>, BlockHashFor<CBlock>, <Block as BlockT>::Header, Balance>,
     Vec<ExtrinsicFor<Block>>,
 );
 

--- a/domains/client/domain-operator/src/domain_worker.rs
+++ b/domains/client/domain-operator/src/domain_worker.rs
@@ -41,11 +41,11 @@ use sp_transaction_pool::runtime_api::TaggedTransactionQueue;
 use std::pin::{pin, Pin};
 use std::sync::Arc;
 use std::task::{Context, Poll};
-use subspace_runtime_primitives::{Balance, BlockHashFor};
+use subspace_runtime_primitives::{Balance, BlockHashFor, HeaderFor};
 use tracing::{info, Instrument};
 
 pub type OpaqueBundleFor<Block, CBlock> =
-    OpaqueBundle<NumberFor<CBlock>, BlockHashFor<CBlock>, <Block as BlockT>::Header, Balance>;
+    OpaqueBundle<NumberFor<CBlock>, BlockHashFor<CBlock>, HeaderFor<Block>, Balance>;
 
 #[allow(clippy::type_complexity, clippy::too_many_arguments)]
 pub(super) async fn start_worker<

--- a/domains/client/domain-operator/src/domain_worker.rs
+++ b/domains/client/domain-operator/src/domain_worker.rs
@@ -41,11 +41,11 @@ use sp_transaction_pool::runtime_api::TaggedTransactionQueue;
 use std::pin::{pin, Pin};
 use std::sync::Arc;
 use std::task::{Context, Poll};
-use subspace_runtime_primitives::Balance;
+use subspace_runtime_primitives::{Balance, BlockHashFor};
 use tracing::{info, Instrument};
 
 pub type OpaqueBundleFor<Block, CBlock> =
-    OpaqueBundle<NumberFor<CBlock>, <CBlock as BlockT>::Hash, <Block as BlockT>::Header, Balance>;
+    OpaqueBundle<NumberFor<CBlock>, BlockHashFor<CBlock>, <Block as BlockT>::Header, Balance>;
 
 #[allow(clippy::type_complexity, clippy::too_many_arguments)]
 pub(super) async fn start_worker<

--- a/domains/client/domain-operator/src/fraud_proof.rs
+++ b/domains/client/domain-operator/src/fraud_proof.rs
@@ -33,6 +33,7 @@ use sp_runtime::{Digest, DigestItem};
 use sp_trie::LayoutV1;
 use std::marker::PhantomData;
 use std::sync::Arc;
+use subspace_runtime_primitives::BlockHashFor;
 
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub enum TraceDiffType {
@@ -105,7 +106,7 @@ impl<Block: BlockT, CBlock, Client, CClient, Backend, E> Clone
 }
 
 type FraudProofFor<CBlock, DomainHeader> =
-    FraudProof<NumberFor<CBlock>, <CBlock as BlockT>::Hash, DomainHeader, H256>;
+    FraudProof<NumberFor<CBlock>, BlockHashFor<CBlock>, DomainHeader, H256>;
 
 impl<Block, CBlock, Client, CClient, Backend, E>
     FraudProofGenerator<Block, CBlock, Client, CClient, Backend, E>

--- a/domains/client/domain-operator/src/lib.rs
+++ b/domains/client/domain-operator/src/lib.rs
@@ -110,7 +110,7 @@ use std::marker::PhantomData;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use subspace_core_primitives::pot::PotOutput;
-use subspace_runtime_primitives::{Balance, BlockHashFor, ExtrinsicFor};
+use subspace_runtime_primitives::{Balance, BlockHashFor, ExtrinsicFor, HeaderFor};
 
 /// Domain sync oracle.
 ///
@@ -156,17 +156,10 @@ where
     }
 }
 
-pub type ExecutionReceiptFor<Block, CBlock> =
-    ExecutionReceipt<<Block as BlockT>::Header, CBlock, Balance>;
+pub type ExecutionReceiptFor<Block, CBlock> = ExecutionReceipt<HeaderFor<Block>, CBlock, Balance>;
 
 type BundleSender<Block, CBlock> = TracingUnboundedSender<
-    Bundle<
-        ExtrinsicFor<Block>,
-        NumberFor<CBlock>,
-        BlockHashFor<CBlock>,
-        <Block as BlockT>::Header,
-        Balance,
-    >,
+    Bundle<ExtrinsicFor<Block>, NumberFor<CBlock>, BlockHashFor<CBlock>, HeaderFor<Block>, Balance>,
 >;
 
 /// Notification streams from the consensus chain driving the executor.

--- a/domains/client/domain-operator/src/lib.rs
+++ b/domains/client/domain-operator/src/lib.rs
@@ -110,7 +110,7 @@ use std::marker::PhantomData;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use subspace_core_primitives::pot::PotOutput;
-use subspace_runtime_primitives::Balance;
+use subspace_runtime_primitives::{Balance, ExtrinsicFor};
 
 /// Domain sync oracle.
 ///
@@ -161,7 +161,7 @@ pub type ExecutionReceiptFor<Block, CBlock> =
 
 type BundleSender<Block, CBlock> = TracingUnboundedSender<
     Bundle<
-        <Block as BlockT>::Extrinsic,
+        ExtrinsicFor<Block>,
         NumberFor<CBlock>,
         <CBlock as BlockT>::Hash,
         <Block as BlockT>::Header,

--- a/domains/client/domain-operator/src/lib.rs
+++ b/domains/client/domain-operator/src/lib.rs
@@ -110,7 +110,7 @@ use std::marker::PhantomData;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use subspace_core_primitives::pot::PotOutput;
-use subspace_runtime_primitives::{Balance, ExtrinsicFor};
+use subspace_runtime_primitives::{Balance, BlockHashFor, ExtrinsicFor};
 
 /// Domain sync oracle.
 ///
@@ -163,7 +163,7 @@ type BundleSender<Block, CBlock> = TracingUnboundedSender<
     Bundle<
         ExtrinsicFor<Block>,
         NumberFor<CBlock>,
-        <CBlock as BlockT>::Hash,
+        BlockHashFor<CBlock>,
         <Block as BlockT>::Header,
         Balance,
     >,

--- a/domains/client/domain-operator/src/tests.rs
+++ b/domains/client/domain-operator/src/tests.rs
@@ -56,9 +56,7 @@ use sp_messenger::messages::{CrossDomainMessage, Proof};
 use sp_messenger::MessengerApi;
 use sp_mmr_primitives::{EncodableOpaqueLeaf, LeafProof as MmrProof};
 use sp_runtime::generic::{BlockId, DigestItem};
-use sp_runtime::traits::{
-    BlakeTwo256, Block as BlockT, Convert, Hash as HashT, Header as HeaderT, Zero,
-};
+use sp_runtime::traits::{BlakeTwo256, Convert, Hash as HashT, Header as HeaderT, Zero};
 use sp_runtime::transaction_validity::{
     InvalidTransaction, TransactionSource, TransactionValidityError,
 };
@@ -74,7 +72,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use subspace_core_primitives::pot::PotOutput;
 use subspace_runtime_primitives::opaque::Block as CBlock;
-use subspace_runtime_primitives::{Balance, BlockHashFor, SSC};
+use subspace_runtime_primitives::{Balance, BlockHashFor, HeaderFor, SSC};
 use subspace_test_primitives::{OnchainStateApi as _, DOMAINS_BLOCK_PRUNING_DEPTH};
 use subspace_test_runtime::Runtime;
 use subspace_test_service::{
@@ -7559,7 +7557,7 @@ async fn test_custom_api_storage_root_match_upstream_root() {
     let mut roots = vec![];
     let runtime_api_instance = alice.client.runtime_api();
 
-    let init_header = <<DomainBlock as BlockT>::Header as HeaderT>::new(
+    let init_header = <HeaderFor<DomainBlock> as HeaderT>::new(
         domain_parent_number + 1u32,
         Default::default(),
         Default::default(),

--- a/domains/client/domain-operator/src/tests.rs
+++ b/domains/client/domain-operator/src/tests.rs
@@ -74,7 +74,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use subspace_core_primitives::pot::PotOutput;
 use subspace_runtime_primitives::opaque::Block as CBlock;
-use subspace_runtime_primitives::{Balance, SSC};
+use subspace_runtime_primitives::{Balance, BlockHashFor, SSC};
 use subspace_test_primitives::{OnchainStateApi as _, DOMAINS_BLOCK_PRUNING_DEPTH};
 use subspace_test_runtime::Runtime;
 use subspace_test_service::{
@@ -6361,7 +6361,7 @@ async fn test_multiple_consensus_blocks_derive_similar_domain_block() {
     // The domain block header should contain a digest that points to the consensus block, which
     // derives the domain block
     let get_header = |hash| alice.client.header(hash).unwrap().unwrap();
-    let get_digest_consensus_block_hash = |header: &Header| -> <CBlock as BlockT>::Hash {
+    let get_digest_consensus_block_hash = |header: &Header| -> BlockHashFor<CBlock> {
         header
             .digest()
             .convert_first(DigestItem::as_consensus_block_info)
@@ -7605,9 +7605,9 @@ async fn test_custom_api_storage_root_match_upstream_root() {
         .unwrap();
     roots.push((*finalized_header.state_root()).into());
 
-    let roots: Vec<<DomainBlock as BlockT>::Hash> = roots
+    let roots: Vec<BlockHashFor<DomainBlock>> = roots
         .into_iter()
-        .map(|r| <DomainBlock as BlockT>::Hash::decode(&mut r.as_slice()).unwrap())
+        .map(|r| BlockHashFor::<DomainBlock>::decode(&mut r.as_slice()).unwrap())
         .collect();
 
     assert_eq!(receipt.execution_trace, roots);

--- a/domains/client/relayer/Cargo.toml
+++ b/domains/client/relayer/Cargo.toml
@@ -28,4 +28,5 @@ sp-messenger.workspace = true
 sp-mmr-primitives.workspace = true
 sp-runtime.workspace = true
 sp-subspace-mmr.workspace = true
+subspace-runtime-primitives.workspace = true
 tracing.workspace = true

--- a/domains/client/relayer/Cargo.toml
+++ b/domains/client/relayer/Cargo.toml
@@ -28,5 +28,5 @@ sp-messenger.workspace = true
 sp-mmr-primitives.workspace = true
 sp-runtime.workspace = true
 sp-subspace-mmr.workspace = true
-subspace-runtime-primitives.workspace = true
+subspace-runtime-primitives = { workspace = true, features = ["std"] }
 tracing.workspace = true

--- a/domains/client/relayer/src/lib.rs
+++ b/domains/client/relayer/src/lib.rs
@@ -27,6 +27,7 @@ use sp_runtime::ArithmeticError;
 use sp_subspace_mmr::ConsensusChainMmrLeafProof;
 use std::marker::PhantomData;
 use std::sync::Arc;
+use subspace_runtime_primitives::BlockHashFor;
 use tracing::log;
 
 /// The logging target.
@@ -94,7 +95,7 @@ impl From<sp_api::ApiError> for Error {
     }
 }
 
-type ProofOf<Block> = Proof<NumberFor<Block>, <Block as BlockT>::Hash, H256>;
+type ProofOf<Block> = Proof<NumberFor<Block>, BlockHashFor<Block>, H256>;
 
 fn construct_consensus_mmr_proof<Client, Block>(
     consensus_chain_client: &Arc<Client>,

--- a/domains/runtime/auto-id/src/lib.rs
+++ b/domains/runtime/auto-id/src/lib.rs
@@ -70,7 +70,7 @@ use sp_version::RuntimeVersion;
 use static_assertions::const_assert;
 use subspace_runtime_primitives::utility::DefaultNonceProvider;
 use subspace_runtime_primitives::{
-    BlockNumber as ConsensusBlockNumber, DomainEventSegmentSize, ExtrinsicFor,
+    BlockHashFor, BlockNumber as ConsensusBlockNumber, DomainEventSegmentSize, ExtrinsicFor,
     Hash as ConsensusBlockHash, Moment, SlowAdjustingFeeUpdate, XdmAdjustedWeightToFee,
     XdmFeeMultipler, MAX_CALL_RECURSION_DEPTH, SHANNON, SSC,
 };
@@ -793,7 +793,7 @@ impl_runtime_apis! {
         fn validate_transaction(
             source: TransactionSource,
             tx: ExtrinsicFor<Block>,
-            block_hash: <Block as BlockT>::Hash,
+            block_hash: BlockHashFor<Block>,
         ) -> TransactionValidity {
             Executive::validate_transaction(source, tx, block_hash)
         }
@@ -907,7 +907,7 @@ impl_runtime_apis! {
         }
 
         fn check_extrinsics_and_do_pre_dispatch(uxts: Vec<ExtrinsicFor<Block>>, block_number: BlockNumber,
-            block_hash: <Block as BlockT>::Hash) -> Result<(), CheckExtrinsicsValidityError> {
+            block_hash: BlockHashFor<Block>) -> Result<(), CheckExtrinsicsValidityError> {
             // Initializing block related storage required for validation
             System::initialize(
                 &(block_number + BlockNumber::one()),
@@ -1046,11 +1046,11 @@ impl_runtime_apis! {
             Messenger::get_block_messages()
         }
 
-        fn outbox_message_unsigned(msg: CrossDomainMessage<NumberFor<Block>, <Block as BlockT>::Hash, <Block as BlockT>::Hash>) -> Option<ExtrinsicFor<Block>> {
+        fn outbox_message_unsigned(msg: CrossDomainMessage<NumberFor<Block>, BlockHashFor<Block>, BlockHashFor<Block>>) -> Option<ExtrinsicFor<Block>> {
             Messenger::outbox_message_unsigned(msg)
         }
 
-        fn inbox_response_message_unsigned(msg: CrossDomainMessage<NumberFor<Block>, <Block as BlockT>::Hash, <Block as BlockT>::Hash>) -> Option<ExtrinsicFor<Block>> {
+        fn inbox_response_message_unsigned(msg: CrossDomainMessage<NumberFor<Block>, BlockHashFor<Block>, BlockHashFor<Block>>) -> Option<ExtrinsicFor<Block>> {
             Messenger::inbox_response_message_unsigned(msg)
         }
 

--- a/domains/runtime/auto-id/src/lib.rs
+++ b/domains/runtime/auto-id/src/lib.rs
@@ -70,9 +70,9 @@ use sp_version::RuntimeVersion;
 use static_assertions::const_assert;
 use subspace_runtime_primitives::utility::DefaultNonceProvider;
 use subspace_runtime_primitives::{
-    BlockNumber as ConsensusBlockNumber, DomainEventSegmentSize, Hash as ConsensusBlockHash,
-    Moment, SlowAdjustingFeeUpdate, XdmAdjustedWeightToFee, XdmFeeMultipler,
-    MAX_CALL_RECURSION_DEPTH, SHANNON, SSC,
+    BlockNumber as ConsensusBlockNumber, DomainEventSegmentSize, ExtrinsicFor,
+    Hash as ConsensusBlockHash, Moment, SlowAdjustingFeeUpdate, XdmAdjustedWeightToFee,
+    XdmFeeMultipler, MAX_CALL_RECURSION_DEPTH, SHANNON, SSC,
 };
 
 /// Block type as expected by this runtime.
@@ -571,7 +571,7 @@ fn create_unsigned_general_extrinsic(call: RuntimeCall) -> UncheckedExtrinsic {
     UncheckedExtrinsic::new_transaction(call, extra)
 }
 
-fn is_xdm_mmr_proof_valid(ext: &<Block as BlockT>::Extrinsic) -> Option<bool> {
+fn is_xdm_mmr_proof_valid(ext: &ExtrinsicFor<Block>) -> Option<bool> {
     match &ext.function {
         RuntimeCall::Messenger(pallet_messenger::Call::relay_message { msg })
         | RuntimeCall::Messenger(pallet_messenger::Call::relay_message_response { msg }) => {
@@ -601,7 +601,7 @@ fn is_valid_sudo_call(encoded_ext: Vec<u8>) -> bool {
     .is_ok()
 }
 
-fn construct_sudo_call_extrinsic(encoded_ext: Vec<u8>) -> <Block as BlockT>::Extrinsic {
+fn construct_sudo_call_extrinsic(encoded_ext: Vec<u8>) -> ExtrinsicFor<Block> {
     let ext = UncheckedExtrinsic::decode(&mut encoded_ext.as_slice()).expect(
         "must always be a valid extrinsic due to the check above and storage proof check; qed",
     );
@@ -643,7 +643,7 @@ pub fn extract_signer(
         .collect()
 }
 
-fn extrinsic_era(extrinsic: &<Block as BlockT>::Extrinsic) -> Option<Era> {
+fn extrinsic_era(extrinsic: &ExtrinsicFor<Block>) -> Option<Era> {
     match &extrinsic.preamble {
         Preamble::Bare(_) | Preamble::General(_, _) => None,
         Preamble::Signed(_, _, extra) => Some(extra.4 .0),
@@ -662,7 +662,7 @@ mod benches {
 }
 
 fn check_transaction_and_do_pre_dispatch_inner(
-    uxt: &<Block as BlockT>::Extrinsic,
+    uxt: &ExtrinsicFor<Block>,
 ) -> Result<(), TransactionValidityError> {
     let lookup = frame_system::ChainContext::<Runtime>::default();
 
@@ -769,7 +769,7 @@ impl_runtime_apis! {
     }
 
     impl sp_block_builder::BlockBuilder<Block> for Runtime {
-        fn apply_extrinsic(extrinsic: <Block as BlockT>::Extrinsic) -> ApplyExtrinsicResult {
+        fn apply_extrinsic(extrinsic: ExtrinsicFor<Block>) -> ApplyExtrinsicResult {
             Executive::apply_extrinsic(extrinsic)
         }
 
@@ -777,7 +777,7 @@ impl_runtime_apis! {
             Executive::finalize_block()
         }
 
-        fn inherent_extrinsics(data: sp_inherents::InherentData) -> Vec<<Block as BlockT>::Extrinsic> {
+        fn inherent_extrinsics(data: sp_inherents::InherentData) -> Vec<ExtrinsicFor<Block>> {
             data.create_extrinsics()
         }
 
@@ -792,7 +792,7 @@ impl_runtime_apis! {
     impl sp_transaction_pool::runtime_api::TaggedTransactionQueue<Block> for Runtime {
         fn validate_transaction(
             source: TransactionSource,
-            tx: <Block as BlockT>::Extrinsic,
+            tx: ExtrinsicFor<Block>,
             block_hash: <Block as BlockT>::Hash,
         ) -> TransactionValidity {
             Executive::validate_transaction(source, tx, block_hash)
@@ -825,13 +825,13 @@ impl_runtime_apis! {
 
     impl pallet_transaction_payment_rpc_runtime_api::TransactionPaymentApi<Block, Balance> for Runtime {
         fn query_info(
-            uxt: <Block as BlockT>::Extrinsic,
+            uxt: ExtrinsicFor<Block>,
             len: u32,
         ) -> pallet_transaction_payment_rpc_runtime_api::RuntimeDispatchInfo<Balance> {
             TransactionPayment::query_info(uxt, len)
         }
         fn query_fee_details(
-            uxt: <Block as BlockT>::Extrinsic,
+            uxt: ExtrinsicFor<Block>,
             len: u32,
         ) -> pallet_transaction_payment::FeeDetails<Balance> {
             TransactionPayment::query_fee_details(uxt, len)
@@ -846,13 +846,13 @@ impl_runtime_apis! {
 
     impl sp_domains::core_api::DomainCoreApi<Block> for Runtime {
         fn extract_signer(
-            extrinsics: Vec<<Block as BlockT>::Extrinsic>,
-        ) -> Vec<(Option<opaque::AccountId>, <Block as BlockT>::Extrinsic)> {
+            extrinsics: Vec<ExtrinsicFor<Block>>,
+        ) -> Vec<(Option<opaque::AccountId>, ExtrinsicFor<Block>)> {
             extract_signer(extrinsics)
         }
 
         fn is_within_tx_range(
-            extrinsic: &<Block as BlockT>::Extrinsic,
+            extrinsic: &ExtrinsicFor<Block>,
             bundle_vrf_hash: &subspace_core_primitives::U256,
             tx_range: &subspace_core_primitives::U256
         ) -> bool {
@@ -877,7 +877,7 @@ impl_runtime_apis! {
             Executive::storage_root()
         }
 
-        fn apply_extrinsic_with_post_state_root(extrinsic: <Block as BlockT>::Extrinsic) -> Vec<u8> {
+        fn apply_extrinsic_with_post_state_root(extrinsic: ExtrinsicFor<Block>) -> Vec<u8> {
             let _ = Executive::apply_extrinsic(extrinsic);
             Executive::storage_root()
         }
@@ -890,13 +890,13 @@ impl_runtime_apis! {
             ).encode()
         }
 
-        fn construct_timestamp_extrinsic(moment: Moment) -> <Block as BlockT>::Extrinsic {
+        fn construct_timestamp_extrinsic(moment: Moment) -> ExtrinsicFor<Block> {
             UncheckedExtrinsic::new_bare(
                 pallet_timestamp::Call::set{ now: moment }.into()
             )
         }
 
-        fn is_inherent_extrinsic(extrinsic: &<Block as BlockT>::Extrinsic) -> bool {
+        fn is_inherent_extrinsic(extrinsic: &ExtrinsicFor<Block>) -> bool {
             match &extrinsic.function {
                 RuntimeCall::Timestamp(call) => Timestamp::is_inherent(call),
                 RuntimeCall::ExecutivePallet(call) => ExecutivePallet::is_inherent(call),
@@ -906,7 +906,7 @@ impl_runtime_apis! {
             }
         }
 
-        fn check_extrinsics_and_do_pre_dispatch(uxts: Vec<<Block as BlockT>::Extrinsic>, block_number: BlockNumber,
+        fn check_extrinsics_and_do_pre_dispatch(uxts: Vec<ExtrinsicFor<Block>>, block_number: BlockNumber,
             block_hash: <Block as BlockT>::Hash) -> Result<(), CheckExtrinsicsValidityError> {
             // Initializing block related storage required for validation
             System::initialize(
@@ -929,7 +929,7 @@ impl_runtime_apis! {
 
         fn decode_extrinsic(
             opaque_extrinsic: sp_runtime::OpaqueExtrinsic,
-        ) -> Result<<Block as BlockT>::Extrinsic, DecodeExtrinsicError> {
+        ) -> Result<ExtrinsicFor<Block>, DecodeExtrinsicError> {
             let encoded = opaque_extrinsic.encode();
 
             UncheckedExtrinsic::decode_with_depth_limit(
@@ -939,12 +939,12 @@ impl_runtime_apis! {
         }
 
         fn extrinsic_era(
-          extrinsic: &<Block as BlockT>::Extrinsic
+          extrinsic: &ExtrinsicFor<Block>
         ) -> Option<Era> {
             extrinsic_era(extrinsic)
         }
 
-        fn extrinsic_weight(ext: &<Block as BlockT>::Extrinsic) -> Weight {
+        fn extrinsic_weight(ext: &ExtrinsicFor<Block>) -> Weight {
             let len = ext.encoded_size() as u64;
             let info = ext.get_dispatch_info();
             info.call_weight.saturating_add(info.extension_weight)
@@ -964,13 +964,13 @@ impl_runtime_apis! {
             System::block_weight().total()
         }
 
-        fn construct_consensus_chain_byte_fee_extrinsic(transaction_byte_fee: Balance) -> <Block as BlockT>::Extrinsic {
+        fn construct_consensus_chain_byte_fee_extrinsic(transaction_byte_fee: Balance) -> ExtrinsicFor<Block> {
             UncheckedExtrinsic::new_bare(
                 pallet_block_fees::Call::set_next_consensus_chain_byte_fee{ transaction_byte_fee }.into()
             )
         }
 
-        fn construct_domain_update_chain_allowlist_extrinsic(updates: DomainAllowlistUpdates) -> <Block as BlockT>::Extrinsic {
+        fn construct_domain_update_chain_allowlist_extrinsic(updates: DomainAllowlistUpdates) -> ExtrinsicFor<Block> {
              UncheckedExtrinsic::new_bare(
                 pallet_messenger::Call::update_domain_allowlist{ updates }.into()
             )
@@ -991,12 +991,12 @@ impl_runtime_apis! {
 
     impl sp_messenger::MessengerApi<Block, ConsensusBlockNumber, ConsensusBlockHash> for Runtime {
         fn is_xdm_mmr_proof_valid(
-            extrinsic: &<Block as BlockT>::Extrinsic,
+            extrinsic: &ExtrinsicFor<Block>,
         ) -> Option<bool> {
             is_xdm_mmr_proof_valid(extrinsic)
         }
 
-        fn extract_xdm_mmr_proof(ext: &<Block as BlockT>::Extrinsic) -> Option<ConsensusChainMmrLeafProof<ConsensusBlockNumber, ConsensusBlockHash, sp_core::H256>> {
+        fn extract_xdm_mmr_proof(ext: &ExtrinsicFor<Block>) -> Option<ConsensusChainMmrLeafProof<ConsensusBlockNumber, ConsensusBlockHash, sp_core::H256>> {
             match &ext.function {
                 RuntimeCall::Messenger(pallet_messenger::Call::relay_message { msg })
                 | RuntimeCall::Messenger(pallet_messenger::Call::relay_message_response { msg }) => {
@@ -1024,7 +1024,7 @@ impl_runtime_apis! {
             None
         }
 
-        fn xdm_id(ext: &<Block as BlockT>::Extrinsic) -> Option<XdmId> {
+        fn xdm_id(ext: &ExtrinsicFor<Block>) -> Option<XdmId> {
             match &ext.function {
                 RuntimeCall::Messenger(pallet_messenger::Call::relay_message { msg })=> {
                     Some(XdmId::RelayMessage((msg.src_chain_id, msg.channel_id, msg.nonce)))
@@ -1046,11 +1046,11 @@ impl_runtime_apis! {
             Messenger::get_block_messages()
         }
 
-        fn outbox_message_unsigned(msg: CrossDomainMessage<NumberFor<Block>, <Block as BlockT>::Hash, <Block as BlockT>::Hash>) -> Option<<Block as BlockT>::Extrinsic> {
+        fn outbox_message_unsigned(msg: CrossDomainMessage<NumberFor<Block>, <Block as BlockT>::Hash, <Block as BlockT>::Hash>) -> Option<ExtrinsicFor<Block>> {
             Messenger::outbox_message_unsigned(msg)
         }
 
-        fn inbox_response_message_unsigned(msg: CrossDomainMessage<NumberFor<Block>, <Block as BlockT>::Hash, <Block as BlockT>::Hash>) -> Option<<Block as BlockT>::Extrinsic> {
+        fn inbox_response_message_unsigned(msg: CrossDomainMessage<NumberFor<Block>, <Block as BlockT>::Hash, <Block as BlockT>::Hash>) -> Option<ExtrinsicFor<Block>> {
             Messenger::inbox_response_message_unsigned(msg)
         }
 
@@ -1080,7 +1080,7 @@ impl_runtime_apis! {
             is_valid_sudo_call(extrinsic)
         }
 
-        fn construct_domain_sudo_extrinsic(inner: Vec<u8>) -> <Block as BlockT>::Extrinsic {
+        fn construct_domain_sudo_extrinsic(inner: Vec<u8>) -> ExtrinsicFor<Block> {
             construct_sudo_call_extrinsic(inner)
         }
     }

--- a/domains/runtime/auto-id/src/lib.rs
+++ b/domains/runtime/auto-id/src/lib.rs
@@ -50,8 +50,8 @@ use sp_messenger_host_functions::{get_storage_key, StorageKeyRequest};
 use sp_mmr_primitives::EncodableOpaqueLeaf;
 use sp_runtime::generic::{Era, ExtrinsicFormat, Preamble};
 use sp_runtime::traits::{
-    AccountIdLookup, BlakeTwo256, Block as BlockT, Checkable, DispatchTransaction, Keccak256,
-    NumberFor, One, TransactionExtension, ValidateUnsigned, Zero,
+    AccountIdLookup, BlakeTwo256, Checkable, DispatchTransaction, Keccak256, NumberFor, One,
+    TransactionExtension, ValidateUnsigned, Zero,
 };
 use sp_runtime::transaction_validity::{
     InvalidTransaction, TransactionSource, TransactionValidity, TransactionValidityError,
@@ -71,7 +71,7 @@ use static_assertions::const_assert;
 use subspace_runtime_primitives::utility::DefaultNonceProvider;
 use subspace_runtime_primitives::{
     BlockHashFor, BlockNumber as ConsensusBlockNumber, DomainEventSegmentSize, ExtrinsicFor,
-    Hash as ConsensusBlockHash, Moment, SlowAdjustingFeeUpdate, XdmAdjustedWeightToFee,
+    Hash as ConsensusBlockHash, HeaderFor, Moment, SlowAdjustingFeeUpdate, XdmAdjustedWeightToFee,
     XdmFeeMultipler, MAX_CALL_RECURSION_DEPTH, SHANNON, SSC,
 };
 
@@ -749,7 +749,7 @@ impl_runtime_apis! {
             Executive::execute_block(block)
         }
 
-        fn initialize_block(header: &<Block as BlockT>::Header) -> ExtrinsicInclusionMode {
+        fn initialize_block(header: &HeaderFor<Block>) -> ExtrinsicInclusionMode {
             Executive::initialize_block(header)
         }
     }
@@ -773,7 +773,7 @@ impl_runtime_apis! {
             Executive::apply_extrinsic(extrinsic)
         }
 
-        fn finalize_block() -> <Block as BlockT>::Header {
+        fn finalize_block() -> HeaderFor<Block> {
             Executive::finalize_block()
         }
 
@@ -800,7 +800,7 @@ impl_runtime_apis! {
     }
 
     impl sp_offchain::OffchainWorkerApi<Block> for Runtime {
-        fn offchain_worker(header: &<Block as BlockT>::Header) {
+        fn offchain_worker(header: &HeaderFor<Block>) {
             Executive::offchain_worker(header)
         }
     }
@@ -872,7 +872,7 @@ impl_runtime_apis! {
             }
         }
 
-        fn initialize_block_with_post_state_root(header: &<Block as BlockT>::Header) -> Vec<u8> {
+        fn initialize_block_with_post_state_root(header: &HeaderFor<Block>) -> Vec<u8> {
             Executive::initialize_block(header);
             Executive::storage_root()
         }

--- a/domains/runtime/evm/src/lib.rs
+++ b/domains/runtime/evm/src/lib.rs
@@ -72,9 +72,9 @@ use sp_messenger_host_functions::{get_storage_key, StorageKeyRequest};
 use sp_mmr_primitives::EncodableOpaqueLeaf;
 use sp_runtime::generic::{Era, ExtrinsicFormat, Preamble};
 use sp_runtime::traits::{
-    BlakeTwo256, Block as BlockT, Checkable, DispatchInfoOf, DispatchTransaction, Dispatchable,
-    IdentityLookup, Keccak256, NumberFor, One, PostDispatchInfoOf, TransactionExtension,
-    UniqueSaturatedInto, ValidateUnsigned, Zero,
+    BlakeTwo256, Checkable, DispatchInfoOf, DispatchTransaction, Dispatchable, IdentityLookup,
+    Keccak256, NumberFor, One, PostDispatchInfoOf, TransactionExtension, UniqueSaturatedInto,
+    ValidateUnsigned, Zero,
 };
 use sp_runtime::transaction_validity::{
     InvalidTransaction, TransactionSource, TransactionValidity, TransactionValidityError,
@@ -97,7 +97,7 @@ use static_assertions::const_assert;
 use subspace_runtime_primitives::utility::{MaybeNestedCall, MaybeUtilityCall};
 use subspace_runtime_primitives::{
     BlockHashFor, BlockNumber as ConsensusBlockNumber, DomainEventSegmentSize, ExtrinsicFor,
-    Hash as ConsensusBlockHash, Moment, SlowAdjustingFeeUpdate, XdmAdjustedWeightToFee,
+    Hash as ConsensusBlockHash, HeaderFor, Moment, SlowAdjustingFeeUpdate, XdmAdjustedWeightToFee,
     XdmFeeMultipler, MAX_CALL_RECURSION_DEPTH, SHANNON, SSC,
 };
 
@@ -1172,7 +1172,7 @@ impl_runtime_apis! {
             Executive::execute_block(block)
         }
 
-        fn initialize_block(header: &<Block as BlockT>::Header) -> ExtrinsicInclusionMode {
+        fn initialize_block(header: &HeaderFor<Block>) -> ExtrinsicInclusionMode {
             Executive::initialize_block(header)
         }
     }
@@ -1196,7 +1196,7 @@ impl_runtime_apis! {
             Executive::apply_extrinsic(extrinsic)
         }
 
-        fn finalize_block() -> <Block as BlockT>::Header {
+        fn finalize_block() -> HeaderFor<Block> {
             Executive::finalize_block()
         }
 
@@ -1223,7 +1223,7 @@ impl_runtime_apis! {
     }
 
     impl sp_offchain::OffchainWorkerApi<Block> for Runtime {
-        fn offchain_worker(header: &<Block as BlockT>::Header) {
+        fn offchain_worker(header: &HeaderFor<Block>) {
             Executive::offchain_worker(header)
         }
     }
@@ -1295,7 +1295,7 @@ impl_runtime_apis! {
             }
         }
 
-        fn initialize_block_with_post_state_root(header: &<Block as BlockT>::Header) -> Vec<u8> {
+        fn initialize_block_with_post_state_root(header: &HeaderFor<Block>) -> Vec<u8> {
             Executive::initialize_block(header);
             Executive::storage_root()
         }
@@ -1681,7 +1681,7 @@ impl_runtime_apis! {
             )
         }
 
-        fn initialize_pending_block(header: &<Block as BlockT>::Header) {
+        fn initialize_pending_block(header: &HeaderFor<Block>) {
             Executive::initialize_block(header);
         }
     }

--- a/domains/runtime/evm/src/lib.rs
+++ b/domains/runtime/evm/src/lib.rs
@@ -96,7 +96,7 @@ use sp_version::RuntimeVersion;
 use static_assertions::const_assert;
 use subspace_runtime_primitives::utility::{MaybeNestedCall, MaybeUtilityCall};
 use subspace_runtime_primitives::{
-    BlockNumber as ConsensusBlockNumber, DomainEventSegmentSize, ExtrinsicFor,
+    BlockHashFor, BlockNumber as ConsensusBlockNumber, DomainEventSegmentSize, ExtrinsicFor,
     Hash as ConsensusBlockHash, Moment, SlowAdjustingFeeUpdate, XdmAdjustedWeightToFee,
     XdmFeeMultipler, MAX_CALL_RECURSION_DEPTH, SHANNON, SSC,
 };
@@ -1216,7 +1216,7 @@ impl_runtime_apis! {
         fn validate_transaction(
             source: TransactionSource,
             tx: ExtrinsicFor<Block>,
-            block_hash: <Block as BlockT>::Hash,
+            block_hash: BlockHashFor<Block>,
         ) -> TransactionValidity {
             Executive::validate_transaction(source, tx, block_hash)
         }
@@ -1331,7 +1331,7 @@ impl_runtime_apis! {
         }
 
         fn check_extrinsics_and_do_pre_dispatch(uxts: Vec<ExtrinsicFor<Block>>, block_number: BlockNumber,
-            block_hash: <Block as BlockT>::Hash) -> Result<(), CheckExtrinsicsValidityError> {
+            block_hash: BlockHashFor<Block>) -> Result<(), CheckExtrinsicsValidityError> {
             // Initializing block related storage required for validation
             System::initialize(
                 &(block_number + BlockNumber::one()),
@@ -1470,11 +1470,11 @@ impl_runtime_apis! {
             Messenger::get_block_messages()
         }
 
-        fn outbox_message_unsigned(msg: CrossDomainMessage<NumberFor<Block>, <Block as BlockT>::Hash, <Block as BlockT>::Hash>) -> Option<ExtrinsicFor<Block>> {
+        fn outbox_message_unsigned(msg: CrossDomainMessage<NumberFor<Block>, BlockHashFor<Block>, BlockHashFor<Block>>) -> Option<ExtrinsicFor<Block>> {
             Messenger::outbox_message_unsigned(msg)
         }
 
-        fn inbox_response_message_unsigned(msg: CrossDomainMessage<NumberFor<Block>, <Block as BlockT>::Hash, <Block as BlockT>::Hash>) -> Option<ExtrinsicFor<Block>> {
+        fn inbox_response_message_unsigned(msg: CrossDomainMessage<NumberFor<Block>, BlockHashFor<Block>, BlockHashFor<Block>>) -> Option<ExtrinsicFor<Block>> {
             Messenger::inbox_response_message_unsigned(msg)
         }
 

--- a/domains/runtime/evm/src/lib.rs
+++ b/domains/runtime/evm/src/lib.rs
@@ -96,9 +96,9 @@ use sp_version::RuntimeVersion;
 use static_assertions::const_assert;
 use subspace_runtime_primitives::utility::{MaybeNestedCall, MaybeUtilityCall};
 use subspace_runtime_primitives::{
-    BlockNumber as ConsensusBlockNumber, DomainEventSegmentSize, Hash as ConsensusBlockHash,
-    Moment, SlowAdjustingFeeUpdate, XdmAdjustedWeightToFee, XdmFeeMultipler,
-    MAX_CALL_RECURSION_DEPTH, SHANNON, SSC,
+    BlockNumber as ConsensusBlockNumber, DomainEventSegmentSize, ExtrinsicFor,
+    Hash as ConsensusBlockHash, Moment, SlowAdjustingFeeUpdate, XdmAdjustedWeightToFee,
+    XdmFeeMultipler, MAX_CALL_RECURSION_DEPTH, SHANNON, SSC,
 };
 
 /// The address format for describing accounts.
@@ -860,7 +860,7 @@ impl fp_rpc::ConvertTransaction<opaque::UncheckedExtrinsic> for TransactionConve
     }
 }
 
-fn is_xdm_mmr_proof_valid(ext: &<Block as BlockT>::Extrinsic) -> Option<bool> {
+fn is_xdm_mmr_proof_valid(ext: &ExtrinsicFor<Block>) -> Option<bool> {
     match &ext.0.function {
         RuntimeCall::Messenger(pallet_messenger::Call::relay_message { msg })
         | RuntimeCall::Messenger(pallet_messenger::Call::relay_message_response { msg }) => {
@@ -891,7 +891,7 @@ fn is_valid_sudo_call(encoded_ext: Vec<u8>) -> bool {
 }
 
 /// Constructs a domain-sudo call extrinsic from the given encoded extrinsic.
-fn construct_sudo_call_extrinsic(encoded_ext: Vec<u8>) -> <Block as BlockT>::Extrinsic {
+fn construct_sudo_call_extrinsic(encoded_ext: Vec<u8>) -> ExtrinsicFor<Block> {
     let ext = UncheckedExtrinsic::decode(&mut encoded_ext.as_slice()).expect(
         "must always be a valid extrinsic due to the check above and storage proof check; qed",
     );
@@ -906,7 +906,7 @@ fn construct_sudo_call_extrinsic(encoded_ext: Vec<u8>) -> <Block as BlockT>::Ext
 /// Constructs an evm-tracker call extrinsic from the given extrinsic.
 fn construct_evm_contract_creation_allowed_by_extrinsic(
     decoded_argument: PermissionedActionAllowedBy<AccountId>,
-) -> <Block as BlockT>::Extrinsic {
+) -> ExtrinsicFor<Block> {
     UncheckedExtrinsic::new_bare(
         pallet_evm_tracker::Call::set_contract_creation_allowed_by {
             contract_creation_allowed_by: decoded_argument,
@@ -952,7 +952,7 @@ pub fn extract_signer(
         .collect()
 }
 
-fn extrinsic_era(extrinsic: &<Block as BlockT>::Extrinsic) -> Option<Era> {
+fn extrinsic_era(extrinsic: &ExtrinsicFor<Block>) -> Option<Era> {
     match &extrinsic.0.preamble {
         Preamble::Bare(_) | Preamble::General(_, _) => None,
         Preamble::Signed(_, _, extra) => Some(extra.4 .0),
@@ -1029,7 +1029,7 @@ fn pre_dispatch_evm_transaction(
 }
 
 fn check_transaction_and_do_pre_dispatch_inner(
-    uxt: &<Block as BlockT>::Extrinsic,
+    uxt: &ExtrinsicFor<Block>,
 ) -> Result<(), TransactionValidityError> {
     let lookup = frame_system::ChainContext::<Runtime>::default();
 
@@ -1192,7 +1192,7 @@ impl_runtime_apis! {
     }
 
     impl sp_block_builder::BlockBuilder<Block> for Runtime {
-        fn apply_extrinsic(extrinsic: <Block as BlockT>::Extrinsic) -> ApplyExtrinsicResult {
+        fn apply_extrinsic(extrinsic: ExtrinsicFor<Block>) -> ApplyExtrinsicResult {
             Executive::apply_extrinsic(extrinsic)
         }
 
@@ -1200,7 +1200,7 @@ impl_runtime_apis! {
             Executive::finalize_block()
         }
 
-        fn inherent_extrinsics(data: sp_inherents::InherentData) -> Vec<<Block as BlockT>::Extrinsic> {
+        fn inherent_extrinsics(data: sp_inherents::InherentData) -> Vec<ExtrinsicFor<Block>> {
             data.create_extrinsics()
         }
 
@@ -1215,7 +1215,7 @@ impl_runtime_apis! {
     impl sp_transaction_pool::runtime_api::TaggedTransactionQueue<Block> for Runtime {
         fn validate_transaction(
             source: TransactionSource,
-            tx: <Block as BlockT>::Extrinsic,
+            tx: ExtrinsicFor<Block>,
             block_hash: <Block as BlockT>::Hash,
         ) -> TransactionValidity {
             Executive::validate_transaction(source, tx, block_hash)
@@ -1248,13 +1248,13 @@ impl_runtime_apis! {
 
     impl pallet_transaction_payment_rpc_runtime_api::TransactionPaymentApi<Block, Balance> for Runtime {
         fn query_info(
-            uxt: <Block as BlockT>::Extrinsic,
+            uxt: ExtrinsicFor<Block>,
             len: u32,
         ) -> pallet_transaction_payment_rpc_runtime_api::RuntimeDispatchInfo<Balance> {
             TransactionPayment::query_info(uxt, len)
         }
         fn query_fee_details(
-            uxt: <Block as BlockT>::Extrinsic,
+            uxt: ExtrinsicFor<Block>,
             len: u32,
         ) -> pallet_transaction_payment::FeeDetails<Balance> {
             TransactionPayment::query_fee_details(uxt, len)
@@ -1269,13 +1269,13 @@ impl_runtime_apis! {
 
     impl sp_domains::core_api::DomainCoreApi<Block> for Runtime {
         fn extract_signer(
-            extrinsics: Vec<<Block as BlockT>::Extrinsic>,
-        ) -> Vec<(Option<opaque::AccountId>, <Block as BlockT>::Extrinsic)> {
+            extrinsics: Vec<ExtrinsicFor<Block>>,
+        ) -> Vec<(Option<opaque::AccountId>, ExtrinsicFor<Block>)> {
             extract_signer(extrinsics)
         }
 
         fn is_within_tx_range(
-            extrinsic: &<Block as BlockT>::Extrinsic,
+            extrinsic: &ExtrinsicFor<Block>,
             bundle_vrf_hash: &subspace_core_primitives::U256,
             tx_range: &subspace_core_primitives::U256
         ) -> bool {
@@ -1300,7 +1300,7 @@ impl_runtime_apis! {
             Executive::storage_root()
         }
 
-        fn apply_extrinsic_with_post_state_root(extrinsic: <Block as BlockT>::Extrinsic) -> Vec<u8> {
+        fn apply_extrinsic_with_post_state_root(extrinsic: ExtrinsicFor<Block>) -> Vec<u8> {
             let _ = Executive::apply_extrinsic(extrinsic);
             Executive::storage_root()
         }
@@ -1313,13 +1313,13 @@ impl_runtime_apis! {
             ).encode()
         }
 
-        fn construct_timestamp_extrinsic(moment: Moment) -> <Block as BlockT>::Extrinsic {
+        fn construct_timestamp_extrinsic(moment: Moment) -> ExtrinsicFor<Block> {
             UncheckedExtrinsic::new_bare(
                 pallet_timestamp::Call::set{ now: moment }.into()
             )
         }
 
-        fn is_inherent_extrinsic(extrinsic: &<Block as BlockT>::Extrinsic) -> bool {
+        fn is_inherent_extrinsic(extrinsic: &ExtrinsicFor<Block>) -> bool {
             match &extrinsic.0.function {
                 RuntimeCall::Timestamp(call) => Timestamp::is_inherent(call),
                 RuntimeCall::ExecutivePallet(call) => ExecutivePallet::is_inherent(call),
@@ -1330,7 +1330,7 @@ impl_runtime_apis! {
             }
         }
 
-        fn check_extrinsics_and_do_pre_dispatch(uxts: Vec<<Block as BlockT>::Extrinsic>, block_number: BlockNumber,
+        fn check_extrinsics_and_do_pre_dispatch(uxts: Vec<ExtrinsicFor<Block>>, block_number: BlockNumber,
             block_hash: <Block as BlockT>::Hash) -> Result<(), CheckExtrinsicsValidityError> {
             // Initializing block related storage required for validation
             System::initialize(
@@ -1353,7 +1353,7 @@ impl_runtime_apis! {
 
         fn decode_extrinsic(
             opaque_extrinsic: sp_runtime::OpaqueExtrinsic,
-        ) -> Result<<Block as BlockT>::Extrinsic, DecodeExtrinsicError> {
+        ) -> Result<ExtrinsicFor<Block>, DecodeExtrinsicError> {
             let encoded = opaque_extrinsic.encode();
 
             UncheckedExtrinsic::decode_with_depth_limit(
@@ -1363,12 +1363,12 @@ impl_runtime_apis! {
         }
 
         fn extrinsic_era(
-          extrinsic: &<Block as BlockT>::Extrinsic
+          extrinsic: &ExtrinsicFor<Block>
         ) -> Option<Era> {
             extrinsic_era(extrinsic)
         }
 
-        fn extrinsic_weight(ext: &<Block as BlockT>::Extrinsic) -> Weight {
+        fn extrinsic_weight(ext: &ExtrinsicFor<Block>) -> Weight {
             let len = ext.encoded_size() as u64;
             let info = ext.get_dispatch_info();
             info.call_weight.saturating_add(info.extension_weight)
@@ -1388,13 +1388,13 @@ impl_runtime_apis! {
             System::block_weight().total()
         }
 
-        fn construct_consensus_chain_byte_fee_extrinsic(transaction_byte_fee: Balance) -> <Block as BlockT>::Extrinsic {
+        fn construct_consensus_chain_byte_fee_extrinsic(transaction_byte_fee: Balance) -> ExtrinsicFor<Block> {
             UncheckedExtrinsic::new_bare(
                 pallet_block_fees::Call::set_next_consensus_chain_byte_fee{ transaction_byte_fee }.into()
             )
         }
 
-        fn construct_domain_update_chain_allowlist_extrinsic(updates: DomainAllowlistUpdates) -> <Block as BlockT>::Extrinsic {
+        fn construct_domain_update_chain_allowlist_extrinsic(updates: DomainAllowlistUpdates) -> ExtrinsicFor<Block> {
              UncheckedExtrinsic::new_bare(
                 pallet_messenger::Call::update_domain_allowlist{ updates }.into()
             )
@@ -1415,12 +1415,12 @@ impl_runtime_apis! {
 
     impl sp_messenger::MessengerApi<Block, ConsensusBlockNumber, ConsensusBlockHash> for Runtime {
         fn is_xdm_mmr_proof_valid(
-            extrinsic: &<Block as BlockT>::Extrinsic
+            extrinsic: &ExtrinsicFor<Block>
         ) -> Option<bool> {
             is_xdm_mmr_proof_valid(extrinsic)
         }
 
-        fn extract_xdm_mmr_proof(ext: &<Block as BlockT>::Extrinsic) -> Option<ConsensusChainMmrLeafProof<ConsensusBlockNumber, ConsensusBlockHash, sp_core::H256>> {
+        fn extract_xdm_mmr_proof(ext: &ExtrinsicFor<Block>) -> Option<ConsensusChainMmrLeafProof<ConsensusBlockNumber, ConsensusBlockHash, sp_core::H256>> {
             match &ext.0.function {
                 RuntimeCall::Messenger(pallet_messenger::Call::relay_message { msg })
                 | RuntimeCall::Messenger(pallet_messenger::Call::relay_message_response { msg }) => {
@@ -1448,7 +1448,7 @@ impl_runtime_apis! {
             None
         }
 
-        fn xdm_id(ext: &<Block as BlockT>::Extrinsic) -> Option<XdmId> {
+        fn xdm_id(ext: &ExtrinsicFor<Block>) -> Option<XdmId> {
             match &ext.0.function {
                 RuntimeCall::Messenger(pallet_messenger::Call::relay_message { msg })=> {
                     Some(XdmId::RelayMessage((msg.src_chain_id, msg.channel_id, msg.nonce)))
@@ -1470,11 +1470,11 @@ impl_runtime_apis! {
             Messenger::get_block_messages()
         }
 
-        fn outbox_message_unsigned(msg: CrossDomainMessage<NumberFor<Block>, <Block as BlockT>::Hash, <Block as BlockT>::Hash>) -> Option<<Block as BlockT>::Extrinsic> {
+        fn outbox_message_unsigned(msg: CrossDomainMessage<NumberFor<Block>, <Block as BlockT>::Hash, <Block as BlockT>::Hash>) -> Option<ExtrinsicFor<Block>> {
             Messenger::outbox_message_unsigned(msg)
         }
 
-        fn inbox_response_message_unsigned(msg: CrossDomainMessage<NumberFor<Block>, <Block as BlockT>::Hash, <Block as BlockT>::Hash>) -> Option<<Block as BlockT>::Extrinsic> {
+        fn inbox_response_message_unsigned(msg: CrossDomainMessage<NumberFor<Block>, <Block as BlockT>::Hash, <Block as BlockT>::Hash>) -> Option<ExtrinsicFor<Block>> {
             Messenger::inbox_response_message_unsigned(msg)
         }
 
@@ -1652,7 +1652,7 @@ impl_runtime_apis! {
         }
 
         fn extrinsic_filter(
-            xts: Vec<<Block as BlockT>::Extrinsic>,
+            xts: Vec<ExtrinsicFor<Block>>,
         ) -> Vec<EthereumTransaction> {
             xts.into_iter().filter_map(|xt| match xt.0.function {
                 RuntimeCall::Ethereum(pallet_ethereum::Call::transact { transaction }) => Some(transaction),
@@ -1667,7 +1667,7 @@ impl_runtime_apis! {
         fn gas_limit_multiplier_support() {}
 
         fn pending_block(
-            xts: Vec<<Block as BlockT>::Extrinsic>,
+            xts: Vec<ExtrinsicFor<Block>>,
         ) -> (Option<pallet_ethereum::Block>, Option<Vec<TransactionStatus>>) {
             for ext in xts.into_iter() {
                 let _ = Executive::apply_extrinsic(ext);
@@ -1687,7 +1687,7 @@ impl_runtime_apis! {
     }
 
     impl fp_rpc::ConvertTransactionRuntimeApi<Block> for Runtime {
-        fn convert_transaction(transaction: EthereumTransaction) -> <Block as BlockT>::Extrinsic {
+        fn convert_transaction(transaction: EthereumTransaction) -> ExtrinsicFor<Block> {
             UncheckedExtrinsic::new_bare(
                 pallet_ethereum::Call::transact { transaction }.into(),
             )
@@ -1699,13 +1699,13 @@ impl_runtime_apis! {
             is_valid_sudo_call(extrinsic)
         }
 
-        fn construct_domain_sudo_extrinsic(inner: Vec<u8>) -> <Block as BlockT>::Extrinsic {
+        fn construct_domain_sudo_extrinsic(inner: Vec<u8>) -> ExtrinsicFor<Block> {
             construct_sudo_call_extrinsic(inner)
         }
     }
 
     impl sp_evm_tracker::EvmTrackerApi<Block> for Runtime {
-        fn construct_evm_contract_creation_allowed_by_extrinsic(decoded_argument: PermissionedActionAllowedBy<AccountId>) -> <Block as BlockT>::Extrinsic {
+        fn construct_evm_contract_creation_allowed_by_extrinsic(decoded_argument: PermissionedActionAllowedBy<AccountId>) -> ExtrinsicFor<Block> {
             construct_evm_contract_creation_allowed_by_extrinsic(decoded_argument)
         }
     }

--- a/domains/service/src/domain.rs
+++ b/domains/service/src/domain.rs
@@ -51,7 +51,7 @@ use std::marker::PhantomData;
 use std::str::FromStr;
 use std::sync::Arc;
 use subspace_core_primitives::pot::PotOutput;
-use subspace_runtime_primitives::Nonce;
+use subspace_runtime_primitives::{HeaderFor, Nonce};
 use substrate_frame_rpc_system::AccountNonceApi;
 
 pub type DomainOperator<Block, CBlock, CClient, RuntimeApi> = Operator<
@@ -274,8 +274,7 @@ where
     pub skip_out_of_order_slot: bool,
     pub confirmation_depth_k: NumberFor<CBlock>,
     pub challenge_period: NumberFor<CBlock>,
-    pub consensus_chain_sync_params:
-        Option<ConsensusChainSyncParams<CBlock, <Block as BlockT>::Header>>,
+    pub consensus_chain_sync_params: Option<ConsensusChainSyncParams<CBlock, HeaderFor<Block>>>,
     pub domain_backend: Arc<FullBackend<Block>>,
 }
 

--- a/domains/service/src/network.rs
+++ b/domains/service/src/network.rs
@@ -18,6 +18,7 @@ use sp_blockchain::{HeaderBackend, HeaderMetadata};
 use sp_consensus::block_validation::{Chain, DefaultBlockAnnounceValidator};
 use sp_runtime::traits::BlockIdTo;
 use std::sync::Arc;
+use subspace_runtime_primitives::BlockHashFor;
 
 /// Build the network service, the network status sinks and an RPC sender.
 #[allow(clippy::type_complexity)]
@@ -28,7 +29,7 @@ pub fn build_network<Block, Net, TxPool, IQ, Client>(
     (
         Arc<dyn sc_network::service::traits::NetworkService>,
         TracingUnboundedSender<sc_rpc::system::Request<Block>>,
-        sc_network_transactions::TransactionsHandlerController<<Block as BlockT>::Hash>,
+        sc_network_transactions::TransactionsHandlerController<BlockHashFor<Block>>,
         NetworkStarter,
         Arc<SyncingService<Block>>,
         NetworkServiceHandle,
@@ -48,9 +49,9 @@ where
         + BlockchainEvents<Block>
         + AuxStore
         + 'static,
-    TxPool: TransactionPool<Block = Block, Hash = <Block as BlockT>::Hash> + 'static,
+    TxPool: TransactionPool<Block = Block, Hash = BlockHashFor<Block>> + 'static,
     IQ: ImportQueue<Block> + 'static,
-    Net: NetworkBackend<Block, <Block as BlockT>::Hash>,
+    Net: NetworkBackend<Block, BlockHashFor<Block>>,
 {
     let BuildNetworkParams {
         config,

--- a/domains/test/runtime/auto-id/src/lib.rs
+++ b/domains/test/runtime/auto-id/src/lib.rs
@@ -50,8 +50,8 @@ use sp_messenger_host_functions::{get_storage_key, StorageKeyRequest};
 use sp_mmr_primitives::EncodableOpaqueLeaf;
 use sp_runtime::generic::{Era, ExtrinsicFormat, Preamble};
 use sp_runtime::traits::{
-    AccountIdLookup, BlakeTwo256, Block as BlockT, Checkable, DispatchTransaction, Keccak256,
-    NumberFor, One, TransactionExtension, ValidateUnsigned, Zero,
+    AccountIdLookup, BlakeTwo256, Checkable, DispatchTransaction, Keccak256, NumberFor, One,
+    TransactionExtension, ValidateUnsigned, Zero,
 };
 use sp_runtime::transaction_validity::{
     InvalidTransaction, TransactionSource, TransactionValidity, TransactionValidityError,
@@ -71,7 +71,7 @@ use static_assertions::const_assert;
 use subspace_runtime_primitives::utility::DefaultNonceProvider;
 use subspace_runtime_primitives::{
     BlockHashFor, BlockNumber as ConsensusBlockNumber, DomainEventSegmentSize, ExtrinsicFor,
-    Hash as ConsensusBlockHash, Moment, SlowAdjustingFeeUpdate, XdmAdjustedWeightToFee,
+    Hash as ConsensusBlockHash, HeaderFor, Moment, SlowAdjustingFeeUpdate, XdmAdjustedWeightToFee,
     XdmFeeMultipler, MAX_CALL_RECURSION_DEPTH, SSC,
 };
 
@@ -745,7 +745,7 @@ impl_runtime_apis! {
             Executive::execute_block(block)
         }
 
-        fn initialize_block(header: &<Block as BlockT>::Header) -> ExtrinsicInclusionMode {
+        fn initialize_block(header: &HeaderFor<Block>) -> ExtrinsicInclusionMode {
             Executive::initialize_block(header)
         }
     }
@@ -769,7 +769,7 @@ impl_runtime_apis! {
             Executive::apply_extrinsic(extrinsic)
         }
 
-        fn finalize_block() -> <Block as BlockT>::Header {
+        fn finalize_block() -> HeaderFor<Block> {
             Executive::finalize_block()
         }
 
@@ -796,7 +796,7 @@ impl_runtime_apis! {
     }
 
     impl sp_offchain::OffchainWorkerApi<Block> for Runtime {
-        fn offchain_worker(header: &<Block as BlockT>::Header) {
+        fn offchain_worker(header: &HeaderFor<Block>) {
             Executive::offchain_worker(header)
         }
     }
@@ -868,7 +868,7 @@ impl_runtime_apis! {
             }
         }
 
-        fn initialize_block_with_post_state_root(header: &<Block as BlockT>::Header) -> Vec<u8> {
+        fn initialize_block_with_post_state_root(header: &HeaderFor<Block>) -> Vec<u8> {
             Executive::initialize_block(header);
             Executive::storage_root()
         }

--- a/domains/test/runtime/auto-id/src/lib.rs
+++ b/domains/test/runtime/auto-id/src/lib.rs
@@ -70,9 +70,9 @@ use sp_version::RuntimeVersion;
 use static_assertions::const_assert;
 use subspace_runtime_primitives::utility::DefaultNonceProvider;
 use subspace_runtime_primitives::{
-    BlockNumber as ConsensusBlockNumber, DomainEventSegmentSize, Hash as ConsensusBlockHash,
-    Moment, SlowAdjustingFeeUpdate, XdmAdjustedWeightToFee, XdmFeeMultipler,
-    MAX_CALL_RECURSION_DEPTH, SSC,
+    BlockNumber as ConsensusBlockNumber, DomainEventSegmentSize, ExtrinsicFor,
+    Hash as ConsensusBlockHash, Moment, SlowAdjustingFeeUpdate, XdmAdjustedWeightToFee,
+    XdmFeeMultipler, MAX_CALL_RECURSION_DEPTH, SSC,
 };
 
 /// Block type as expected by this runtime.
@@ -528,7 +528,7 @@ construct_runtime!(
     }
 );
 
-fn is_xdm_mmr_proof_valid(ext: &<Block as BlockT>::Extrinsic) -> Option<bool> {
+fn is_xdm_mmr_proof_valid(ext: &ExtrinsicFor<Block>) -> Option<bool> {
     match &ext.function {
         RuntimeCall::Messenger(pallet_messenger::Call::relay_message { msg })
         | RuntimeCall::Messenger(pallet_messenger::Call::relay_message_response { msg }) => {
@@ -558,7 +558,7 @@ fn is_valid_sudo_call(encoded_ext: Vec<u8>) -> bool {
     .is_ok()
 }
 
-fn construct_sudo_call_extrinsic(encoded_ext: Vec<u8>) -> <Block as BlockT>::Extrinsic {
+fn construct_sudo_call_extrinsic(encoded_ext: Vec<u8>) -> ExtrinsicFor<Block> {
     let ext = UncheckedExtrinsic::decode(&mut encoded_ext.as_slice()).expect(
         "must always be a valid extrinsic due to the check above and storage proof check; qed",
     );
@@ -602,7 +602,7 @@ pub fn extract_signer(
         .collect()
 }
 
-fn extrinsic_era(extrinsic: &<Block as BlockT>::Extrinsic) -> Option<Era> {
+fn extrinsic_era(extrinsic: &ExtrinsicFor<Block>) -> Option<Era> {
     match &extrinsic.preamble {
         Preamble::Bare(_) | Preamble::General(_, _) => None,
         Preamble::Signed(_, _, extra) => Some(extra.4 .0),
@@ -659,7 +659,7 @@ mod benches {
 }
 
 fn check_transaction_and_do_pre_dispatch_inner(
-    uxt: &<Block as BlockT>::Extrinsic,
+    uxt: &ExtrinsicFor<Block>,
 ) -> Result<(), TransactionValidityError> {
     let lookup = frame_system::ChainContext::<Runtime>::default();
 
@@ -765,7 +765,7 @@ impl_runtime_apis! {
     }
 
     impl sp_block_builder::BlockBuilder<Block> for Runtime {
-        fn apply_extrinsic(extrinsic: <Block as BlockT>::Extrinsic) -> ApplyExtrinsicResult {
+        fn apply_extrinsic(extrinsic: ExtrinsicFor<Block>) -> ApplyExtrinsicResult {
             Executive::apply_extrinsic(extrinsic)
         }
 
@@ -773,7 +773,7 @@ impl_runtime_apis! {
             Executive::finalize_block()
         }
 
-        fn inherent_extrinsics(data: sp_inherents::InherentData) -> Vec<<Block as BlockT>::Extrinsic> {
+        fn inherent_extrinsics(data: sp_inherents::InherentData) -> Vec<ExtrinsicFor<Block>> {
             data.create_extrinsics()
         }
 
@@ -788,7 +788,7 @@ impl_runtime_apis! {
     impl sp_transaction_pool::runtime_api::TaggedTransactionQueue<Block> for Runtime {
         fn validate_transaction(
             source: TransactionSource,
-            tx: <Block as BlockT>::Extrinsic,
+            tx: ExtrinsicFor<Block>,
             block_hash: <Block as BlockT>::Hash,
         ) -> TransactionValidity {
             Executive::validate_transaction(source, tx, block_hash)
@@ -821,13 +821,13 @@ impl_runtime_apis! {
 
     impl pallet_transaction_payment_rpc_runtime_api::TransactionPaymentApi<Block, Balance> for Runtime {
         fn query_info(
-            uxt: <Block as BlockT>::Extrinsic,
+            uxt: ExtrinsicFor<Block>,
             len: u32,
         ) -> pallet_transaction_payment_rpc_runtime_api::RuntimeDispatchInfo<Balance> {
             TransactionPayment::query_info(uxt, len)
         }
         fn query_fee_details(
-            uxt: <Block as BlockT>::Extrinsic,
+            uxt: ExtrinsicFor<Block>,
             len: u32,
         ) -> pallet_transaction_payment::FeeDetails<Balance> {
             TransactionPayment::query_fee_details(uxt, len)
@@ -842,13 +842,13 @@ impl_runtime_apis! {
 
     impl sp_domains::core_api::DomainCoreApi<Block> for Runtime {
         fn extract_signer(
-            extrinsics: Vec<<Block as BlockT>::Extrinsic>,
-        ) -> Vec<(Option<opaque::AccountId>, <Block as BlockT>::Extrinsic)> {
+            extrinsics: Vec<ExtrinsicFor<Block>>,
+        ) -> Vec<(Option<opaque::AccountId>, ExtrinsicFor<Block>)> {
             extract_signer(extrinsics)
         }
 
         fn is_within_tx_range(
-            extrinsic: &<Block as BlockT>::Extrinsic,
+            extrinsic: &ExtrinsicFor<Block>,
             bundle_vrf_hash: &subspace_core_primitives::U256,
             tx_range: &subspace_core_primitives::U256
         ) -> bool {
@@ -873,7 +873,7 @@ impl_runtime_apis! {
             Executive::storage_root()
         }
 
-        fn apply_extrinsic_with_post_state_root(extrinsic: <Block as BlockT>::Extrinsic) -> Vec<u8> {
+        fn apply_extrinsic_with_post_state_root(extrinsic: ExtrinsicFor<Block>) -> Vec<u8> {
             let _ = Executive::apply_extrinsic(extrinsic);
             Executive::storage_root()
         }
@@ -886,13 +886,13 @@ impl_runtime_apis! {
             ).encode()
         }
 
-        fn construct_timestamp_extrinsic(moment: Moment) -> <Block as BlockT>::Extrinsic {
+        fn construct_timestamp_extrinsic(moment: Moment) -> ExtrinsicFor<Block> {
             UncheckedExtrinsic::new_bare(
                 pallet_timestamp::Call::set{ now: moment }.into()
             )
         }
 
-        fn is_inherent_extrinsic(extrinsic: &<Block as BlockT>::Extrinsic) -> bool {
+        fn is_inherent_extrinsic(extrinsic: &ExtrinsicFor<Block>) -> bool {
             match &extrinsic.function {
                 RuntimeCall::Timestamp(call) => Timestamp::is_inherent(call),
                 RuntimeCall::ExecutivePallet(call) => ExecutivePallet::is_inherent(call),
@@ -902,7 +902,7 @@ impl_runtime_apis! {
             }
         }
 
-        fn check_extrinsics_and_do_pre_dispatch(uxts: Vec<<Block as BlockT>::Extrinsic>, block_number: BlockNumber,
+        fn check_extrinsics_and_do_pre_dispatch(uxts: Vec<ExtrinsicFor<Block>>, block_number: BlockNumber,
             block_hash: <Block as BlockT>::Hash) -> Result<(), CheckExtrinsicsValidityError> {
             // Initializing block related storage required for validation
             System::initialize(
@@ -925,7 +925,7 @@ impl_runtime_apis! {
 
         fn decode_extrinsic(
             opaque_extrinsic: sp_runtime::OpaqueExtrinsic,
-        ) -> Result<<Block as BlockT>::Extrinsic, DecodeExtrinsicError> {
+        ) -> Result<ExtrinsicFor<Block>, DecodeExtrinsicError> {
             let encoded = opaque_extrinsic.encode();
 
             UncheckedExtrinsic::decode_with_depth_limit(
@@ -935,12 +935,12 @@ impl_runtime_apis! {
         }
 
         fn extrinsic_era(
-          extrinsic: &<Block as BlockT>::Extrinsic
+          extrinsic: &ExtrinsicFor<Block>
         ) -> Option<Era> {
             extrinsic_era(extrinsic)
         }
 
-        fn extrinsic_weight(ext: &<Block as BlockT>::Extrinsic) -> Weight {
+        fn extrinsic_weight(ext: &ExtrinsicFor<Block>) -> Weight {
             let len = ext.encoded_size() as u64;
             let info = ext.get_dispatch_info();
             info.call_weight
@@ -960,13 +960,13 @@ impl_runtime_apis! {
             System::block_weight().total()
         }
 
-        fn construct_consensus_chain_byte_fee_extrinsic(transaction_byte_fee: Balance) -> <Block as BlockT>::Extrinsic {
+        fn construct_consensus_chain_byte_fee_extrinsic(transaction_byte_fee: Balance) -> ExtrinsicFor<Block> {
             UncheckedExtrinsic::new_bare(
                 pallet_block_fees::Call::set_next_consensus_chain_byte_fee{ transaction_byte_fee }.into()
             )
         }
 
-        fn construct_domain_update_chain_allowlist_extrinsic(updates: DomainAllowlistUpdates) -> <Block as BlockT>::Extrinsic {
+        fn construct_domain_update_chain_allowlist_extrinsic(updates: DomainAllowlistUpdates) -> ExtrinsicFor<Block> {
              UncheckedExtrinsic::new_bare(
                 pallet_messenger::Call::update_domain_allowlist{ updates }.into()
             )
@@ -987,12 +987,12 @@ impl_runtime_apis! {
 
     impl sp_messenger::MessengerApi<Block, ConsensusBlockNumber, ConsensusBlockHash> for Runtime {
         fn is_xdm_mmr_proof_valid(
-            extrinsic: &<Block as BlockT>::Extrinsic,
+            extrinsic: &ExtrinsicFor<Block>,
         ) -> Option<bool> {
             is_xdm_mmr_proof_valid(extrinsic)
         }
 
-        fn extract_xdm_mmr_proof(ext: &<Block as BlockT>::Extrinsic) -> Option<ConsensusChainMmrLeafProof<ConsensusBlockNumber, ConsensusBlockHash, sp_core::H256>> {
+        fn extract_xdm_mmr_proof(ext: &ExtrinsicFor<Block>) -> Option<ConsensusChainMmrLeafProof<ConsensusBlockNumber, ConsensusBlockHash, sp_core::H256>> {
             match &ext.function {
                 RuntimeCall::Messenger(pallet_messenger::Call::relay_message { msg })
                 | RuntimeCall::Messenger(pallet_messenger::Call::relay_message_response { msg }) => {
@@ -1020,7 +1020,7 @@ impl_runtime_apis! {
             None
         }
 
-        fn xdm_id(ext: &<Block as BlockT>::Extrinsic) -> Option<XdmId> {
+        fn xdm_id(ext: &ExtrinsicFor<Block>) -> Option<XdmId> {
             match &ext.function {
                 RuntimeCall::Messenger(pallet_messenger::Call::relay_message { msg })=> {
                     Some(XdmId::RelayMessage((msg.src_chain_id, msg.channel_id, msg.nonce)))
@@ -1042,11 +1042,11 @@ impl_runtime_apis! {
             Messenger::get_block_messages()
         }
 
-        fn outbox_message_unsigned(msg: CrossDomainMessage<NumberFor<Block>, <Block as BlockT>::Hash, <Block as BlockT>::Hash>) -> Option<<Block as BlockT>::Extrinsic> {
+        fn outbox_message_unsigned(msg: CrossDomainMessage<NumberFor<Block>, <Block as BlockT>::Hash, <Block as BlockT>::Hash>) -> Option<ExtrinsicFor<Block>> {
             Messenger::outbox_message_unsigned(msg)
         }
 
-        fn inbox_response_message_unsigned(msg: CrossDomainMessage<NumberFor<Block>, <Block as BlockT>::Hash, <Block as BlockT>::Hash>) -> Option<<Block as BlockT>::Extrinsic> {
+        fn inbox_response_message_unsigned(msg: CrossDomainMessage<NumberFor<Block>, <Block as BlockT>::Hash, <Block as BlockT>::Hash>) -> Option<ExtrinsicFor<Block>> {
             Messenger::inbox_response_message_unsigned(msg)
         }
 
@@ -1076,7 +1076,7 @@ impl_runtime_apis! {
             is_valid_sudo_call(extrinsic)
         }
 
-        fn construct_domain_sudo_extrinsic(inner: Vec<u8>) -> <Block as BlockT>::Extrinsic {
+        fn construct_domain_sudo_extrinsic(inner: Vec<u8>) -> ExtrinsicFor<Block> {
             construct_sudo_call_extrinsic(inner)
         }
     }

--- a/domains/test/runtime/auto-id/src/lib.rs
+++ b/domains/test/runtime/auto-id/src/lib.rs
@@ -70,7 +70,7 @@ use sp_version::RuntimeVersion;
 use static_assertions::const_assert;
 use subspace_runtime_primitives::utility::DefaultNonceProvider;
 use subspace_runtime_primitives::{
-    BlockNumber as ConsensusBlockNumber, DomainEventSegmentSize, ExtrinsicFor,
+    BlockHashFor, BlockNumber as ConsensusBlockNumber, DomainEventSegmentSize, ExtrinsicFor,
     Hash as ConsensusBlockHash, Moment, SlowAdjustingFeeUpdate, XdmAdjustedWeightToFee,
     XdmFeeMultipler, MAX_CALL_RECURSION_DEPTH, SSC,
 };
@@ -789,7 +789,7 @@ impl_runtime_apis! {
         fn validate_transaction(
             source: TransactionSource,
             tx: ExtrinsicFor<Block>,
-            block_hash: <Block as BlockT>::Hash,
+            block_hash: BlockHashFor<Block>,
         ) -> TransactionValidity {
             Executive::validate_transaction(source, tx, block_hash)
         }
@@ -903,7 +903,7 @@ impl_runtime_apis! {
         }
 
         fn check_extrinsics_and_do_pre_dispatch(uxts: Vec<ExtrinsicFor<Block>>, block_number: BlockNumber,
-            block_hash: <Block as BlockT>::Hash) -> Result<(), CheckExtrinsicsValidityError> {
+            block_hash: BlockHashFor<Block>) -> Result<(), CheckExtrinsicsValidityError> {
             // Initializing block related storage required for validation
             System::initialize(
                 &(block_number + BlockNumber::one()),
@@ -1042,11 +1042,11 @@ impl_runtime_apis! {
             Messenger::get_block_messages()
         }
 
-        fn outbox_message_unsigned(msg: CrossDomainMessage<NumberFor<Block>, <Block as BlockT>::Hash, <Block as BlockT>::Hash>) -> Option<ExtrinsicFor<Block>> {
+        fn outbox_message_unsigned(msg: CrossDomainMessage<NumberFor<Block>, BlockHashFor<Block>, BlockHashFor<Block>>) -> Option<ExtrinsicFor<Block>> {
             Messenger::outbox_message_unsigned(msg)
         }
 
-        fn inbox_response_message_unsigned(msg: CrossDomainMessage<NumberFor<Block>, <Block as BlockT>::Hash, <Block as BlockT>::Hash>) -> Option<ExtrinsicFor<Block>> {
+        fn inbox_response_message_unsigned(msg: CrossDomainMessage<NumberFor<Block>, BlockHashFor<Block>, BlockHashFor<Block>>) -> Option<ExtrinsicFor<Block>> {
             Messenger::inbox_response_message_unsigned(msg)
         }
 

--- a/domains/test/runtime/evm/src/lib.rs
+++ b/domains/test/runtime/evm/src/lib.rs
@@ -92,7 +92,7 @@ use sp_version::RuntimeVersion;
 use static_assertions::const_assert;
 use subspace_runtime_primitives::utility::{MaybeNestedCall, MaybeUtilityCall};
 use subspace_runtime_primitives::{
-    BlockNumber as ConsensusBlockNumber, DomainEventSegmentSize, ExtrinsicFor,
+    BlockHashFor, BlockNumber as ConsensusBlockNumber, DomainEventSegmentSize, ExtrinsicFor,
     Hash as ConsensusBlockHash, Moment, SlowAdjustingFeeUpdate, XdmAdjustedWeightToFee,
     XdmFeeMultipler, MAX_CALL_RECURSION_DEPTH, SHANNON, SSC,
 };
@@ -1241,7 +1241,7 @@ impl_runtime_apis! {
         fn validate_transaction(
             source: TransactionSource,
             tx: ExtrinsicFor<Block>,
-            block_hash: <Block as BlockT>::Hash,
+            block_hash: BlockHashFor<Block>,
         ) -> TransactionValidity {
             Executive::validate_transaction(source, tx, block_hash)
         }
@@ -1362,7 +1362,7 @@ impl_runtime_apis! {
         fn check_extrinsics_and_do_pre_dispatch(
             uxts: Vec<ExtrinsicFor<Block>>,
             block_number: BlockNumber,
-            block_hash: <Block as BlockT>::Hash) -> Result<(), CheckExtrinsicsValidityError> {
+            block_hash: BlockHashFor<Block>) -> Result<(), CheckExtrinsicsValidityError> {
             // Initializing block related storage required for validation
             System::initialize(
                 &(block_number + BlockNumber::one()),
@@ -1494,11 +1494,11 @@ impl_runtime_apis! {
             Messenger::get_block_messages()
         }
 
-        fn outbox_message_unsigned(msg: CrossDomainMessage<NumberFor<Block>, <Block as BlockT>::Hash, <Block as BlockT>::Hash>) -> Option<ExtrinsicFor<Block>> {
+        fn outbox_message_unsigned(msg: CrossDomainMessage<NumberFor<Block>, BlockHashFor<Block>, BlockHashFor<Block>>) -> Option<ExtrinsicFor<Block>> {
             Messenger::outbox_message_unsigned(msg)
         }
 
-        fn inbox_response_message_unsigned(msg: CrossDomainMessage<NumberFor<Block>, <Block as BlockT>::Hash, <Block as BlockT>::Hash>) -> Option<ExtrinsicFor<Block>> {
+        fn inbox_response_message_unsigned(msg: CrossDomainMessage<NumberFor<Block>, BlockHashFor<Block>, BlockHashFor<Block>>) -> Option<ExtrinsicFor<Block>> {
             Messenger::inbox_response_message_unsigned(msg)
         }
 

--- a/domains/test/runtime/evm/src/lib.rs
+++ b/domains/test/runtime/evm/src/lib.rs
@@ -92,9 +92,9 @@ use sp_version::RuntimeVersion;
 use static_assertions::const_assert;
 use subspace_runtime_primitives::utility::{MaybeNestedCall, MaybeUtilityCall};
 use subspace_runtime_primitives::{
-    BlockNumber as ConsensusBlockNumber, DomainEventSegmentSize, Hash as ConsensusBlockHash,
-    Moment, SlowAdjustingFeeUpdate, XdmAdjustedWeightToFee, XdmFeeMultipler,
-    MAX_CALL_RECURSION_DEPTH, SHANNON, SSC,
+    BlockNumber as ConsensusBlockNumber, DomainEventSegmentSize, ExtrinsicFor,
+    Hash as ConsensusBlockHash, Moment, SlowAdjustingFeeUpdate, XdmAdjustedWeightToFee,
+    XdmFeeMultipler, MAX_CALL_RECURSION_DEPTH, SHANNON, SSC,
 };
 
 /// The address format for describing accounts.
@@ -940,7 +940,7 @@ impl fp_rpc::ConvertTransaction<opaque::UncheckedExtrinsic> for TransactionConve
     }
 }
 
-fn is_xdm_mmr_proof_valid(ext: &<Block as BlockT>::Extrinsic) -> Option<bool> {
+fn is_xdm_mmr_proof_valid(ext: &ExtrinsicFor<Block>) -> Option<bool> {
     match &ext.0.function {
         RuntimeCall::Messenger(pallet_messenger::Call::relay_message { msg })
         | RuntimeCall::Messenger(pallet_messenger::Call::relay_message_response { msg }) => {
@@ -971,7 +971,7 @@ fn is_valid_sudo_call(encoded_ext: Vec<u8>) -> bool {
 }
 
 /// Constructs a domain-sudo call extrinsic from the given encoded extrinsic.
-fn construct_sudo_call_extrinsic(encoded_ext: Vec<u8>) -> <Block as BlockT>::Extrinsic {
+fn construct_sudo_call_extrinsic(encoded_ext: Vec<u8>) -> ExtrinsicFor<Block> {
     let ext = UncheckedExtrinsic::decode(&mut encoded_ext.as_slice()).expect(
         "must always be a valid extrinsic due to the check above and storage proof check; qed",
     );
@@ -986,7 +986,7 @@ fn construct_sudo_call_extrinsic(encoded_ext: Vec<u8>) -> <Block as BlockT>::Ext
 /// Constructs an evm-tracker call extrinsic from the given extrinsic.
 fn construct_evm_contract_creation_allowed_by_extrinsic(
     decoded_argument: PermissionedActionAllowedBy<AccountId>,
-) -> <Block as BlockT>::Extrinsic {
+) -> ExtrinsicFor<Block> {
     UncheckedExtrinsic::new_bare(
         pallet_evm_tracker::Call::set_contract_creation_allowed_by {
             contract_creation_allowed_by: decoded_argument,
@@ -1032,7 +1032,7 @@ pub fn extract_signer(
         .collect()
 }
 
-fn extrinsic_era(extrinsic: &<Block as BlockT>::Extrinsic) -> Option<Era> {
+fn extrinsic_era(extrinsic: &ExtrinsicFor<Block>) -> Option<Era> {
     match &extrinsic.0.preamble {
         Preamble::Bare(_) | Preamble::General(_, _) => None,
         Preamble::Signed(_, _, extra) => Some(extra.4 .0),
@@ -1099,7 +1099,7 @@ fn pre_dispatch_evm_transaction(
 }
 
 fn check_transaction_and_do_pre_dispatch_inner(
-    uxt: &<Block as BlockT>::Extrinsic,
+    uxt: &ExtrinsicFor<Block>,
 ) -> Result<(), TransactionValidityError> {
     let lookup = frame_system::ChainContext::<Runtime>::default();
 
@@ -1217,7 +1217,7 @@ impl_runtime_apis! {
     }
 
     impl sp_block_builder::BlockBuilder<Block> for Runtime {
-        fn apply_extrinsic(extrinsic: <Block as BlockT>::Extrinsic) -> ApplyExtrinsicResult {
+        fn apply_extrinsic(extrinsic: ExtrinsicFor<Block>) -> ApplyExtrinsicResult {
             Executive::apply_extrinsic(extrinsic)
         }
 
@@ -1225,7 +1225,7 @@ impl_runtime_apis! {
             Executive::finalize_block()
         }
 
-        fn inherent_extrinsics(data: sp_inherents::InherentData) -> Vec<<Block as BlockT>::Extrinsic> {
+        fn inherent_extrinsics(data: sp_inherents::InherentData) -> Vec<ExtrinsicFor<Block>> {
             data.create_extrinsics()
         }
 
@@ -1240,7 +1240,7 @@ impl_runtime_apis! {
     impl sp_transaction_pool::runtime_api::TaggedTransactionQueue<Block> for Runtime {
         fn validate_transaction(
             source: TransactionSource,
-            tx: <Block as BlockT>::Extrinsic,
+            tx: ExtrinsicFor<Block>,
             block_hash: <Block as BlockT>::Hash,
         ) -> TransactionValidity {
             Executive::validate_transaction(source, tx, block_hash)
@@ -1273,13 +1273,13 @@ impl_runtime_apis! {
 
     impl pallet_transaction_payment_rpc_runtime_api::TransactionPaymentApi<Block, Balance> for Runtime {
         fn query_info(
-            uxt: <Block as BlockT>::Extrinsic,
+            uxt: ExtrinsicFor<Block>,
             len: u32,
         ) -> pallet_transaction_payment_rpc_runtime_api::RuntimeDispatchInfo<Balance> {
             TransactionPayment::query_info(uxt, len)
         }
         fn query_fee_details(
-            uxt: <Block as BlockT>::Extrinsic,
+            uxt: ExtrinsicFor<Block>,
             len: u32,
         ) -> pallet_transaction_payment::FeeDetails<Balance> {
             TransactionPayment::query_fee_details(uxt, len)
@@ -1294,13 +1294,13 @@ impl_runtime_apis! {
 
     impl sp_domains::core_api::DomainCoreApi<Block> for Runtime {
         fn extract_signer(
-            extrinsics: Vec<<Block as BlockT>::Extrinsic>,
-        ) -> Vec<(Option<opaque::AccountId>, <Block as BlockT>::Extrinsic)> {
+            extrinsics: Vec<ExtrinsicFor<Block>>,
+        ) -> Vec<(Option<opaque::AccountId>, ExtrinsicFor<Block>)> {
             extract_signer(extrinsics)
         }
 
         fn is_within_tx_range(
-            extrinsic: &<Block as BlockT>::Extrinsic,
+            extrinsic: &ExtrinsicFor<Block>,
             bundle_vrf_hash: &subspace_core_primitives::U256,
             tx_range: &subspace_core_primitives::U256
         ) -> bool {
@@ -1323,7 +1323,7 @@ impl_runtime_apis! {
             Executive::storage_root()
         }
 
-        fn apply_extrinsic_with_post_state_root(extrinsic: <Block as BlockT>::Extrinsic) -> Vec<u8> {
+        fn apply_extrinsic_with_post_state_root(extrinsic: ExtrinsicFor<Block>) -> Vec<u8> {
             let _ = Executive::apply_extrinsic(extrinsic);
             Executive::storage_root()
         }
@@ -1336,19 +1336,19 @@ impl_runtime_apis! {
             ).encode()
         }
 
-        fn construct_timestamp_extrinsic(moment: Moment) -> <Block as BlockT>::Extrinsic {
+        fn construct_timestamp_extrinsic(moment: Moment) -> ExtrinsicFor<Block> {
             UncheckedExtrinsic::new_bare(
                 pallet_timestamp::Call::set{ now: moment }.into()
             )
         }
 
-        fn construct_domain_update_chain_allowlist_extrinsic(updates: DomainAllowlistUpdates) -> <Block as BlockT>::Extrinsic {
+        fn construct_domain_update_chain_allowlist_extrinsic(updates: DomainAllowlistUpdates) -> ExtrinsicFor<Block> {
              UncheckedExtrinsic::new_bare(
                 pallet_messenger::Call::update_domain_allowlist{ updates }.into()
             )
         }
 
-        fn is_inherent_extrinsic(extrinsic: &<Block as BlockT>::Extrinsic) -> bool {
+        fn is_inherent_extrinsic(extrinsic: &ExtrinsicFor<Block>) -> bool {
             match &extrinsic.0.function {
                 RuntimeCall::Timestamp(call) => Timestamp::is_inherent(call),
                 RuntimeCall::ExecutivePallet(call) => ExecutivePallet::is_inherent(call),
@@ -1360,7 +1360,7 @@ impl_runtime_apis! {
         }
 
         fn check_extrinsics_and_do_pre_dispatch(
-            uxts: Vec<<Block as BlockT>::Extrinsic>,
+            uxts: Vec<ExtrinsicFor<Block>>,
             block_number: BlockNumber,
             block_hash: <Block as BlockT>::Hash) -> Result<(), CheckExtrinsicsValidityError> {
             // Initializing block related storage required for validation
@@ -1384,7 +1384,7 @@ impl_runtime_apis! {
 
         fn decode_extrinsic(
             opaque_extrinsic: sp_runtime::OpaqueExtrinsic,
-        ) -> Result<<Block as BlockT>::Extrinsic, DecodeExtrinsicError> {
+        ) -> Result<ExtrinsicFor<Block>, DecodeExtrinsicError> {
             let encoded = opaque_extrinsic.encode();
 
             UncheckedExtrinsic::decode_with_depth_limit(
@@ -1394,12 +1394,12 @@ impl_runtime_apis! {
         }
 
         fn extrinsic_era(
-          extrinsic: &<Block as BlockT>::Extrinsic
+          extrinsic: &ExtrinsicFor<Block>
         ) -> Option<Era> {
             extrinsic_era(extrinsic)
         }
 
-        fn extrinsic_weight(ext: &<Block as BlockT>::Extrinsic) -> Weight {
+        fn extrinsic_weight(ext: &ExtrinsicFor<Block>) -> Weight {
             let len = ext.encoded_size() as u64;
             let info = ext.get_dispatch_info();
             info.call_weight.saturating_add(info.extension_weight)
@@ -1419,7 +1419,7 @@ impl_runtime_apis! {
             System::block_weight().total()
         }
 
-        fn construct_consensus_chain_byte_fee_extrinsic(transaction_byte_fee: Balance) -> <Block as BlockT>::Extrinsic {
+        fn construct_consensus_chain_byte_fee_extrinsic(transaction_byte_fee: Balance) -> ExtrinsicFor<Block> {
             UncheckedExtrinsic::new_bare(
                 pallet_block_fees::Call::set_next_consensus_chain_byte_fee{ transaction_byte_fee }.into()
             )
@@ -1440,12 +1440,12 @@ impl_runtime_apis! {
 
     impl sp_messenger::MessengerApi<Block, ConsensusBlockNumber, ConsensusBlockHash> for Runtime {
         fn is_xdm_mmr_proof_valid(
-            extrinsic: &<Block as BlockT>::Extrinsic
+            extrinsic: &ExtrinsicFor<Block>
         ) -> Option<bool> {
             is_xdm_mmr_proof_valid(extrinsic)
         }
 
-        fn extract_xdm_mmr_proof(ext: &<Block as BlockT>::Extrinsic) -> Option<ConsensusChainMmrLeafProof<ConsensusBlockNumber, ConsensusBlockHash, sp_core::H256>> {
+        fn extract_xdm_mmr_proof(ext: &ExtrinsicFor<Block>) -> Option<ConsensusChainMmrLeafProof<ConsensusBlockNumber, ConsensusBlockHash, sp_core::H256>> {
             match &ext.0.function {
                 RuntimeCall::Messenger(pallet_messenger::Call::relay_message { msg })
                 | RuntimeCall::Messenger(pallet_messenger::Call::relay_message_response { msg }) => {
@@ -1472,7 +1472,7 @@ impl_runtime_apis! {
             None
         }
 
-        fn xdm_id(ext: &<Block as BlockT>::Extrinsic) -> Option<XdmId> {
+        fn xdm_id(ext: &ExtrinsicFor<Block>) -> Option<XdmId> {
             match &ext.0.function {
                 RuntimeCall::Messenger(pallet_messenger::Call::relay_message { msg })=> {
                     Some(XdmId::RelayMessage((msg.src_chain_id, msg.channel_id, msg.nonce)))
@@ -1494,11 +1494,11 @@ impl_runtime_apis! {
             Messenger::get_block_messages()
         }
 
-        fn outbox_message_unsigned(msg: CrossDomainMessage<NumberFor<Block>, <Block as BlockT>::Hash, <Block as BlockT>::Hash>) -> Option<<Block as BlockT>::Extrinsic> {
+        fn outbox_message_unsigned(msg: CrossDomainMessage<NumberFor<Block>, <Block as BlockT>::Hash, <Block as BlockT>::Hash>) -> Option<ExtrinsicFor<Block>> {
             Messenger::outbox_message_unsigned(msg)
         }
 
-        fn inbox_response_message_unsigned(msg: CrossDomainMessage<NumberFor<Block>, <Block as BlockT>::Hash, <Block as BlockT>::Hash>) -> Option<<Block as BlockT>::Extrinsic> {
+        fn inbox_response_message_unsigned(msg: CrossDomainMessage<NumberFor<Block>, <Block as BlockT>::Hash, <Block as BlockT>::Hash>) -> Option<ExtrinsicFor<Block>> {
             Messenger::inbox_response_message_unsigned(msg)
         }
 
@@ -1660,7 +1660,7 @@ impl_runtime_apis! {
         }
 
         fn extrinsic_filter(
-            xts: Vec<<Block as BlockT>::Extrinsic>,
+            xts: Vec<ExtrinsicFor<Block>>,
         ) -> Vec<EthereumTransaction> {
             xts.into_iter().filter_map(|xt| match xt.0.function {
                 RuntimeCall::Ethereum(transact { transaction }) => Some(transaction),
@@ -1675,7 +1675,7 @@ impl_runtime_apis! {
         fn gas_limit_multiplier_support() {}
 
         fn pending_block(
-            xts: Vec<<Block as BlockT>::Extrinsic>,
+            xts: Vec<ExtrinsicFor<Block>>,
         ) -> (Option<pallet_ethereum::Block>, Option<Vec<TransactionStatus>>) {
             for ext in xts.into_iter() {
                 let _ = Executive::apply_extrinsic(ext);
@@ -1695,7 +1695,7 @@ impl_runtime_apis! {
     }
 
     impl fp_rpc::ConvertTransactionRuntimeApi<Block> for Runtime {
-        fn convert_transaction(transaction: EthereumTransaction) -> <Block as BlockT>::Extrinsic {
+        fn convert_transaction(transaction: EthereumTransaction) -> ExtrinsicFor<Block> {
             UncheckedExtrinsic::new_bare(
                 pallet_ethereum::Call::<Runtime>::transact { transaction }.into(),
             )
@@ -1744,13 +1744,13 @@ impl_runtime_apis! {
             is_valid_sudo_call(extrinsic)
         }
 
-        fn construct_domain_sudo_extrinsic(inner: Vec<u8>) -> <Block as BlockT>::Extrinsic {
+        fn construct_domain_sudo_extrinsic(inner: Vec<u8>) -> ExtrinsicFor<Block> {
             construct_sudo_call_extrinsic(inner)
         }
     }
 
     impl sp_evm_tracker::EvmTrackerApi<Block> for Runtime {
-        fn construct_evm_contract_creation_allowed_by_extrinsic(decoded_argument: PermissionedActionAllowedBy<AccountId>) -> <Block as BlockT>::Extrinsic {
+        fn construct_evm_contract_creation_allowed_by_extrinsic(decoded_argument: PermissionedActionAllowedBy<AccountId>) -> ExtrinsicFor<Block> {
             construct_evm_contract_creation_allowed_by_extrinsic(decoded_argument)
         }
     }

--- a/domains/test/runtime/evm/src/lib.rs
+++ b/domains/test/runtime/evm/src/lib.rs
@@ -68,9 +68,9 @@ use sp_messenger_host_functions::{get_storage_key, StorageKeyRequest};
 use sp_mmr_primitives::EncodableOpaqueLeaf;
 use sp_runtime::generic::{Era, ExtrinsicFormat, Preamble, SignedPayload};
 use sp_runtime::traits::{
-    BlakeTwo256, Block as BlockT, Checkable, DispatchInfoOf, DispatchTransaction, Dispatchable,
-    IdentityLookup, Keccak256, NumberFor, One, PostDispatchInfoOf, TransactionExtension,
-    UniqueSaturatedInto, ValidateUnsigned, Zero,
+    BlakeTwo256, Checkable, DispatchInfoOf, DispatchTransaction, Dispatchable, IdentityLookup,
+    Keccak256, NumberFor, One, PostDispatchInfoOf, TransactionExtension, UniqueSaturatedInto,
+    ValidateUnsigned, Zero,
 };
 use sp_runtime::transaction_validity::{
     InvalidTransaction, TransactionSource, TransactionValidity, TransactionValidityError,
@@ -93,7 +93,7 @@ use static_assertions::const_assert;
 use subspace_runtime_primitives::utility::{MaybeNestedCall, MaybeUtilityCall};
 use subspace_runtime_primitives::{
     BlockHashFor, BlockNumber as ConsensusBlockNumber, DomainEventSegmentSize, ExtrinsicFor,
-    Hash as ConsensusBlockHash, Moment, SlowAdjustingFeeUpdate, XdmAdjustedWeightToFee,
+    Hash as ConsensusBlockHash, HeaderFor, Moment, SlowAdjustingFeeUpdate, XdmAdjustedWeightToFee,
     XdmFeeMultipler, MAX_CALL_RECURSION_DEPTH, SHANNON, SSC,
 };
 
@@ -1197,7 +1197,7 @@ impl_runtime_apis! {
             Executive::execute_block(block)
         }
 
-        fn initialize_block(header: &<Block as BlockT>::Header) -> ExtrinsicInclusionMode {
+        fn initialize_block(header: &HeaderFor<Block>) -> ExtrinsicInclusionMode {
             Executive::initialize_block(header)
         }
     }
@@ -1221,7 +1221,7 @@ impl_runtime_apis! {
             Executive::apply_extrinsic(extrinsic)
         }
 
-        fn finalize_block() -> <Block as BlockT>::Header {
+        fn finalize_block() -> HeaderFor<Block> {
             Executive::finalize_block()
         }
 
@@ -1248,7 +1248,7 @@ impl_runtime_apis! {
     }
 
     impl sp_offchain::OffchainWorkerApi<Block> for Runtime {
-        fn offchain_worker(header: &<Block as BlockT>::Header) {
+        fn offchain_worker(header: &HeaderFor<Block>) {
             Executive::offchain_worker(header)
         }
     }
@@ -1318,7 +1318,7 @@ impl_runtime_apis! {
             }
         }
 
-        fn initialize_block_with_post_state_root(header: &<Block as BlockT>::Header) -> Vec<u8> {
+        fn initialize_block_with_post_state_root(header: &HeaderFor<Block>) -> Vec<u8> {
             Executive::initialize_block(header);
             Executive::storage_root()
         }
@@ -1689,7 +1689,7 @@ impl_runtime_apis! {
             )
         }
 
-        fn initialize_pending_block(header: &<Block as BlockT>::Header) {
+        fn initialize_pending_block(header: &HeaderFor<Block>) {
             Executive::initialize_block(header);
         }
     }

--- a/domains/test/service/src/domain.rs
+++ b/domains/test/service/src/domain.rs
@@ -36,14 +36,14 @@ use sp_domains::{DomainId, OperatorId, PermissionedActionAllowedBy};
 use sp_messenger::messages::{ChainId, ChannelId};
 use sp_messenger::{MessengerApi, RelayerApi};
 use sp_offchain::OffchainWorkerApi;
-use sp_runtime::traits::{AsSystemOriginSigner, Block as BlockT, Dispatchable, NumberFor};
+use sp_runtime::traits::{AsSystemOriginSigner, Dispatchable, NumberFor};
 use sp_runtime::OpaqueExtrinsic;
 use sp_session::SessionKeys;
 use sp_transaction_pool::runtime_api::TaggedTransactionQueue;
 use std::future::Future;
 use std::sync::Arc;
 use subspace_runtime_primitives::opaque::Block as CBlock;
-use subspace_runtime_primitives::{BlockHashFor, Nonce};
+use subspace_runtime_primitives::{BlockHashFor, HeaderFor, Nonce};
 use subspace_test_primitives::DOMAINS_BLOCK_PRUNING_DEPTH;
 use subspace_test_service::MockConsensusNode;
 use substrate_frame_rpc_system::AccountNonceApi;
@@ -236,9 +236,7 @@ where
             maybe_operator_id,
             confirmation_depth_k: chain_constants.confirmation_depth_k(),
             challenge_period: DOMAINS_BLOCK_PRUNING_DEPTH,
-            consensus_chain_sync_params: None::<
-                ConsensusChainSyncParams<_, <Block as BlockT>::Header>,
-            >,
+            consensus_chain_sync_params: None::<ConsensusChainSyncParams<_, HeaderFor<Block>>>,
             domain_backend,
         };
 

--- a/domains/test/service/src/domain.rs
+++ b/domains/test/service/src/domain.rs
@@ -43,7 +43,7 @@ use sp_transaction_pool::runtime_api::TaggedTransactionQueue;
 use std::future::Future;
 use std::sync::Arc;
 use subspace_runtime_primitives::opaque::Block as CBlock;
-use subspace_runtime_primitives::Nonce;
+use subspace_runtime_primitives::{BlockHashFor, Nonce};
 use subspace_test_primitives::DOMAINS_BLOCK_PRUNING_DEPTH;
 use subspace_test_service::MockConsensusNode;
 use substrate_frame_rpc_system::AccountNonceApi;
@@ -71,11 +71,11 @@ where
         + OffchainWorkerApi<Block>
         + SessionKeys<Block>
         + DomainCoreApi<Block>
-        + MessengerApi<Block, NumberFor<CBlock>, <CBlock as BlockT>::Hash>
+        + MessengerApi<Block, NumberFor<CBlock>, BlockHashFor<CBlock>>
         + TaggedTransactionQueue<Block>
         + AccountNonceApi<Block, Runtime::AccountId, Nonce>
         + TransactionPaymentRuntimeApi<Block, Balance>
-        + RelayerApi<Block, NumberFor<Block>, NumberFor<CBlock>, <CBlock as BlockT>::Hash>,
+        + RelayerApi<Block, NumberFor<Block>, NumberFor<CBlock>, BlockHashFor<CBlock>>,
 {
     /// The domain id
     pub domain_id: DomainId,
@@ -127,8 +127,8 @@ where
         + TaggedTransactionQueue<Block>
         + AccountNonceApi<Block, <Runtime as DomainRuntime>::AccountId, Nonce>
         + TransactionPaymentRuntimeApi<Block, Balance>
-        + MessengerApi<Block, NumberFor<CBlock>, <CBlock as BlockT>::Hash>
-        + RelayerApi<Block, NumberFor<Block>, NumberFor<CBlock>, <CBlock as BlockT>::Hash>
+        + MessengerApi<Block, NumberFor<CBlock>, BlockHashFor<CBlock>>
+        + RelayerApi<Block, NumberFor<Block>, NumberFor<CBlock>, BlockHashFor<CBlock>>
         + OnchainStateApi<Block, <Runtime as DomainRuntime>::AccountId, Balance>,
     <RuntimeCallFor<Runtime> as Dispatchable>::RuntimeOrigin:
         AsSystemOriginSigner<<Runtime as frame_system::Config>::AccountId> + Clone,
@@ -531,8 +531,8 @@ where
         + TaggedTransactionQueue<Block>
         + AccountNonceApi<Block, <Runtime as DomainRuntime>::AccountId, Nonce>
         + TransactionPaymentRuntimeApi<Block, Balance>
-        + MessengerApi<Block, NumberFor<CBlock>, <CBlock as BlockT>::Hash>
-        + RelayerApi<Block, NumberFor<Block>, NumberFor<CBlock>, <CBlock as BlockT>::Hash>
+        + MessengerApi<Block, NumberFor<CBlock>, BlockHashFor<CBlock>>
+        + RelayerApi<Block, NumberFor<Block>, NumberFor<CBlock>, BlockHashFor<CBlock>>
         + EvmOnchainStateApi<Block>,
 {
     /// Returns the current EVM contract creation allow list.

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -86,9 +86,9 @@ use sp_messenger::{ChannelNonce, XdmId};
 use sp_messenger_host_functions::{get_storage_key, StorageKeyRequest};
 use sp_mmr_primitives::EncodableOpaqueLeaf;
 use sp_runtime::traits::{
-    AccountIdConversion, AccountIdLookup, AsSystemOriginSigner, BlakeTwo256, Block as BlockT,
-    ConstBool, DispatchInfoOf, Keccak256, NumberFor, PostDispatchInfoOf, TransactionExtension,
-    ValidateResult, Zero,
+    AccountIdConversion, AccountIdLookup, AsSystemOriginSigner, BlakeTwo256, ConstBool,
+    DispatchInfoOf, Keccak256, NumberFor, PostDispatchInfoOf, TransactionExtension, ValidateResult,
+    Zero,
 };
 use sp_runtime::transaction_validity::{
     InvalidTransaction, TransactionSource, TransactionValidity, TransactionValidityError,
@@ -118,9 +118,9 @@ use subspace_runtime_primitives::utility::{
 };
 use subspace_runtime_primitives::{
     AccountId, Balance, BlockHashFor, BlockNumber, ConsensusEventSegmentSize, ExtrinsicFor,
-    FindBlockRewardAddress, Hash, HoldIdentifier, Moment, Nonce, Signature, SlowAdjustingFeeUpdate,
-    TargetBlockFullness, XdmAdjustedWeightToFee, XdmFeeMultipler, MAX_BLOCK_LENGTH,
-    MAX_CALL_RECURSION_DEPTH, MIN_REPLICATION_FACTOR, SHANNON, SSC,
+    FindBlockRewardAddress, Hash, HeaderFor, HoldIdentifier, Moment, Nonce, Signature,
+    SlowAdjustingFeeUpdate, TargetBlockFullness, XdmAdjustedWeightToFee, XdmFeeMultipler,
+    MAX_BLOCK_LENGTH, MAX_CALL_RECURSION_DEPTH, MIN_REPLICATION_FACTOR, SHANNON, SSC,
 };
 use subspace_test_primitives::DOMAINS_BLOCK_PRUNING_DEPTH;
 
@@ -1336,7 +1336,7 @@ impl_runtime_apis! {
             Executive::execute_block(block);
         }
 
-        fn initialize_block(header: &<Block as BlockT>::Header) -> ExtrinsicInclusionMode {
+        fn initialize_block(header: &HeaderFor<Block>) -> ExtrinsicInclusionMode {
             Executive::initialize_block(header)
         }
     }
@@ -1360,7 +1360,7 @@ impl_runtime_apis! {
             Executive::apply_extrinsic(extrinsic)
         }
 
-        fn finalize_block() -> <Block as BlockT>::Header {
+        fn finalize_block() -> HeaderFor<Block> {
             Executive::finalize_block()
         }
 
@@ -1387,7 +1387,7 @@ impl_runtime_apis! {
     }
 
     impl sp_offchain::OffchainWorkerApi<Block> for Runtime {
-        fn offchain_worker(header: &<Block as BlockT>::Header) {
+        fn offchain_worker(header: &HeaderFor<Block>) {
             Executive::offchain_worker(header)
         }
     }

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -117,7 +117,7 @@ use subspace_runtime_primitives::utility::{
     nested_call_iter, DefaultNonceProvider, MaybeMultisigCall, MaybeNestedCall, MaybeUtilityCall,
 };
 use subspace_runtime_primitives::{
-    AccountId, Balance, BlockNumber, ConsensusEventSegmentSize, ExtrinsicFor,
+    AccountId, Balance, BlockHashFor, BlockNumber, ConsensusEventSegmentSize, ExtrinsicFor,
     FindBlockRewardAddress, Hash, HoldIdentifier, Moment, Nonce, Signature, SlowAdjustingFeeUpdate,
     TargetBlockFullness, XdmAdjustedWeightToFee, XdmFeeMultipler, MAX_BLOCK_LENGTH,
     MAX_CALL_RECURSION_DEPTH, MIN_REPLICATION_FACTOR, SHANNON, SSC,
@@ -1380,7 +1380,7 @@ impl_runtime_apis! {
         fn validate_transaction(
             source: TransactionSource,
             tx: ExtrinsicFor<Block>,
-            block_hash: <Block as BlockT>::Hash,
+            block_hash: BlockHashFor<Block>,
         ) -> TransactionValidity {
             Executive::validate_transaction(source, tx, block_hash)
         }
@@ -1408,7 +1408,7 @@ impl_runtime_apis! {
         }
 
         fn submit_vote_extrinsic(
-            signed_vote: SignedVote<NumberFor<Block>, <Block as BlockT>::Hash, PublicKey>,
+            signed_vote: SignedVote<NumberFor<Block>, BlockHashFor<Block>, PublicKey>,
         ) {
             let SignedVote { vote, signature } = signed_vote;
             let Vote::V0 {
@@ -1481,13 +1481,13 @@ impl_runtime_apis! {
 
     impl sp_domains::DomainsApi<Block, DomainHeader> for Runtime {
         fn submit_bundle_unsigned(
-            opaque_bundle: OpaqueBundle<NumberFor<Block>, <Block as BlockT>::Hash, DomainHeader, Balance>,
+            opaque_bundle: OpaqueBundle<NumberFor<Block>, BlockHashFor<Block>, DomainHeader, Balance>,
         ) {
             Domains::submit_bundle_unsigned(opaque_bundle)
         }
 
         fn submit_receipt_unsigned(
-            singleton_receipt: sp_domains::SealedSingletonReceipt<NumberFor<Block>, <Block as BlockT>::Hash, DomainHeader, Balance>,
+            singleton_receipt: sp_domains::SealedSingletonReceipt<NumberFor<Block>, BlockHashFor<Block>, DomainHeader, Balance>,
         ) {
             Domains::submit_receipt_unsigned(singleton_receipt)
         }
@@ -1659,14 +1659,14 @@ impl_runtime_apis! {
         }
     }
 
-    impl sp_messenger::MessengerApi<Block, BlockNumber, <Block as BlockT>::Hash> for Runtime {
+    impl sp_messenger::MessengerApi<Block, BlockNumber, BlockHashFor<Block>> for Runtime {
         fn is_xdm_mmr_proof_valid(
             extrinsic: &ExtrinsicFor<Block>
         ) -> Option<bool> {
             is_xdm_mmr_proof_valid(extrinsic)
         }
 
-        fn extract_xdm_mmr_proof(ext: &ExtrinsicFor<Block>) -> Option<ConsensusChainMmrLeafProof<BlockNumber, <Block as BlockT>::Hash, sp_core::H256>> {
+        fn extract_xdm_mmr_proof(ext: &ExtrinsicFor<Block>) -> Option<ConsensusChainMmrLeafProof<BlockNumber, BlockHashFor<Block>, sp_core::H256>> {
             match &ext.function {
                 RuntimeCall::Messenger(pallet_messenger::Call::relay_message { msg })
                 | RuntimeCall::Messenger(pallet_messenger::Call::relay_message_response { msg }) => {
@@ -1709,16 +1709,16 @@ impl_runtime_apis! {
         }
     }
 
-    impl sp_messenger::RelayerApi<Block, BlockNumber, BlockNumber, <Block as BlockT>::Hash> for Runtime {
+    impl sp_messenger::RelayerApi<Block, BlockNumber, BlockNumber, BlockHashFor<Block>> for Runtime {
         fn block_messages() -> BlockMessagesWithStorageKey {
             Messenger::get_block_messages()
         }
 
-        fn outbox_message_unsigned(msg: CrossDomainMessage<NumberFor<Block>, <Block as BlockT>::Hash, <Block as BlockT>::Hash>) -> Option<ExtrinsicFor<Block>> {
+        fn outbox_message_unsigned(msg: CrossDomainMessage<NumberFor<Block>, BlockHashFor<Block>, BlockHashFor<Block>>) -> Option<ExtrinsicFor<Block>> {
             Messenger::outbox_message_unsigned(msg)
         }
 
-        fn inbox_response_message_unsigned(msg: CrossDomainMessage<NumberFor<Block>, <Block as BlockT>::Hash, <Block as BlockT>::Hash>) -> Option<ExtrinsicFor<Block>> {
+        fn inbox_response_message_unsigned(msg: CrossDomainMessage<NumberFor<Block>, BlockHashFor<Block>, BlockHashFor<Block>>) -> Option<ExtrinsicFor<Block>> {
             Messenger::inbox_response_message_unsigned(msg)
         }
 
@@ -1744,7 +1744,7 @@ impl_runtime_apis! {
     }
 
     impl sp_domains_fraud_proof::FraudProofApi<Block, DomainHeader> for Runtime {
-        fn submit_fraud_proof_unsigned(fraud_proof: FraudProof<NumberFor<Block>, <Block as BlockT>::Hash, DomainHeader, H256>) {
+        fn submit_fraud_proof_unsigned(fraud_proof: FraudProof<NumberFor<Block>, BlockHashFor<Block>, DomainHeader, H256>) {
             Domains::submit_fraud_proof_unsigned(fraud_proof)
         }
 
@@ -1808,7 +1808,7 @@ impl_runtime_apis! {
             Messenger::get_open_channel_for_chain(dst_chain_id).map(|(c, _)| c)
         }
 
-        fn verify_proof_and_extract_leaf(mmr_leaf_proof: ConsensusChainMmrLeafProof<NumberFor<Block>, <Block as BlockT>::Hash, H256>) -> Option<mmr::Leaf> {
+        fn verify_proof_and_extract_leaf(mmr_leaf_proof: ConsensusChainMmrLeafProof<NumberFor<Block>, BlockHashFor<Block>, H256>) -> Option<mmr::Leaf> {
             <MmrProofVerifier as sp_subspace_mmr::MmrProofVerifier<_, _, _,>>::verify_proof_and_extract_leaf(mmr_leaf_proof)
         }
 

--- a/test/subspace-test-service/src/lib.rs
+++ b/test/subspace-test-service/src/lib.rs
@@ -90,7 +90,9 @@ use subspace_core_primitives::pot::PotOutput;
 use subspace_core_primitives::solutions::Solution;
 use subspace_core_primitives::{BlockNumber, PublicKey};
 use subspace_runtime_primitives::opaque::Block;
-use subspace_runtime_primitives::{AccountId, Balance, ExtrinsicFor, Hash, Signature};
+use subspace_runtime_primitives::{
+    AccountId, Balance, BlockHashFor, ExtrinsicFor, Hash, Signature,
+};
 use subspace_service::{FullSelectChain, RuntimeExecutor};
 use subspace_test_client::{chain_spec, Backend, Client};
 use subspace_test_primitives::OnchainStateApi;
@@ -102,7 +104,7 @@ use substrate_frame_rpc_system::AccountNonceApi;
 use substrate_test_client::{RpcHandlersExt, RpcTransactionError, RpcTransactionOutput};
 
 type FraudProofFor<Block, DomainBlock> =
-    FraudProof<NumberFor<Block>, <Block as BlockT>::Hash, <DomainBlock as BlockT>::Header, H256>;
+    FraudProof<NumberFor<Block>, BlockHashFor<Block>, <DomainBlock as BlockT>::Header, H256>;
 
 const MAX_PRODUCE_BUNDLE_TRY: usize = 10;
 
@@ -820,7 +822,7 @@ impl MockConsensusNode {
 
     async fn prune_txs_from_pool(
         &self,
-        tx_hashes: &[<Block as BlockT>::Hash],
+        tx_hashes: &[BlockHashFor<Block>],
     ) -> Result<(), Box<dyn Error>> {
         let hash_and_number = HashAndNumber {
             number: self.client.info().best_number,
@@ -842,7 +844,7 @@ impl MockConsensusNode {
     /// Return if the given ER exist in the consensus state
     pub fn does_receipt_exist(
         &self,
-        er_hash: <DomainBlock as BlockT>::Hash,
+        er_hash: BlockHashFor<DomainBlock>,
     ) -> Result<bool, Box<dyn Error>> {
         Ok(self
             .client
@@ -974,7 +976,7 @@ impl MockConsensusNode {
     async fn build_block(
         &self,
         slot: Slot,
-        parent_hash: <Block as BlockT>::Hash,
+        parent_hash: BlockHashFor<Block>,
         extrinsics: Vec<ExtrinsicFor<Block>>,
     ) -> Result<(Block, StorageChanges), Box<dyn Error>> {
         let inherent_digest = self.mock_subspace_digest(slot);
@@ -1005,7 +1007,7 @@ impl MockConsensusNode {
         &self,
         block: Block,
         storage_changes: Option<StorageChanges>,
-    ) -> Result<<Block as BlockT>::Hash, Box<dyn Error>> {
+    ) -> Result<BlockHashFor<Block>, Box<dyn Error>> {
         let (header, body) = block.deconstruct();
 
         let header_hash = header.hash();
@@ -1051,9 +1053,9 @@ impl MockConsensusNode {
     pub async fn produce_block_with_slot_at(
         &mut self,
         new_slot: NewSlot,
-        parent_hash: <Block as BlockT>::Hash,
+        parent_hash: BlockHashFor<Block>,
         maybe_extrinsics: Option<Vec<ExtrinsicFor<Block>>>,
-    ) -> Result<<Block as BlockT>::Hash, Box<dyn Error>> {
+    ) -> Result<BlockHashFor<Block>, Box<dyn Error>> {
         let block_timer = time::Instant::now();
 
         let extrinsics = match maybe_extrinsics {

--- a/test/subspace-test-service/src/lib.rs
+++ b/test/subspace-test-service/src/lib.rs
@@ -91,7 +91,7 @@ use subspace_core_primitives::solutions::Solution;
 use subspace_core_primitives::{BlockNumber, PublicKey};
 use subspace_runtime_primitives::opaque::Block;
 use subspace_runtime_primitives::{
-    AccountId, Balance, BlockHashFor, ExtrinsicFor, Hash, Signature,
+    AccountId, Balance, BlockHashFor, ExtrinsicFor, Hash, HeaderFor, Signature,
 };
 use subspace_service::{FullSelectChain, RuntimeExecutor};
 use subspace_test_client::{chain_spec, Backend, Client};
@@ -104,7 +104,7 @@ use substrate_frame_rpc_system::AccountNonceApi;
 use substrate_test_client::{RpcHandlersExt, RpcTransactionError, RpcTransactionOutput};
 
 type FraudProofFor<Block, DomainBlock> =
-    FraudProof<NumberFor<Block>, BlockHashFor<Block>, <DomainBlock as BlockT>::Header, H256>;
+    FraudProof<NumberFor<Block>, BlockHashFor<Block>, HeaderFor<DomainBlock>, H256>;
 
 const MAX_PRODUCE_BUNDLE_TRY: usize = 10;
 

--- a/test/subspace-test-service/src/lib.rs
+++ b/test/subspace-test-service/src/lib.rs
@@ -90,7 +90,7 @@ use subspace_core_primitives::pot::PotOutput;
 use subspace_core_primitives::solutions::Solution;
 use subspace_core_primitives::{BlockNumber, PublicKey};
 use subspace_runtime_primitives::opaque::Block;
-use subspace_runtime_primitives::{AccountId, Balance, Hash, Signature};
+use subspace_runtime_primitives::{AccountId, Balance, ExtrinsicFor, Hash, Signature};
 use subspace_service::{FullSelectChain, RuntimeExecutor};
 use subspace_test_client::{chain_spec, Backend, Client};
 use subspace_test_primitives::OnchainStateApi;
@@ -934,7 +934,7 @@ impl MockConsensusNode {
 }
 
 impl MockConsensusNode {
-    async fn collect_txn_from_pool(&self, parent_hash: Hash) -> Vec<<Block as BlockT>::Extrinsic> {
+    async fn collect_txn_from_pool(&self, parent_hash: Hash) -> Vec<ExtrinsicFor<Block>> {
         self.transaction_pool
             .ready_at(parent_hash)
             .await
@@ -975,7 +975,7 @@ impl MockConsensusNode {
         &self,
         slot: Slot,
         parent_hash: <Block as BlockT>::Hash,
-        extrinsics: Vec<<Block as BlockT>::Extrinsic>,
+        extrinsics: Vec<ExtrinsicFor<Block>>,
     ) -> Result<(Block, StorageChanges), Box<dyn Error>> {
         let inherent_digest = self.mock_subspace_digest(slot);
 
@@ -1052,7 +1052,7 @@ impl MockConsensusNode {
         &mut self,
         new_slot: NewSlot,
         parent_hash: <Block as BlockT>::Hash,
-        maybe_extrinsics: Option<Vec<<Block as BlockT>::Extrinsic>>,
+        maybe_extrinsics: Option<Vec<ExtrinsicFor<Block>>>,
     ) -> Result<<Block as BlockT>::Hash, Box<dyn Error>> {
         let block_timer = time::Instant::now();
 
@@ -1097,7 +1097,7 @@ impl MockConsensusNode {
     #[sc_tracing::logging::prefix_logs_with(self.log_prefix)]
     pub async fn produce_block_with_extrinsics(
         &mut self,
-        extrinsics: Vec<<Block as BlockT>::Extrinsic>,
+        extrinsics: Vec<ExtrinsicFor<Block>>,
     ) -> Result<(), Box<dyn Error>> {
         let slot = self.produce_slot();
         self.produce_block_with_slot_at(slot, self.client.info().best_hash, Some(extrinsics))


### PR DESCRIPTION
Original from https://github.com/autonomys/subspace/pull/3528#discussion_r2084023390

This PR uses helpful type aliases for `<Block as BlockT>::Extrinsic`, `<Block as BlockT>::Hash`, and `<Block as BlockT>::Header` that can make our life much easier.

Pure refactoring, no logical change.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
