### PR TITLE
Fix broken `pallet-domains` benchmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7982,6 +7982,7 @@ dependencies = [
  "log",
  "pallet-balances",
  "pallet-block-fees",
+ "pallet-subspace",
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",

--- a/crates/pallet-domains/Cargo.toml
+++ b/crates/pallet-domains/Cargo.toml
@@ -20,6 +20,7 @@ frame-system.workspace = true
 hexlit.workspace = true
 log.workspace = true
 pallet-balances.workspace = true
+pallet-subspace = { workspace = true, optional = true }
 scale-info = { workspace = true, features = ["derive"] }
 sp-consensus-slots.workspace = true
 sp-consensus-subspace.workspace = true
@@ -37,6 +38,7 @@ subspace-runtime-primitives.workspace = true
 [dev-dependencies]
 domain-pallet-executive.workspace = true
 hex-literal.workspace = true
+pallet-subspace.workspace = true
 pallet-timestamp.workspace = true
 pallet-block-fees.workspace = true
 sp-externalities.workspace = true
@@ -51,6 +53,7 @@ std = [
     "frame-system/std",
     "log/std",
     "pallet-balances/std",
+    "pallet-subspace/std",
     "scale-info/std",
     "sp-consensus-slots/std",
     "sp-consensus-subspace/std",
@@ -70,6 +73,7 @@ runtime-benchmarks = [
     "frame-system/runtime-benchmarks",
     "frame-benchmarking",
     "frame-benchmarking/runtime-benchmarks",
+    "pallet-subspace/runtime-benchmarks",
     "sp-domains/runtime-benchmarks",
     "sp-domains-fraud-proof/runtime-benchmarks",
     "sp-runtime/runtime-benchmarks",

--- a/crates/pallet-domains/src/benchmarking.rs
+++ b/crates/pallet-domains/src/benchmarking.rs
@@ -850,8 +850,8 @@ mod benchmarks {
     #[benchmark]
     fn transfer_treasury_funds() {
         // Ensure the treasury account has balance
-        let treasury_amount = 5000u32.into();
-        let transfer_amount = 500u32.into();
+        let transfer_amount = T::Currency::minimum_balance();
+        let treasury_amount = T::Currency::minimum_balance() + transfer_amount;
         let account = account("slashed_account", 1, SEED);
         assert_eq!(T::Currency::balance(&account), 0u32.into());
         T::Currency::set_balance(&T::TreasuryAccount::get(), treasury_amount);

--- a/crates/pallet-domains/src/benchmarking.rs
+++ b/crates/pallet-domains/src/benchmarking.rs
@@ -26,6 +26,7 @@ use frame_support::assert_ok;
 use frame_support::traits::fungible::{Inspect, Mutate};
 use frame_support::traits::Hooks;
 use frame_system::{Pallet as System, RawOrigin};
+use pallet_subspace::BlockRandomness;
 use sp_core::crypto::{Ss58Codec, UncheckedFrom};
 use sp_domains::{
     dummy_opaque_bundle, DomainId, ExecutionReceipt, OperatorAllowList, OperatorId,
@@ -35,11 +36,16 @@ use sp_domains::{
 use sp_domains_fraud_proof::fraud_proof::FraudProof;
 use sp_runtime::traits::{CheckedAdd, One, Zero};
 use sp_std::collections::btree_set::BTreeSet;
+use subspace_core_primitives::Randomness;
 
 const SEED: u32 = 0;
 const MAX_NOMINATORS_TO_SLASH_WITHOUT_OPERATOR: u32 = MAX_NOMINATORS_TO_SLASH - 1;
 
-#[benchmarks(where <RuntimeCallFor<T> as sp_runtime::traits::Dispatchable>::RuntimeOrigin: From<DomainOrigin>)]
+#[allow(clippy::multiple_bound_locations)]
+#[benchmarks(where
+    T: pallet_subspace::Config,
+    <RuntimeCallFor<T> as sp_runtime::traits::Dispatchable>::RuntimeOrigin: From<DomainOrigin>,
+)]
 mod benchmarks {
     use super::*;
     use sp_std::vec;
@@ -995,12 +1001,16 @@ mod benchmarks {
         (operator_account, operator_id)
     }
 
-    fn run_to_block<T: Config>(block_number: BlockNumberFor<T>, parent_hash: T::Hash) {
+    fn run_to_block<T: Config + pallet_subspace::Config>(
+        block_number: BlockNumberFor<T>,
+        parent_hash: T::Hash,
+    ) {
         if let Some(parent_block_number) = block_number.checked_sub(&One::one()) {
             Domains::<T>::on_finalize(parent_block_number);
         }
         System::<T>::set_block_number(block_number);
         System::<T>::initialize(&block_number, &parent_hash, &Default::default());
+        BlockRandomness::<T>::put(Randomness::default());
         Domains::<T>::on_initialize(block_number);
         System::<T>::finalize();
     }


### PR DESCRIPTION
This PR fixes the following broken `pallet-domains` benchmarks, while these benchmarks can pass the test (with a mock runtime), they are failing with the production runtime:
- `transfer_treasury_funds`
- `submit_bundle`
- `submit_fraud_proof`

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
