### PR TITLE
Temporarily disable XDM relayer due to Runtime memory constraints

### DIFF
--- a/domains/client/domain-operator/src/tests.rs
+++ b/domains/client/domain-operator/src/tests.rs
@@ -5346,6 +5346,7 @@ async fn existing_bundle_can_be_resubmitted_to_new_fork() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[ignore]
 async fn test_domain_sudo_calls() {
     let (_directory, mut ferdie, mut alice, account_infos) =
         setup_evm_test_accounts(Sr25519Alice, true, Sr25519Alice).await;
@@ -5763,6 +5764,7 @@ async fn test_public_evm_rejects_allow_list_domain_owner_calls() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[ignore]
 async fn test_xdm_between_consensus_and_domain_should_work() {
     let directory = TempDir::new().expect("Must be able to create temporary directory");
 
@@ -5921,6 +5923,7 @@ async fn test_xdm_between_consensus_and_domain_should_work() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[ignore]
 async fn test_xdm_between_domains_should_work() {
     let directory = TempDir::new().expect("Must be able to create temporary directory");
 
@@ -6044,6 +6047,7 @@ async fn test_xdm_between_domains_should_work() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[ignore]
 async fn test_unordered_cross_domains_message_should_work() {
     let directory = TempDir::new().expect("Must be able to create temporary directory");
 
@@ -7139,6 +7143,7 @@ async fn test_equivocated_bundle_check() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[ignore]
 async fn test_xdm_false_invalid_fraud_proof() {
     let directory = TempDir::new().expect("Must be able to create temporary directory");
 
@@ -7612,6 +7617,7 @@ async fn test_custom_api_storage_root_match_upstream_root() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[ignore]
 async fn test_xdm_channel_allowlist_removed_after_xdm_initiated() {
     let directory = TempDir::new().expect("Must be able to create temporary directory");
 
@@ -7689,6 +7695,7 @@ async fn test_xdm_channel_allowlist_removed_after_xdm_initiated() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[ignore]
 async fn test_xdm_channel_allowlist_removed_after_xdm_req_relaying() {
     let directory = TempDir::new().expect("Must be able to create temporary directory");
 
@@ -7795,6 +7802,7 @@ async fn test_xdm_channel_allowlist_removed_after_xdm_req_relaying() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[ignore]
 async fn test_xdm_channel_allowlist_removed_after_xdm_resp_relaying() {
     let directory = TempDir::new().expect("Must be able to create temporary directory");
 
@@ -7899,6 +7907,7 @@ async fn test_xdm_channel_allowlist_removed_after_xdm_resp_relaying() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[ignore]
 async fn test_xdm_transfer_below_existential_deposit() {
     let directory = TempDir::new().expect("Must be able to create temporary directory");
 
@@ -7974,6 +7983,7 @@ async fn test_xdm_transfer_below_existential_deposit() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[ignore]
 async fn test_xdm_transfer_to_wrong_format_address() {
     let directory = TempDir::new().expect("Must be able to create temporary directory");
 
@@ -8422,6 +8432,7 @@ async fn test_invalid_chain_reward_receipt() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[ignore]
 async fn test_domain_total_issuance_match_consensus_chain_bookkeeping_with_xdm() {
     let directory = TempDir::new().expect("Must be able to create temporary directory");
 

--- a/domains/service/src/domain.rs
+++ b/domains/service/src/domain.rs
@@ -516,18 +516,18 @@ where
     .await?;
 
     if is_authority {
-        let relayer_worker = domain_client_message_relayer::worker::start_relaying_messages(
-            domain_id,
-            consensus_client.clone(),
-            client.clone(),
-            confirmation_depth_k,
-            // domain relayer will use consensus chain sync oracle instead of domain sync oracle
-            // since domain sync oracle will always return `synced` due to force sync being set.
-            domain_sync_oracle.clone(),
-            gossip_message_sink.clone(),
-        );
-
-        spawn_essential.spawn_essential_blocking("domain-relayer", None, Box::pin(relayer_worker));
+        // let relayer_worker = domain_client_message_relayer::worker::start_relaying_messages(
+        //     domain_id,
+        //     consensus_client.clone(),
+        //     client.clone(),
+        //     confirmation_depth_k,
+        //     // domain relayer will use consensus chain sync oracle instead of domain sync oracle
+        //     // since domain sync oracle will always return `synced` due to force sync being set.
+        //     domain_sync_oracle.clone(),
+        //     gossip_message_sink.clone(),
+        // );
+        //
+        // spawn_essential.spawn_essential_blocking("domain-relayer", None, Box::pin(relayer_worker));
 
         let channel_update_worker =
             domain_client_message_relayer::worker::gossip_channel_updates::<_, _, CBlock, _>(


### PR DESCRIPTION
Seems like while Runtime allocation fails as we are fetching too many XDM from runtime. Until a fix is rolled out, temporily disabled Relayer

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
