### PR TITLE
add empty migrations for mainnet

### DIFF
--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -13,6 +13,7 @@ pub mod block_tree;
 pub mod bundle_storage_fund;
 pub mod domain_registry;
 pub mod extensions;
+pub mod migrations;
 pub mod runtime_registry;
 mod staking;
 mod staking_epoch;

--- a/crates/pallet-domains/src/migrations.rs
+++ b/crates/pallet-domains/src/migrations.rs
@@ -1,0 +1,3 @@
+mod v1_to_v5;
+
+pub use v1_to_v5::VersionCheckedMigrateDomainsV1ToV5;

--- a/crates/pallet-domains/src/migrations/v1_to_v5.rs
+++ b/crates/pallet-domains/src/migrations/v1_to_v5.rs
@@ -1,0 +1,22 @@
+//! Migration module for pallet-domains
+
+use crate::{Config, Pallet};
+use core::marker::PhantomData;
+use frame_support::migrations::VersionedMigration;
+use frame_support::traits::UncheckedOnRuntimeUpgrade;
+use frame_support::weights::Weight;
+
+pub type VersionCheckedMigrateDomainsV1ToV5<T> = VersionedMigration<
+    1,
+    5,
+    VersionUncheckedMigrateV1ToV5<T>,
+    Pallet<T>,
+    <T as frame_system::Config>::DbWeight,
+>;
+
+pub struct VersionUncheckedMigrateV1ToV5<T>(PhantomData<T>);
+impl<T: Config> UncheckedOnRuntimeUpgrade for VersionUncheckedMigrateV1ToV5<T> {
+    fn on_runtime_upgrade() -> Weight {
+        Weight::zero()
+    }
+}

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -1100,7 +1100,11 @@ pub type Executive = frame_executive::Executive<
     Runtime,
     AllPalletsWithSystem,
     // TODO: remove only after migrations are run on Mainnet
-    pallet_messenger::migrations::VersionCheckedMigrateDomainsV1ToV2<Runtime>,
+    (
+        pallet_domains::migrations::VersionCheckedMigrateDomainsV1ToV5<Runtime>,
+        pallet_messenger::migrations::VersionCheckedMigrateDomainsV0ToV1<Runtime>,
+        pallet_messenger::migrations::VersionCheckedMigrateDomainsV1ToV2<Runtime>,
+    ),
 >;
 
 impl pallet_subspace::extensions::MaybeSubspaceCall<Runtime> for RuntimeCall {

--- a/domains/pallets/messenger/src/migrations.rs
+++ b/domains/pallets/messenger/src/migrations.rs
@@ -1,4 +1,6 @@
+mod v0_to_v1;
 mod v1_to_v2;
 
+pub use v0_to_v1::VersionCheckedMigrateDomainsV0ToV1;
 pub(crate) use v1_to_v2::migrate_channels::{get_channel, get_open_channels};
 pub use v1_to_v2::VersionCheckedMigrateDomainsV1ToV2;

--- a/domains/pallets/messenger/src/migrations/v0_to_v1.rs
+++ b/domains/pallets/messenger/src/migrations/v0_to_v1.rs
@@ -1,0 +1,22 @@
+//! Migration module for pallet-messenger
+
+use crate::{Config, Pallet};
+use core::marker::PhantomData;
+use frame_support::migrations::VersionedMigration;
+use frame_support::traits::UncheckedOnRuntimeUpgrade;
+use frame_support::weights::Weight;
+
+pub type VersionCheckedMigrateDomainsV0ToV1<T> = VersionedMigration<
+    0,
+    1,
+    VersionUncheckedMigrateV0ToV1<T>,
+    Pallet<T>,
+    <T as frame_system::Config>::DbWeight,
+>;
+
+pub struct VersionUncheckedMigrateV0ToV1<T>(PhantomData<T>);
+impl<T: Config> UncheckedOnRuntimeUpgrade for VersionUncheckedMigrateV0ToV1<T> {
+    fn on_runtime_upgrade() -> Weight {
+        Weight::zero()
+    }
+}


### PR DESCRIPTION
Added empty migrations so that on-code storage version matches with the on-chain storage version for pallet-domains and pallet-messenger

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
