### PR TITLE
XDM Relayer: Optimized XDM processing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2850,6 +2850,7 @@ dependencies = [
  "cross-domain-message-gossip",
  "futures",
  "parity-scale-codec",
+ "rand 0.8.5",
  "sc-client-api",
  "sc-state-db",
  "sc-utils",

--- a/crates/subspace-fake-runtime-api/src/lib.rs
+++ b/crates/subspace-fake-runtime-api/src/lib.rs
@@ -16,7 +16,7 @@ use sp_domains::{
 use sp_domains_fraud_proof::fraud_proof::FraudProof;
 use sp_domains_fraud_proof::storage_proof::FraudProofStorageKeyRequest;
 use sp_messenger::messages::{
-    BlockMessagesQuery, BlockMessagesWithStorageKey, ChainId, ChannelId, ChannelState,
+    BlockMessagesQuery, BlockMessagesWithStorageKey, ChainId, ChannelId, ChannelStateWithNonce,
     CrossDomainMessage, MessageId, MessageKey, Nonce as XdmNonce,
 };
 use sp_messenger::{ChannelNonce, XdmId};
@@ -418,7 +418,7 @@ sp_api::impl_runtime_apis! {
             unreachable!()
         }
 
-        fn channels_and_state() -> Vec<(ChainId, ChannelId, ChannelState)> {
+        fn channels_and_state() -> Vec<(ChainId, ChannelId, ChannelStateWithNonce)> {
             unreachable!()
         }
 

--- a/crates/subspace-fake-runtime-api/src/lib.rs
+++ b/crates/subspace-fake-runtime-api/src/lib.rs
@@ -16,7 +16,8 @@ use sp_domains::{
 use sp_domains_fraud_proof::fraud_proof::FraudProof;
 use sp_domains_fraud_proof::storage_proof::FraudProofStorageKeyRequest;
 use sp_messenger::messages::{
-    BlockMessagesWithStorageKey, ChainId, ChannelId, CrossDomainMessage, MessageId, MessageKey,
+    BlockMessagesQuery, BlockMessagesWithStorageKey, ChainId, ChannelId, ChannelState,
+    CrossDomainMessage, MessageId, MessageKey,
 };
 use sp_messenger::{ChannelNonce, XdmId};
 use sp_runtime::traits::NumberFor;
@@ -410,6 +411,14 @@ sp_api::impl_runtime_apis! {
         }
 
         fn open_channels() -> BTreeSet<(ChainId, ChannelId)> {
+            unreachable!()
+        }
+
+        fn block_messages_with_query(_: BlockMessagesQuery) -> BlockMessagesWithStorageKey {
+            unreachable!()
+        }
+
+        fn channels_and_state() -> Vec<(ChainId, ChannelId, ChannelState)>{
             unreachable!()
         }
     }

--- a/crates/subspace-fake-runtime-api/src/lib.rs
+++ b/crates/subspace-fake-runtime-api/src/lib.rs
@@ -17,7 +17,7 @@ use sp_domains_fraud_proof::fraud_proof::FraudProof;
 use sp_domains_fraud_proof::storage_proof::FraudProofStorageKeyRequest;
 use sp_messenger::messages::{
     BlockMessagesQuery, BlockMessagesWithStorageKey, ChainId, ChannelId, ChannelState,
-    CrossDomainMessage, MessageId, MessageKey,
+    CrossDomainMessage, MessageId, MessageKey, Nonce as XdmNonce,
 };
 use sp_messenger::{ChannelNonce, XdmId};
 use sp_runtime::traits::NumberFor;
@@ -418,7 +418,15 @@ sp_api::impl_runtime_apis! {
             unreachable!()
         }
 
-        fn channels_and_state() -> Vec<(ChainId, ChannelId, ChannelState)>{
+        fn channels_and_state() -> Vec<(ChainId, ChannelId, ChannelState)> {
+            unreachable!()
+        }
+
+        fn should_relay_outbox_messages(_: ChainId, _: ChannelId, _: XdmNonce) -> Option<XdmNonce> {
+            unreachable!()
+        }
+
+        fn should_relay_inbox_message_responses(_: ChainId, _: ChannelId, _: XdmNonce) -> Option<XdmNonce> {
             unreachable!()
         }
     }

--- a/crates/subspace-fake-runtime-api/src/lib.rs
+++ b/crates/subspace-fake-runtime-api/src/lib.rs
@@ -17,7 +17,7 @@ use sp_domains_fraud_proof::fraud_proof::FraudProof;
 use sp_domains_fraud_proof::storage_proof::FraudProofStorageKeyRequest;
 use sp_messenger::messages::{
     BlockMessagesQuery, BlockMessagesWithStorageKey, ChainId, ChannelId, ChannelStateWithNonce,
-    CrossDomainMessage, MessageId, MessageKey, Nonce as XdmNonce,
+    CrossDomainMessage, MessageId, MessageKey, MessagesWithStorageKey, Nonce as XdmNonce,
 };
 use sp_messenger::{ChannelNonce, XdmId};
 use sp_runtime::traits::NumberFor;
@@ -414,7 +414,7 @@ sp_api::impl_runtime_apis! {
             unreachable!()
         }
 
-        fn block_messages_with_query(_: BlockMessagesQuery) -> BlockMessagesWithStorageKey {
+        fn block_messages_with_query(_: BlockMessagesQuery) -> MessagesWithStorageKey {
             unreachable!()
         }
 
@@ -422,11 +422,11 @@ sp_api::impl_runtime_apis! {
             unreachable!()
         }
 
-        fn should_relay_outbox_messages(_: ChainId, _: ChannelId, _: XdmNonce) -> Option<XdmNonce> {
+        fn first_outbox_message_nonce_to_relay(_: ChainId, _: ChannelId, _: XdmNonce) -> Option<XdmNonce> {
             unreachable!()
         }
 
-        fn should_relay_inbox_message_responses(_: ChainId, _: ChannelId, _: XdmNonce) -> Option<XdmNonce> {
+        fn first_inbox_message_response_nonce_to_relay(_: ChainId, _: ChannelId, _: XdmNonce) -> Option<XdmNonce> {
             unreachable!()
         }
     }

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -71,7 +71,8 @@ use sp_domains_fraud_proof::storage_proof::{
 };
 use sp_messenger::endpoint::{Endpoint, EndpointHandler as EndpointHandlerT, EndpointId};
 use sp_messenger::messages::{
-    BlockMessagesWithStorageKey, ChainId, CrossDomainMessage, MessageId, MessageKey,
+    BlockMessagesQuery, BlockMessagesWithStorageKey, ChainId, ChannelState, CrossDomainMessage,
+    MessageId, MessageKey,
 };
 use sp_messenger::{ChannelNonce, XdmId};
 use sp_messenger_host_functions::{get_storage_key, StorageKeyRequest};
@@ -1672,7 +1673,7 @@ impl_runtime_apis! {
 
     impl sp_messenger::RelayerApi<Block, BlockNumber, BlockNumber, BlockHashFor<Block>> for Runtime {
         fn block_messages() -> BlockMessagesWithStorageKey {
-            Messenger::get_block_messages()
+            BlockMessagesWithStorageKey::default()
         }
 
         fn outbox_message_unsigned(msg: CrossDomainMessage<NumberFor<Block>, BlockHashFor<Block>, BlockHashFor<Block>>) -> Option<ExtrinsicFor<Block>> {
@@ -1701,6 +1702,14 @@ impl_runtime_apis! {
 
         fn open_channels() -> BTreeSet<(ChainId, ChannelId)> {
             Messenger::open_channels()
+        }
+
+        fn block_messages_with_query(query: BlockMessagesQuery) -> BlockMessagesWithStorageKey {
+            Messenger::get_block_messages(query)
+        }
+
+        fn channels_and_state() -> Vec<(ChainId, ChannelId, ChannelState)>{
+            Messenger::channels_and_states()
         }
     }
 

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -71,8 +71,8 @@ use sp_domains_fraud_proof::storage_proof::{
 };
 use sp_messenger::endpoint::{Endpoint, EndpointHandler as EndpointHandlerT, EndpointId};
 use sp_messenger::messages::{
-    BlockMessagesQuery, BlockMessagesWithStorageKey, ChainId, ChannelState, CrossDomainMessage,
-    MessageId, MessageKey, Nonce as XdmNonce,
+    BlockMessagesQuery, BlockMessagesWithStorageKey, ChainId, ChannelStateWithNonce,
+    CrossDomainMessage, MessageId, MessageKey, Nonce as XdmNonce,
 };
 use sp_messenger::{ChannelNonce, XdmId};
 use sp_messenger_host_functions::{get_storage_key, StorageKeyRequest};
@@ -1708,7 +1708,7 @@ impl_runtime_apis! {
             Messenger::get_block_messages(query)
         }
 
-        fn channels_and_state() -> Vec<(ChainId, ChannelId, ChannelState)> {
+        fn channels_and_state() -> Vec<(ChainId, ChannelId, ChannelStateWithNonce)> {
             Messenger::channels_and_states()
         }
 

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -72,7 +72,7 @@ use sp_domains_fraud_proof::storage_proof::{
 use sp_messenger::endpoint::{Endpoint, EndpointHandler as EndpointHandlerT, EndpointId};
 use sp_messenger::messages::{
     BlockMessagesQuery, BlockMessagesWithStorageKey, ChainId, ChannelState, CrossDomainMessage,
-    MessageId, MessageKey,
+    MessageId, MessageKey, Nonce as XdmNonce,
 };
 use sp_messenger::{ChannelNonce, XdmId};
 use sp_messenger_host_functions::{get_storage_key, StorageKeyRequest};
@@ -1684,12 +1684,12 @@ impl_runtime_apis! {
             Messenger::inbox_response_message_unsigned(msg)
         }
 
-        fn should_relay_outbox_message(dst_chain_id: ChainId, msg_id: MessageId) -> bool {
-            Messenger::should_relay_outbox_message(dst_chain_id, msg_id)
+        fn should_relay_outbox_message(_: ChainId, _: MessageId) -> bool {
+            false
         }
 
-        fn should_relay_inbox_message_response(dst_chain_id: ChainId, msg_id: MessageId) -> bool {
-            Messenger::should_relay_inbox_message_response(dst_chain_id, msg_id)
+        fn should_relay_inbox_message_response(_: ChainId, _: MessageId) -> bool {
+            false
         }
 
         fn updated_channels() -> BTreeSet<(ChainId, ChannelId)> {
@@ -1708,8 +1708,16 @@ impl_runtime_apis! {
             Messenger::get_block_messages(query)
         }
 
-        fn channels_and_state() -> Vec<(ChainId, ChannelId, ChannelState)>{
+        fn channels_and_state() -> Vec<(ChainId, ChannelId, ChannelState)> {
             Messenger::channels_and_states()
+        }
+
+        fn should_relay_outbox_messages(dst_chain_id: ChainId, channel_id: ChannelId, from_nonce: XdmNonce) -> Option<XdmNonce> {
+            Messenger::should_relay_outbox_messages(dst_chain_id, channel_id, from_nonce)
+        }
+
+        fn should_relay_inbox_message_responses(dst_chain_id: ChainId, channel_id: ChannelId, from_nonce: XdmNonce) -> Option<XdmNonce> {
+            Messenger::should_relay_inbox_message_responses(dst_chain_id, channel_id, from_nonce)
         }
     }
 

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -72,7 +72,7 @@ use sp_domains_fraud_proof::storage_proof::{
 use sp_messenger::endpoint::{Endpoint, EndpointHandler as EndpointHandlerT, EndpointId};
 use sp_messenger::messages::{
     BlockMessagesQuery, BlockMessagesWithStorageKey, ChainId, ChannelStateWithNonce,
-    CrossDomainMessage, MessageId, MessageKey, Nonce as XdmNonce,
+    CrossDomainMessage, MessageId, MessageKey, MessagesWithStorageKey, Nonce as XdmNonce,
 };
 use sp_messenger::{ChannelNonce, XdmId};
 use sp_messenger_host_functions::{get_storage_key, StorageKeyRequest};
@@ -1704,7 +1704,7 @@ impl_runtime_apis! {
             Messenger::open_channels()
         }
 
-        fn block_messages_with_query(query: BlockMessagesQuery) -> BlockMessagesWithStorageKey {
+        fn block_messages_with_query(query: BlockMessagesQuery) -> MessagesWithStorageKey {
             Messenger::get_block_messages(query)
         }
 
@@ -1712,12 +1712,12 @@ impl_runtime_apis! {
             Messenger::channels_and_states()
         }
 
-        fn should_relay_outbox_messages(dst_chain_id: ChainId, channel_id: ChannelId, from_nonce: XdmNonce) -> Option<XdmNonce> {
-            Messenger::should_relay_outbox_messages(dst_chain_id, channel_id, from_nonce)
+        fn first_outbox_message_nonce_to_relay(dst_chain_id: ChainId, channel_id: ChannelId, from_nonce: XdmNonce) -> Option<XdmNonce> {
+            Messenger::first_outbox_message_nonce_to_relay(dst_chain_id, channel_id, from_nonce)
         }
 
-        fn should_relay_inbox_message_responses(dst_chain_id: ChainId, channel_id: ChannelId, from_nonce: XdmNonce) -> Option<XdmNonce> {
-            Messenger::should_relay_inbox_message_responses(dst_chain_id, channel_id, from_nonce)
+        fn first_inbox_message_response_nonce_to_relay(dst_chain_id: ChainId, channel_id: ChannelId, from_nonce: XdmNonce) -> Option<XdmNonce> {
+            Messenger::first_inbox_message_response_nonce_to_relay(dst_chain_id, channel_id, from_nonce)
         }
     }
 

--- a/domains/client/cross-domain-message-gossip/src/aux_schema.rs
+++ b/domains/client/cross-domain-message-gossip/src/aux_schema.rs
@@ -1,6 +1,5 @@
 //! Schema for channel update storage.
 
-use crate::RELAYER_PREFIX;
 use parity_scale_codec::{Decode, Encode};
 use sc_client_api::backend::AuxStore;
 use sp_blockchain::{Error as ClientError, Info, Result as ClientResult};
@@ -89,19 +88,6 @@ where
             channel_detail.encode().as_slice(),
         )],
         vec![],
-    )?;
-
-    let channel_nonce = ChannelNonce {
-        relay_msg_nonce: Some(channel_detail.next_inbox_nonce),
-        relay_response_msg_nonce: channel_detail.latest_response_received_message_nonce,
-    };
-    let prefix = (RELAYER_PREFIX, src_chain_id, self_chain_id).encode();
-    cleanup_chain_channel_storages(
-        backend,
-        &prefix,
-        src_chain_id,
-        channel_detail.channel_id,
-        channel_nonce,
     )
 }
 

--- a/domains/client/cross-domain-message-gossip/src/lib.rs
+++ b/domains/client/cross-domain-message-gossip/src/lib.rs
@@ -13,6 +13,4 @@ pub use gossip_worker::{
     xdm_gossip_peers_set_config, ChainMsg, ChainSink, ChannelUpdate, GossipWorker,
     GossipWorkerBuilder, Message, MessageData,
 };
-pub use message_listener::{
-    can_allow_xdm_submission, start_cross_chain_message_listener, RELAYER_PREFIX,
-};
+pub use message_listener::{can_allow_xdm_submission, start_cross_chain_message_listener};

--- a/domains/client/cross-domain-message-gossip/src/message_listener.rs
+++ b/domains/client/cross-domain-message-gossip/src/message_listener.rs
@@ -33,7 +33,6 @@ use thiserror::Error;
 
 pub(crate) const LOG_TARGET: &str = "domain_message_listener";
 const TX_POOL_PREFIX: &[u8] = b"xdm_tx_pool_listener";
-pub const RELAYER_PREFIX: &[u8] = b"xdm_relayer";
 
 /// Number of blocks an already submitted XDM is not accepted since last submission.
 const XDM_ACCEPT_BLOCK_LIMIT: u32 = 15;

--- a/domains/client/domain-operator/src/tests.rs
+++ b/domains/client/domain-operator/src/tests.rs
@@ -5346,7 +5346,6 @@ async fn existing_bundle_can_be_resubmitted_to_new_fork() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[ignore]
 async fn test_domain_sudo_calls() {
     let (_directory, mut ferdie, mut alice, account_infos) =
         setup_evm_test_accounts(Sr25519Alice, true, Sr25519Alice).await;
@@ -5764,7 +5763,6 @@ async fn test_public_evm_rejects_allow_list_domain_owner_calls() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[ignore]
 async fn test_xdm_between_consensus_and_domain_should_work() {
     let directory = TempDir::new().expect("Must be able to create temporary directory");
 
@@ -5923,7 +5921,6 @@ async fn test_xdm_between_consensus_and_domain_should_work() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[ignore]
 async fn test_xdm_between_domains_should_work() {
     let directory = TempDir::new().expect("Must be able to create temporary directory");
 
@@ -6047,7 +6044,6 @@ async fn test_xdm_between_domains_should_work() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[ignore]
 async fn test_unordered_cross_domains_message_should_work() {
     let directory = TempDir::new().expect("Must be able to create temporary directory");
 
@@ -7143,7 +7139,6 @@ async fn test_equivocated_bundle_check() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[ignore]
 async fn test_xdm_false_invalid_fraud_proof() {
     let directory = TempDir::new().expect("Must be able to create temporary directory");
 
@@ -7617,7 +7612,6 @@ async fn test_custom_api_storage_root_match_upstream_root() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[ignore]
 async fn test_xdm_channel_allowlist_removed_after_xdm_initiated() {
     let directory = TempDir::new().expect("Must be able to create temporary directory");
 
@@ -7695,7 +7689,6 @@ async fn test_xdm_channel_allowlist_removed_after_xdm_initiated() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[ignore]
 async fn test_xdm_channel_allowlist_removed_after_xdm_req_relaying() {
     let directory = TempDir::new().expect("Must be able to create temporary directory");
 
@@ -7802,7 +7795,6 @@ async fn test_xdm_channel_allowlist_removed_after_xdm_req_relaying() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[ignore]
 async fn test_xdm_channel_allowlist_removed_after_xdm_resp_relaying() {
     let directory = TempDir::new().expect("Must be able to create temporary directory");
 
@@ -7907,7 +7899,6 @@ async fn test_xdm_channel_allowlist_removed_after_xdm_resp_relaying() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[ignore]
 async fn test_xdm_transfer_below_existential_deposit() {
     let directory = TempDir::new().expect("Must be able to create temporary directory");
 
@@ -7983,7 +7974,6 @@ async fn test_xdm_transfer_below_existential_deposit() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[ignore]
 async fn test_xdm_transfer_to_wrong_format_address() {
     let directory = TempDir::new().expect("Must be able to create temporary directory");
 
@@ -8432,7 +8422,6 @@ async fn test_invalid_chain_reward_receipt() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[ignore]
 async fn test_domain_total_issuance_match_consensus_chain_bookkeeping_with_xdm() {
     let directory = TempDir::new().expect("Must be able to create temporary directory");
 

--- a/domains/client/relayer/Cargo.toml
+++ b/domains/client/relayer/Cargo.toml
@@ -16,6 +16,7 @@ async-channel.workspace = true
 cross-domain-message-gossip.workspace = true
 futures.workspace = true
 parity-scale-codec = { workspace = true, features = ["derive"] }
+rand.workspace = true
 sc-client-api.workspace = true
 sc-state-db.workspace = true
 sc-utils.workspace = true

--- a/domains/client/relayer/src/aux_schema.rs
+++ b/domains/client/relayer/src/aux_schema.rs
@@ -1,16 +1,32 @@
 //! Schema for processed channel data
 
+use crate::CHANNEL_PROCESSED_STATE_CACHE_LIMIT;
 use parity_scale_codec::{Decode, Encode};
 use sc_client_api::backend::AuxStore;
-use sp_blockchain::{Error as ClientError, Result as ClientResult};
-use sp_core::H256;
+use sp_blockchain::{Error as ClientError, HeaderBackend, Result as ClientResult};
 use sp_messenger::messages::{ChainId, ChannelId, Nonce};
-use subspace_runtime_primitives::BlockNumber;
+use sp_runtime::traits::{Block as BlockT, NumberFor};
+use sp_runtime::{SaturatedConversion, Saturating};
+use std::sync::Arc;
 
 const CHANNEL_PROCESSED_STATE: &[u8] = b"channel_processed_state";
+const OUTBOX_MESSAGES_PREFIX: &[u8] = b"outbox_messages";
+const INBOX_RESPONSE_MESSAGES_PREFIX: &[u8] = b"inbox_responses_messages";
 
-fn channel_processed_state_key(dst_chain_id: ChainId, channel_id: ChannelId) -> Vec<u8> {
-    (CHANNEL_PROCESSED_STATE, dst_chain_id, channel_id).encode()
+fn channel_processed_state_key(
+    prefix: &[u8],
+    src_chain_id: ChainId,
+    dst_chain_id: ChainId,
+    channel_id: ChannelId,
+) -> Vec<u8> {
+    (
+        CHANNEL_PROCESSED_STATE,
+        prefix,
+        src_chain_id,
+        dst_chain_id,
+        channel_id,
+    )
+        .encode()
 }
 
 fn load_decode<Backend: AuxStore, T: Decode>(
@@ -29,48 +45,210 @@ fn load_decode<Backend: AuxStore, T: Decode>(
 
 /// Channel processed state for given dst_chain and channel ID.
 #[derive(Debug, Encode, Decode, Clone)]
-pub struct ChannelProcessedState {
+pub struct ChannelProcessedState<Block: BlockT> {
     // Block number of chain at which the channel state is updated
-    pub block_number: BlockNumber,
+    pub block_number: NumberFor<Block>,
     /// Block hash of the chain at which the channel state is updated.
-    pub block_hash: H256,
+    pub block_hash: Block::Hash,
     /// Channel identifier.
     pub channel_id: ChannelId,
-    /// Last processed channel outbox nonce.
-    pub last_outbox_nonce: Nonce,
-    /// Last processed channel inbox message response nonce.
-    pub last_inbox_message_response_nonce: Nonce,
+    /// Last processed channel nonce.
+    pub nonce: Option<Nonce>,
 }
 
-/// Load the channel processed state
-pub fn get_channel_processed_state<Backend>(
+/// Load the channel outbox processed state
+fn get_channel_outbox_processed_state<Backend, Block: BlockT>(
     backend: &Backend,
+    src_chain_id: ChainId,
     dst_chain_id: ChainId,
     channel_id: ChannelId,
-) -> ClientResult<Option<ChannelProcessedState>>
+) -> ClientResult<Option<ChannelProcessedState<Block>>>
 where
     Backend: AuxStore,
 {
-    load_decode::<_, ChannelProcessedState>(
+    load_decode::<_, ChannelProcessedState<Block>>(
         backend,
-        channel_processed_state_key(dst_chain_id, channel_id).as_slice(),
+        channel_processed_state_key(
+            OUTBOX_MESSAGES_PREFIX,
+            src_chain_id,
+            dst_chain_id,
+            channel_id,
+        )
+        .as_slice(),
     )
 }
 
-/// Set the channel processed state
-pub fn set_channel_state<Backend>(
+/// Load the channel inbox response processed state
+fn get_channel_inbox_message_response_processed_state<Backend, Block: BlockT>(
     backend: &Backend,
+    src_chain_id: ChainId,
     dst_chain_id: ChainId,
-    channel_state: ChannelProcessedState,
+    channel_id: ChannelId,
+) -> ClientResult<Option<ChannelProcessedState<Block>>>
+where
+    Backend: AuxStore,
+{
+    load_decode::<_, ChannelProcessedState<Block>>(
+        backend,
+        channel_processed_state_key(
+            INBOX_RESPONSE_MESSAGES_PREFIX,
+            src_chain_id,
+            dst_chain_id,
+            channel_id,
+        )
+        .as_slice(),
+    )
+}
+
+/// Set the channel outbox processed state
+pub(crate) fn set_channel_outbox_processed_state<Backend, Block: BlockT>(
+    backend: &Backend,
+    src_chain_id: ChainId,
+    dst_chain_id: ChainId,
+    channel_state: ChannelProcessedState<Block>,
 ) -> ClientResult<()>
 where
     Backend: AuxStore,
 {
     backend.insert_aux(
         &[(
-            channel_processed_state_key(dst_chain_id, channel_state.channel_id).as_slice(),
+            channel_processed_state_key(
+                OUTBOX_MESSAGES_PREFIX,
+                src_chain_id,
+                dst_chain_id,
+                channel_state.channel_id,
+            )
+            .as_slice(),
             channel_state.encode().as_slice(),
         )],
         vec![],
     )
+}
+
+/// Set the channel inbox processed state
+pub(crate) fn set_channel_inbox_response_processed_state<Backend, Block: BlockT>(
+    backend: &Backend,
+    src_chain_id: ChainId,
+    dst_chain_id: ChainId,
+    channel_state: ChannelProcessedState<Block>,
+) -> ClientResult<()>
+where
+    Backend: AuxStore,
+{
+    backend.insert_aux(
+        &[(
+            channel_processed_state_key(
+                INBOX_RESPONSE_MESSAGES_PREFIX,
+                src_chain_id,
+                dst_chain_id,
+                channel_state.channel_id,
+            )
+            .as_slice(),
+            channel_state.encode().as_slice(),
+        )],
+        vec![],
+    )
+}
+
+/// Last processed nonce data.
+#[derive(Debug, Clone)]
+pub(crate) struct LastProcessedNonces {
+    pub outbox_nonce: Option<Nonce>,
+    pub inbox_response_nonce: Option<Nonce>,
+}
+
+/// Returns non expired last processed nonces.
+pub(crate) fn get_last_processed_nonces<Backend, Client, Block>(
+    backend: &Backend,
+    client: &Arc<Client>,
+    latest_hash: Block::Hash,
+    src_chain_id: ChainId,
+    dst_chain_id: ChainId,
+    channel_id: ChannelId,
+) -> ClientResult<LastProcessedNonces>
+where
+    Backend: AuxStore,
+    Block: BlockT,
+    Client: HeaderBackend<Block>,
+{
+    let last_processed_outbox_nonce = get_channel_outbox_processed_state::<_, Block>(
+        backend,
+        src_chain_id,
+        dst_chain_id,
+        channel_id,
+    )?
+    .and_then(|state| {
+        is_last_processed_nonce_valid(
+            client,
+            latest_hash,
+            state.block_number,
+            state.block_hash,
+            state.nonce,
+        )
+        .ok()
+        .flatten()
+    });
+
+    let last_processed_inbox_response_nonce = get_channel_inbox_message_response_processed_state::<
+        _,
+        Block,
+    >(
+        backend, src_chain_id, dst_chain_id, channel_id
+    )?
+    .and_then(|state| {
+        is_last_processed_nonce_valid(
+            client,
+            latest_hash,
+            state.block_number,
+            state.block_hash,
+            state.nonce,
+        )
+        .ok()
+        .flatten()
+    });
+
+    Ok(LastProcessedNonces {
+        outbox_nonce: last_processed_outbox_nonce,
+        inbox_response_nonce: last_processed_inbox_response_nonce,
+    })
+}
+
+fn is_last_processed_nonce_valid<Client, Block>(
+    client: &Arc<Client>,
+    latest_hash: Block::Hash,
+    processed_block_number: NumberFor<Block>,
+    processed_block_hash: Block::Hash,
+    last_process_nonce: Option<Nonce>,
+) -> ClientResult<Option<Nonce>>
+where
+    Block: BlockT,
+    Client: HeaderBackend<Block>,
+{
+    // short circuit if there is no last processed nonce
+    if last_process_nonce.is_none() {
+        return Ok(None);
+    }
+
+    // there is no block at this number, could be due to re-org
+    let Some(block_hash) = client.hash(processed_block_number)? else {
+        return Ok(None);
+    };
+
+    // hash mismatch could be due to re-org
+    if block_hash != processed_block_hash {
+        return Ok(None);
+    }
+
+    let Some(latest_number) = client.number(latest_hash)? else {
+        return Ok(None);
+    };
+
+    // if the cache limit is reached, return none
+    if latest_number.saturating_sub(processed_block_number)
+        > CHANNEL_PROCESSED_STATE_CACHE_LIMIT.saturated_into()
+    {
+        Ok(None)
+    } else {
+        Ok(last_process_nonce)
+    }
 }

--- a/domains/client/relayer/src/aux_schema.rs
+++ b/domains/client/relayer/src/aux_schema.rs
@@ -1,0 +1,76 @@
+//! Schema for processed channel data
+
+use parity_scale_codec::{Decode, Encode};
+use sc_client_api::backend::AuxStore;
+use sp_blockchain::{Error as ClientError, Result as ClientResult};
+use sp_core::H256;
+use sp_messenger::messages::{ChainId, ChannelId, Nonce};
+use subspace_runtime_primitives::BlockNumber;
+
+const CHANNEL_PROCESSED_STATE: &[u8] = b"channel_processed_state";
+
+fn channel_processed_state_key(dst_chain_id: ChainId, channel_id: ChannelId) -> Vec<u8> {
+    (CHANNEL_PROCESSED_STATE, dst_chain_id, channel_id).encode()
+}
+
+fn load_decode<Backend: AuxStore, T: Decode>(
+    backend: &Backend,
+    key: &[u8],
+) -> ClientResult<Option<T>> {
+    match backend.get_aux(key)? {
+        None => Ok(None),
+        Some(t) => T::decode(&mut &t[..])
+            .map_err(|e| {
+                ClientError::Backend(format!("Relayer DB is corrupted. Decode error: {e}"))
+            })
+            .map(Some),
+    }
+}
+
+/// Channel processed state for given dst_chain and channel ID.
+#[derive(Debug, Encode, Decode, Clone)]
+pub struct ChannelProcessedState {
+    // Block number of chain at which the channel state is updated
+    pub block_number: BlockNumber,
+    /// Block hash of the chain at which the channel state is updated.
+    pub block_hash: H256,
+    /// Channel identifier.
+    pub channel_id: ChannelId,
+    /// Last processed channel outbox nonce.
+    pub last_outbox_nonce: Nonce,
+    /// Last processed channel inbox message response nonce.
+    pub last_inbox_message_response_nonce: Nonce,
+}
+
+/// Load the channel processed state
+pub fn get_channel_processed_state<Backend>(
+    backend: &Backend,
+    dst_chain_id: ChainId,
+    channel_id: ChannelId,
+) -> ClientResult<Option<ChannelProcessedState>>
+where
+    Backend: AuxStore,
+{
+    load_decode::<_, ChannelProcessedState>(
+        backend,
+        channel_processed_state_key(dst_chain_id, channel_id).as_slice(),
+    )
+}
+
+/// Set the channel processed state
+pub fn set_channel_state<Backend>(
+    backend: &Backend,
+    dst_chain_id: ChainId,
+    channel_state: ChannelProcessedState,
+) -> ClientResult<()>
+where
+    Backend: AuxStore,
+{
+    backend.insert_aux(
+        &[(
+            channel_processed_state_key(dst_chain_id, channel_state.channel_id).as_slice(),
+            channel_state.encode().as_slice(),
+        )],
+        vec![],
+    )
+}

--- a/domains/pallets/messenger/src/lib.rs
+++ b/domains/pallets/messenger/src/lib.rs
@@ -1513,12 +1513,12 @@ where
     }
 
     /// Returns the first outbox message nonce that should be relayed to the dst_chain.
-    pub fn should_relay_outbox_messages(
+    pub fn first_outbox_message_nonce_to_relay(
         dst_chain_id: ChainId,
         channel_id: ChannelId,
         from_nonce: Nonce,
     ) -> Option<Nonce> {
-        Self::should_relay_message(
+        Self::first_relay_message(
             dst_chain_id,
             channel_id,
             from_nonce,
@@ -1527,12 +1527,12 @@ where
     }
 
     /// Returns the first inbox response message nonce that should be relayed to the dst_chain.
-    pub fn should_relay_inbox_message_responses(
+    pub fn first_inbox_message_response_nonce_to_relay(
         dst_chain_id: ChainId,
         channel_id: ChannelId,
         from_nonce: Nonce,
     ) -> Option<Nonce> {
-        Self::should_relay_message(
+        Self::first_relay_message(
             dst_chain_id,
             channel_id,
             from_nonce,
@@ -1540,7 +1540,7 @@ where
         )
     }
 
-    fn should_relay_message<Check>(
+    fn first_relay_message<Check>(
         dst_chain_id: ChainId,
         channel_id: ChannelId,
         from_nonce: Nonce,

--- a/domains/pallets/messenger/src/lib.rs
+++ b/domains/pallets/messenger/src/lib.rs
@@ -174,8 +174,9 @@ mod pallet {
         Endpoint, EndpointHandler, EndpointRequest, EndpointRequestWithCollectedFee, Sender,
     };
     use sp_messenger::messages::{
-        ChainId, ChannelOpenParamsV1, CrossDomainMessage, Message, MessageId, MessageKey,
-        MessageWeightTag, PayloadV1, ProtocolMessageRequest, RequestResponse, VersionedPayload,
+        ChainId, ChannelOpenParamsV1, ChannelStateWithNonce, CrossDomainMessage, Message,
+        MessageId, MessageKey, MessageWeightTag, PayloadV1, ProtocolMessageRequest,
+        RequestResponse, VersionedPayload,
     };
     use sp_messenger::{
         ChannelNonce, DomainRegistration, InherentError, InherentType, NoteChainTransfer,
@@ -1414,7 +1415,7 @@ mod pallet {
             Channels::<T>::iter_keys().collect()
         }
 
-        pub fn channels_and_states() -> Vec<(ChainId, ChannelId, ChannelState)> {
+        pub fn channels_and_states() -> Vec<(ChainId, ChannelId, ChannelStateWithNonce)> {
             crate::migrations::get_channels_and_states::<T>()
         }
 

--- a/domains/pallets/messenger/src/lib.rs
+++ b/domains/pallets/messenger/src/lib.rs
@@ -1410,7 +1410,11 @@ mod pallet {
         }
 
         pub fn open_channels() -> BTreeSet<(ChainId, ChannelId)> {
-            crate::migrations::get_open_channels::<T>()
+            Channels::<T>::iter_keys().collect()
+        }
+
+        pub fn channels_and_states() -> Vec<(ChainId, ChannelId, ChannelState)> {
+            crate::migrations::get_channels_and_states::<T>()
         }
 
         pub fn channel_nonce(chain_id: ChainId, channel_id: ChannelId) -> Option<ChannelNonce> {

--- a/domains/pallets/messenger/src/migrations.rs
+++ b/domains/pallets/messenger/src/migrations.rs
@@ -2,5 +2,5 @@ mod v0_to_v1;
 mod v1_to_v2;
 
 pub use v0_to_v1::VersionCheckedMigrateDomainsV0ToV1;
-pub(crate) use v1_to_v2::migrate_channels::{get_channel, get_open_channels};
+pub(crate) use v1_to_v2::migrate_channels::{get_channel, get_channels_and_states};
 pub use v1_to_v2::VersionCheckedMigrateDomainsV1ToV2;

--- a/domains/pallets/messenger/src/migrations/v1_to_v2.rs
+++ b/domains/pallets/messenger/src/migrations/v1_to_v2.rs
@@ -5,7 +5,7 @@ extern crate alloc;
 use crate::migrations::v1_to_v2::migrate_channels::migrate_channels;
 use crate::{BalanceOf, Channels as ChannelStorageV1, Config, Pallet};
 #[cfg(not(feature = "std"))]
-use alloc::collections::BTreeSet;
+use alloc::vec::Vec;
 use core::marker::PhantomData;
 use frame_support::migrations::VersionedMigration;
 use frame_support::pallet_prelude::{Decode, Encode, OptionQuery, TypeInfo};
@@ -14,8 +14,6 @@ use frame_support::weights::Weight;
 use frame_support::{storage_alias, Identity};
 use sp_domains::{ChainId, ChannelId};
 use sp_messenger::messages::{Channel as ChannelV1, ChannelState, Nonce};
-#[cfg(feature = "std")]
-use std::collections::BTreeSet;
 
 pub type VersionCheckedMigrateDomainsV1ToV2<T> = VersionedMigration<
     1,
@@ -91,6 +89,7 @@ pub(crate) mod migrate_channels {
         Channel<BalanceOf<T>, <T as frame_system::Config>::AccountId>,
         OptionQuery,
     >;
+
     pub(super) fn migrate_channels<T: Config>() -> Weight {
         let mut count = 0;
         Channels::<T>::drain().for_each(|(chain_id, channel_id, channel)| {
@@ -111,13 +110,12 @@ pub(crate) mod migrate_channels {
         })
     }
 
-    pub(crate) fn get_open_channels<T: Config>() -> BTreeSet<(ChainId, ChannelId)> {
-        let keys: BTreeSet<(ChainId, ChannelId)> = ChannelStorageV1::<T>::iter_keys().collect();
+    pub(crate) fn get_channels_and_states<T: Config>() -> Vec<(ChainId, ChannelId, ChannelState)> {
+        let keys: Vec<(ChainId, ChannelId)> = ChannelStorageV1::<T>::iter_keys().collect();
         keys.into_iter()
-            .filter(|(chain_id, channel_id)| {
-                get_channel::<T>(*chain_id, *channel_id)
-                    .map(|channel| channel.state != ChannelState::Closed)
-                    .unwrap_or_default()
+            .filter_map(|(chain_id, channel_id)| {
+                get_channel::<T>(chain_id, channel_id)
+                    .map(|channel| (chain_id, channel_id, channel.state))
             })
             .collect()
     }

--- a/domains/primitives/messenger/src/lib.rs
+++ b/domains/primitives/messenger/src/lib.rs
@@ -23,7 +23,7 @@ pub mod messages;
 #[cfg(not(feature = "std"))]
 extern crate alloc;
 
-use crate::messages::{ChannelStateWithNonce, MessageKey, Nonce};
+use crate::messages::{ChannelStateWithNonce, MessageKey, MessagesWithStorageKey, Nonce};
 #[cfg(not(feature = "std"))]
 use alloc::collections::BTreeMap;
 #[cfg(not(feature = "std"))]
@@ -306,16 +306,16 @@ sp_api::decl_runtime_apis! {
 
         /// Returns outbox and inbox responses from given nonce to maximum allowed nonce per block
         /// Storage key is used to generate the storage proof for the message.
-        fn block_messages_with_query(query: BlockMessagesQuery) -> BlockMessagesWithStorageKey;
+        fn block_messages_with_query(query: BlockMessagesQuery) -> MessagesWithStorageKey;
 
         /// Returns all the channels to other chains and their local Channel state.
         fn channels_and_state() -> Vec<(ChainId, ChannelId, ChannelStateWithNonce)>;
 
         /// Returns the first outbox message nonce that should be relayed to the dst_chain.
-        fn should_relay_outbox_messages(dst_chain_id: ChainId, channel_id: ChannelId, from_nonce: Nonce) -> Option<Nonce>;
+        fn first_outbox_message_nonce_to_relay(dst_chain_id: ChainId, channel_id: ChannelId, from_nonce: Nonce) -> Option<Nonce>;
 
         /// Returns the first inbox response message nonce that should be relayed to the dst_chain.
-        fn should_relay_inbox_message_responses(dst_chain_id: ChainId,channel_id: ChannelId, from_nonce: Nonce) -> Option<Nonce>;
+        fn first_inbox_message_response_nonce_to_relay(dst_chain_id: ChainId,channel_id: ChannelId, from_nonce: Nonce) -> Option<Nonce>;
     }
 
     /// Api to provide XDM extraction from Runtime Calls.

--- a/domains/primitives/messenger/src/lib.rs
+++ b/domains/primitives/messenger/src/lib.rs
@@ -23,7 +23,7 @@ pub mod messages;
 #[cfg(not(feature = "std"))]
 extern crate alloc;
 
-use crate::messages::{MessageKey, Nonce};
+use crate::messages::{ChannelState, MessageKey, Nonce};
 #[cfg(not(feature = "std"))]
 use alloc::collections::BTreeMap;
 #[cfg(not(feature = "std"))]
@@ -37,7 +37,9 @@ use frame_support::inherent::{InherentIdentifier, IsFatalError};
 use frame_support::storage::storage_prefix;
 #[cfg(feature = "runtime-benchmarks")]
 use frame_support::{Identity, StorageHasher};
-use messages::{BlockMessagesWithStorageKey, ChannelId, CrossDomainMessage, MessageId};
+use messages::{
+    BlockMessagesQuery, BlockMessagesWithStorageKey, ChannelId, CrossDomainMessage, MessageId,
+};
 use parity_scale_codec::{Decode, Encode};
 use scale_info::TypeInfo;
 use sp_domains::{ChainId, DomainAllowlistUpdates, DomainId};
@@ -266,7 +268,7 @@ pub struct ChannelNonce {
 
 sp_api::decl_runtime_apis! {
     /// Api useful for relayers to fetch messages and submit transactions.
-    #[api_version(2)]
+    #[api_version(3)]
     pub trait RelayerApi<BlockNumber, CNumber, CHash>
     where
         BlockNumber: Encode + Decode,
@@ -301,6 +303,13 @@ sp_api::decl_runtime_apis! {
 
         /// Returns all the open channels to other chains.
         fn open_channels() -> BTreeSet<(ChainId, ChannelId)>;
+
+        /// Returns outbox and inbox responses from given nonce to maximum allowed nonce per block
+        /// Storage key is used to generate the storage proof for the message.
+        fn block_messages_with_query(query: BlockMessagesQuery) -> BlockMessagesWithStorageKey;
+
+        /// Returns all the channels to other chains and their local Channel state.
+        fn channels_and_state() -> Vec<(ChainId, ChannelId, ChannelState)>;
     }
 
     /// Api to provide XDM extraction from Runtime Calls.

--- a/domains/primitives/messenger/src/lib.rs
+++ b/domains/primitives/messenger/src/lib.rs
@@ -23,7 +23,7 @@ pub mod messages;
 #[cfg(not(feature = "std"))]
 extern crate alloc;
 
-use crate::messages::{ChannelState, MessageKey, Nonce};
+use crate::messages::{ChannelStateWithNonce, MessageKey, Nonce};
 #[cfg(not(feature = "std"))]
 use alloc::collections::BTreeMap;
 #[cfg(not(feature = "std"))]
@@ -309,7 +309,7 @@ sp_api::decl_runtime_apis! {
         fn block_messages_with_query(query: BlockMessagesQuery) -> BlockMessagesWithStorageKey;
 
         /// Returns all the channels to other chains and their local Channel state.
-        fn channels_and_state() -> Vec<(ChainId, ChannelId, ChannelState)>;
+        fn channels_and_state() -> Vec<(ChainId, ChannelId, ChannelStateWithNonce)>;
 
         /// Returns the first outbox message nonce that should be relayed to the dst_chain.
         fn should_relay_outbox_messages(dst_chain_id: ChainId, channel_id: ChannelId, from_nonce: Nonce) -> Option<Nonce>;

--- a/domains/primitives/messenger/src/lib.rs
+++ b/domains/primitives/messenger/src/lib.rs
@@ -310,6 +310,12 @@ sp_api::decl_runtime_apis! {
 
         /// Returns all the channels to other chains and their local Channel state.
         fn channels_and_state() -> Vec<(ChainId, ChannelId, ChannelState)>;
+
+        /// Returns the first outbox message nonce that should be relayed to the dst_chain.
+        fn should_relay_outbox_messages(dst_chain_id: ChainId, channel_id: ChannelId, from_nonce: Nonce) -> Option<Nonce>;
+
+        /// Returns the first inbox response message nonce that should be relayed to the dst_chain.
+        fn should_relay_inbox_message_responses(dst_chain_id: ChainId,channel_id: ChannelId, from_nonce: Nonce) -> Option<Nonce>;
     }
 
     /// Api to provide XDM extraction from Runtime Calls.

--- a/domains/primitives/messenger/src/messages.rs
+++ b/domains/primitives/messenger/src/messages.rs
@@ -34,6 +34,21 @@ pub enum ChannelState {
     Closed,
 }
 
+/// State of channel and nonces when channel is closed.
+#[derive(Default, Debug, Encode, Decode, Clone, Eq, PartialEq, TypeInfo)]
+pub enum ChannelStateWithNonce {
+    /// Channel between chains is initiated but do not yet send or receive messages in this state.
+    #[default]
+    Initiated,
+    /// Channel is open and can send and receive messages.
+    Open,
+    /// Channel is closed along with nonces at current point.
+    Closed {
+        next_outbox_nonce: Nonce,
+        next_inbox_nonce: Nonce,
+    },
+}
+
 /// Channel describes a bridge to exchange messages between two chains.
 #[derive(Default, Debug, Encode, Decode, Clone, Eq, PartialEq, TypeInfo)]
 pub struct Channel<Balance, AccountId> {

--- a/domains/primitives/messenger/src/messages.rs
+++ b/domains/primitives/messenger/src/messages.rs
@@ -284,6 +284,24 @@ impl BlockMessagesWithStorageKey {
     }
 }
 
+/// Set of messages with storage keys to be relayed in a given block.
+#[derive(Default, Debug, Encode, Decode, TypeInfo, Clone, Eq, PartialEq)]
+pub struct MessagesWithStorageKey {
+    pub outbox: Vec<MessageNonceWithStorageKey>,
+    pub inbox_responses: Vec<MessageNonceWithStorageKey>,
+}
+
+/// Message with storage key to generate storage proof using the backend.
+#[derive(Debug, Encode, Decode, TypeInfo, Clone, Eq, PartialEq)]
+pub struct MessageNonceWithStorageKey {
+    /// Message nonce within the channel.
+    pub nonce: Nonce,
+    /// Storage key to generate proof for using proof backend.
+    pub storage_key: Vec<u8>,
+    /// The message weight tag
+    pub weight_tag: MessageWeightTag,
+}
+
 /// A query to fetch block messages for Outbox and Inbox Responses
 #[derive(Debug, Encode, Decode, TypeInfo, Clone, Eq, PartialEq)]
 pub struct BlockMessagesQuery {
@@ -295,16 +313,19 @@ pub struct BlockMessagesQuery {
 
 impl<BlockNumber, BlockHash, MmrHash> CrossDomainMessage<BlockNumber, BlockHash, MmrHash> {
     pub fn from_relayer_msg_with_proof(
-        r_msg: BlockMessageWithStorageKey,
+        src_chain_id: ChainId,
+        dst_chain_id: ChainId,
+        channel_id: ChannelId,
+        msg: MessageNonceWithStorageKey,
         proof: Proof<BlockNumber, BlockHash, MmrHash>,
     ) -> Self {
         CrossDomainMessage {
-            src_chain_id: r_msg.src_chain_id,
-            dst_chain_id: r_msg.dst_chain_id,
-            channel_id: r_msg.channel_id,
-            nonce: r_msg.nonce,
+            src_chain_id,
+            dst_chain_id,
+            channel_id,
+            nonce: msg.nonce,
             proof,
-            weight_tag: r_msg.weight_tag,
+            weight_tag: msg.weight_tag,
         }
     }
 }

--- a/domains/primitives/messenger/src/messages.rs
+++ b/domains/primitives/messenger/src/messages.rs
@@ -269,6 +269,15 @@ impl BlockMessagesWithStorageKey {
     }
 }
 
+/// A query to fetch block messages for Outbox and Inbox Responses
+#[derive(Debug, Encode, Decode, TypeInfo, Clone, Eq, PartialEq)]
+pub struct BlockMessagesQuery {
+    pub chain_id: ChainId,
+    pub channel_id: ChannelId,
+    pub outbox_from: Nonce,
+    pub inbox_responses_from: Nonce,
+}
+
 impl<BlockNumber, BlockHash, MmrHash> CrossDomainMessage<BlockNumber, BlockHash, MmrHash> {
     pub fn from_relayer_msg_with_proof(
         r_msg: BlockMessageWithStorageKey,

--- a/domains/runtime/auto-id/src/lib.rs
+++ b/domains/runtime/auto-id/src/lib.rs
@@ -43,7 +43,7 @@ use sp_domains::{ChannelId, DomainAllowlistUpdates, DomainId, Transfers};
 use sp_messenger::endpoint::{Endpoint, EndpointHandler as EndpointHandlerT, EndpointId};
 use sp_messenger::messages::{
     BlockMessagesQuery, BlockMessagesWithStorageKey, ChainId, ChannelState, CrossDomainMessage,
-    MessageId, MessageKey,
+    MessageId, MessageKey, Nonce as XdmNonce,
 };
 use sp_messenger::{ChannelNonce, XdmId};
 use sp_messenger_host_functions::{get_storage_key, StorageKeyRequest};
@@ -1126,12 +1126,12 @@ impl_runtime_apis! {
             Messenger::inbox_response_message_unsigned(msg)
         }
 
-        fn should_relay_outbox_message(dst_chain_id: ChainId, msg_id: MessageId) -> bool {
-            Messenger::should_relay_outbox_message(dst_chain_id, msg_id)
+        fn should_relay_outbox_message(_: ChainId, _: MessageId) -> bool {
+            false
         }
 
-        fn should_relay_inbox_message_response(dst_chain_id: ChainId, msg_id: MessageId) -> bool {
-            Messenger::should_relay_inbox_message_response(dst_chain_id, msg_id)
+        fn should_relay_inbox_message_response(_: ChainId, _: MessageId) -> bool {
+            false
         }
 
         fn updated_channels() -> BTreeSet<(ChainId, ChannelId)> {
@@ -1150,8 +1150,16 @@ impl_runtime_apis! {
             Messenger::get_block_messages(query)
         }
 
-        fn channels_and_state() -> Vec<(ChainId, ChannelId, ChannelState)>{
+        fn channels_and_state() -> Vec<(ChainId, ChannelId, ChannelState)> {
             Messenger::channels_and_states()
+        }
+
+        fn should_relay_outbox_messages(dst_chain_id: ChainId, channel_id: ChannelId, from_nonce: XdmNonce) -> Option<XdmNonce> {
+            Messenger::should_relay_outbox_messages(dst_chain_id, channel_id, from_nonce)
+        }
+
+        fn should_relay_inbox_message_responses(dst_chain_id: ChainId, channel_id: ChannelId, from_nonce: XdmNonce) -> Option<XdmNonce> {
+            Messenger::should_relay_inbox_message_responses(dst_chain_id, channel_id, from_nonce)
         }
     }
 

--- a/domains/runtime/auto-id/src/lib.rs
+++ b/domains/runtime/auto-id/src/lib.rs
@@ -42,7 +42,8 @@ use sp_core::{Get, OpaqueMetadata};
 use sp_domains::{ChannelId, DomainAllowlistUpdates, DomainId, Transfers};
 use sp_messenger::endpoint::{Endpoint, EndpointHandler as EndpointHandlerT, EndpointId};
 use sp_messenger::messages::{
-    BlockMessagesWithStorageKey, ChainId, CrossDomainMessage, MessageId, MessageKey,
+    BlockMessagesQuery, BlockMessagesWithStorageKey, ChainId, ChannelState, CrossDomainMessage,
+    MessageId, MessageKey,
 };
 use sp_messenger::{ChannelNonce, XdmId};
 use sp_messenger_host_functions::{get_storage_key, StorageKeyRequest};
@@ -1114,7 +1115,7 @@ impl_runtime_apis! {
 
     impl sp_messenger::RelayerApi<Block, BlockNumber, ConsensusBlockNumber, ConsensusBlockHash> for Runtime {
         fn block_messages() -> BlockMessagesWithStorageKey {
-            Messenger::get_block_messages()
+            BlockMessagesWithStorageKey::default()
         }
 
         fn outbox_message_unsigned(msg: CrossDomainMessage<NumberFor<Block>, BlockHashFor<Block>, BlockHashFor<Block>>) -> Option<ExtrinsicFor<Block>> {
@@ -1143,6 +1144,14 @@ impl_runtime_apis! {
 
         fn open_channels() -> BTreeSet<(ChainId, ChannelId)> {
             Messenger::open_channels()
+        }
+
+        fn block_messages_with_query(query: BlockMessagesQuery) -> BlockMessagesWithStorageKey {
+            Messenger::get_block_messages(query)
+        }
+
+        fn channels_and_state() -> Vec<(ChainId, ChannelId, ChannelState)>{
+            Messenger::channels_and_states()
         }
     }
 

--- a/domains/runtime/auto-id/src/lib.rs
+++ b/domains/runtime/auto-id/src/lib.rs
@@ -43,7 +43,7 @@ use sp_domains::{ChannelId, DomainAllowlistUpdates, DomainId, Transfers};
 use sp_messenger::endpoint::{Endpoint, EndpointHandler as EndpointHandlerT, EndpointId};
 use sp_messenger::messages::{
     BlockMessagesQuery, BlockMessagesWithStorageKey, ChainId, ChannelStateWithNonce,
-    CrossDomainMessage, MessageId, MessageKey, Nonce as XdmNonce,
+    CrossDomainMessage, MessageId, MessageKey, MessagesWithStorageKey, Nonce as XdmNonce,
 };
 use sp_messenger::{ChannelNonce, XdmId};
 use sp_messenger_host_functions::{get_storage_key, StorageKeyRequest};
@@ -1146,7 +1146,7 @@ impl_runtime_apis! {
             Messenger::open_channels()
         }
 
-        fn block_messages_with_query(query: BlockMessagesQuery) -> BlockMessagesWithStorageKey {
+        fn block_messages_with_query(query: BlockMessagesQuery) -> MessagesWithStorageKey {
             Messenger::get_block_messages(query)
         }
 
@@ -1154,12 +1154,12 @@ impl_runtime_apis! {
             Messenger::channels_and_states()
         }
 
-        fn should_relay_outbox_messages(dst_chain_id: ChainId, channel_id: ChannelId, from_nonce: XdmNonce) -> Option<XdmNonce> {
-            Messenger::should_relay_outbox_messages(dst_chain_id, channel_id, from_nonce)
+        fn first_outbox_message_nonce_to_relay(dst_chain_id: ChainId, channel_id: ChannelId, from_nonce: XdmNonce) -> Option<XdmNonce> {
+            Messenger::first_outbox_message_nonce_to_relay(dst_chain_id, channel_id, from_nonce)
         }
 
-        fn should_relay_inbox_message_responses(dst_chain_id: ChainId, channel_id: ChannelId, from_nonce: XdmNonce) -> Option<XdmNonce> {
-            Messenger::should_relay_inbox_message_responses(dst_chain_id, channel_id, from_nonce)
+        fn first_inbox_message_response_nonce_to_relay(dst_chain_id: ChainId, channel_id: ChannelId, from_nonce: XdmNonce) -> Option<XdmNonce> {
+            Messenger::first_inbox_message_response_nonce_to_relay(dst_chain_id, channel_id, from_nonce)
         }
     }
 

--- a/domains/runtime/auto-id/src/lib.rs
+++ b/domains/runtime/auto-id/src/lib.rs
@@ -42,8 +42,8 @@ use sp_core::{Get, OpaqueMetadata};
 use sp_domains::{ChannelId, DomainAllowlistUpdates, DomainId, Transfers};
 use sp_messenger::endpoint::{Endpoint, EndpointHandler as EndpointHandlerT, EndpointId};
 use sp_messenger::messages::{
-    BlockMessagesQuery, BlockMessagesWithStorageKey, ChainId, ChannelState, CrossDomainMessage,
-    MessageId, MessageKey, Nonce as XdmNonce,
+    BlockMessagesQuery, BlockMessagesWithStorageKey, ChainId, ChannelStateWithNonce,
+    CrossDomainMessage, MessageId, MessageKey, Nonce as XdmNonce,
 };
 use sp_messenger::{ChannelNonce, XdmId};
 use sp_messenger_host_functions::{get_storage_key, StorageKeyRequest};
@@ -1150,7 +1150,7 @@ impl_runtime_apis! {
             Messenger::get_block_messages(query)
         }
 
-        fn channels_and_state() -> Vec<(ChainId, ChannelId, ChannelState)> {
+        fn channels_and_state() -> Vec<(ChainId, ChannelId, ChannelStateWithNonce)> {
             Messenger::channels_and_states()
         }
 

--- a/domains/runtime/evm/src/lib.rs
+++ b/domains/runtime/evm/src/lib.rs
@@ -64,8 +64,8 @@ use sp_evm_tracker::{
 };
 use sp_messenger::endpoint::{Endpoint, EndpointHandler as EndpointHandlerT, EndpointId};
 use sp_messenger::messages::{
-    BlockMessagesQuery, BlockMessagesWithStorageKey, ChainId, ChannelState, CrossDomainMessage,
-    MessageId, MessageKey, Nonce as XdmNonce,
+    BlockMessagesQuery, BlockMessagesWithStorageKey, ChainId, ChannelStateWithNonce,
+    CrossDomainMessage, MessageId, MessageKey, Nonce as XdmNonce,
 };
 use sp_messenger::{ChannelNonce, XdmId};
 use sp_messenger_host_functions::{get_storage_key, StorageKeyRequest};
@@ -1579,7 +1579,7 @@ impl_runtime_apis! {
             Messenger::get_block_messages(query)
         }
 
-        fn channels_and_state() -> Vec<(ChainId, ChannelId, ChannelState)> {
+        fn channels_and_state() -> Vec<(ChainId, ChannelId, ChannelStateWithNonce)> {
             Messenger::channels_and_states()
         }
 

--- a/domains/runtime/evm/src/lib.rs
+++ b/domains/runtime/evm/src/lib.rs
@@ -65,7 +65,7 @@ use sp_evm_tracker::{
 use sp_messenger::endpoint::{Endpoint, EndpointHandler as EndpointHandlerT, EndpointId};
 use sp_messenger::messages::{
     BlockMessagesQuery, BlockMessagesWithStorageKey, ChainId, ChannelStateWithNonce,
-    CrossDomainMessage, MessageId, MessageKey, Nonce as XdmNonce,
+    CrossDomainMessage, MessageId, MessageKey, MessagesWithStorageKey, Nonce as XdmNonce,
 };
 use sp_messenger::{ChannelNonce, XdmId};
 use sp_messenger_host_functions::{get_storage_key, StorageKeyRequest};
@@ -1575,7 +1575,7 @@ impl_runtime_apis! {
             Messenger::open_channels()
         }
 
-        fn block_messages_with_query(query: BlockMessagesQuery) -> BlockMessagesWithStorageKey {
+        fn block_messages_with_query(query: BlockMessagesQuery) -> MessagesWithStorageKey {
             Messenger::get_block_messages(query)
         }
 
@@ -1583,12 +1583,12 @@ impl_runtime_apis! {
             Messenger::channels_and_states()
         }
 
-        fn should_relay_outbox_messages(dst_chain_id: ChainId, channel_id: ChannelId, from_nonce: XdmNonce) -> Option<XdmNonce> {
-            Messenger::should_relay_outbox_messages(dst_chain_id, channel_id, from_nonce)
+        fn first_outbox_message_nonce_to_relay(dst_chain_id: ChainId, channel_id: ChannelId, from_nonce: XdmNonce) -> Option<XdmNonce> {
+            Messenger::first_outbox_message_nonce_to_relay(dst_chain_id, channel_id, from_nonce)
         }
 
-        fn should_relay_inbox_message_responses(dst_chain_id: ChainId, channel_id: ChannelId, from_nonce: XdmNonce) -> Option<XdmNonce> {
-            Messenger::should_relay_inbox_message_responses(dst_chain_id, channel_id, from_nonce)
+        fn first_inbox_message_response_nonce_to_relay(dst_chain_id: ChainId, channel_id: ChannelId, from_nonce: XdmNonce) -> Option<XdmNonce> {
+            Messenger::first_inbox_message_response_nonce_to_relay(dst_chain_id, channel_id, from_nonce)
         }
     }
 

--- a/domains/runtime/evm/src/lib.rs
+++ b/domains/runtime/evm/src/lib.rs
@@ -65,7 +65,7 @@ use sp_evm_tracker::{
 use sp_messenger::endpoint::{Endpoint, EndpointHandler as EndpointHandlerT, EndpointId};
 use sp_messenger::messages::{
     BlockMessagesQuery, BlockMessagesWithStorageKey, ChainId, ChannelState, CrossDomainMessage,
-    MessageId, MessageKey,
+    MessageId, MessageKey, Nonce as XdmNonce,
 };
 use sp_messenger::{ChannelNonce, XdmId};
 use sp_messenger_host_functions::{get_storage_key, StorageKeyRequest};
@@ -1555,12 +1555,12 @@ impl_runtime_apis! {
             Messenger::inbox_response_message_unsigned(msg)
         }
 
-        fn should_relay_outbox_message(dst_chain_id: ChainId, msg_id: MessageId) -> bool {
-            Messenger::should_relay_outbox_message(dst_chain_id, msg_id)
+        fn should_relay_outbox_message(_: ChainId, _: MessageId) -> bool {
+            false
         }
 
-        fn should_relay_inbox_message_response(dst_chain_id: ChainId, msg_id: MessageId) -> bool {
-            Messenger::should_relay_inbox_message_response(dst_chain_id, msg_id)
+        fn should_relay_inbox_message_response(_: ChainId, _: MessageId) -> bool {
+            false
         }
 
         fn updated_channels() -> BTreeSet<(ChainId, ChannelId)> {
@@ -1579,8 +1579,16 @@ impl_runtime_apis! {
             Messenger::get_block_messages(query)
         }
 
-        fn channels_and_state() -> Vec<(ChainId, ChannelId, ChannelState)>{
+        fn channels_and_state() -> Vec<(ChainId, ChannelId, ChannelState)> {
             Messenger::channels_and_states()
+        }
+
+        fn should_relay_outbox_messages(dst_chain_id: ChainId, channel_id: ChannelId, from_nonce: XdmNonce) -> Option<XdmNonce> {
+            Messenger::should_relay_outbox_messages(dst_chain_id, channel_id, from_nonce)
+        }
+
+        fn should_relay_inbox_message_responses(dst_chain_id: ChainId, channel_id: ChannelId, from_nonce: XdmNonce) -> Option<XdmNonce> {
+            Messenger::should_relay_inbox_message_responses(dst_chain_id, channel_id, from_nonce)
         }
     }
 

--- a/domains/runtime/evm/src/lib.rs
+++ b/domains/runtime/evm/src/lib.rs
@@ -64,7 +64,8 @@ use sp_evm_tracker::{
 };
 use sp_messenger::endpoint::{Endpoint, EndpointHandler as EndpointHandlerT, EndpointId};
 use sp_messenger::messages::{
-    BlockMessagesWithStorageKey, ChainId, CrossDomainMessage, MessageId, MessageKey,
+    BlockMessagesQuery, BlockMessagesWithStorageKey, ChainId, ChannelState, CrossDomainMessage,
+    MessageId, MessageKey,
 };
 use sp_messenger::{ChannelNonce, XdmId};
 use sp_messenger_host_functions::{get_storage_key, StorageKeyRequest};
@@ -1543,7 +1544,7 @@ impl_runtime_apis! {
 
     impl sp_messenger::RelayerApi<Block, BlockNumber, ConsensusBlockNumber, ConsensusBlockHash> for Runtime {
         fn block_messages() -> BlockMessagesWithStorageKey {
-            Messenger::get_block_messages()
+            BlockMessagesWithStorageKey::default()
         }
 
         fn outbox_message_unsigned(msg: CrossDomainMessage<NumberFor<Block>, BlockHashFor<Block>, BlockHashFor<Block>>) -> Option<ExtrinsicFor<Block>> {
@@ -1572,6 +1573,14 @@ impl_runtime_apis! {
 
         fn open_channels() -> BTreeSet<(ChainId, ChannelId)> {
             Messenger::open_channels()
+        }
+
+        fn block_messages_with_query(query: BlockMessagesQuery) -> BlockMessagesWithStorageKey {
+            Messenger::get_block_messages(query)
+        }
+
+        fn channels_and_state() -> Vec<(ChainId, ChannelId, ChannelState)>{
+            Messenger::channels_and_states()
         }
     }
 

--- a/domains/service/src/domain.rs
+++ b/domains/service/src/domain.rs
@@ -516,18 +516,18 @@ where
     .await?;
 
     if is_authority {
-        // let relayer_worker = domain_client_message_relayer::worker::start_relaying_messages(
-        //     domain_id,
-        //     consensus_client.clone(),
-        //     client.clone(),
-        //     confirmation_depth_k,
-        //     // domain relayer will use consensus chain sync oracle instead of domain sync oracle
-        //     // since domain sync oracle will always return `synced` due to force sync being set.
-        //     domain_sync_oracle.clone(),
-        //     gossip_message_sink.clone(),
-        // );
-        //
-        // spawn_essential.spawn_essential_blocking("domain-relayer", None, Box::pin(relayer_worker));
+        let relayer_worker = domain_client_message_relayer::worker::start_relaying_messages(
+            domain_id,
+            consensus_client.clone(),
+            client.clone(),
+            confirmation_depth_k,
+            // domain relayer will use consensus chain sync oracle instead of domain sync oracle
+            // since domain sync oracle will always return `synced` due to force sync being set.
+            domain_sync_oracle.clone(),
+            gossip_message_sink.clone(),
+        );
+
+        spawn_essential.spawn_essential_blocking("domain-relayer", None, Box::pin(relayer_worker));
 
         let channel_update_worker =
             domain_client_message_relayer::worker::gossip_channel_updates::<_, _, CBlock, _>(

--- a/domains/test/runtime/auto-id/src/lib.rs
+++ b/domains/test/runtime/auto-id/src/lib.rs
@@ -43,7 +43,7 @@ use sp_domains::{ChannelId, DomainAllowlistUpdates, DomainId, Transfers};
 use sp_messenger::endpoint::{Endpoint, EndpointHandler as EndpointHandlerT, EndpointId};
 use sp_messenger::messages::{
     BlockMessagesQuery, BlockMessagesWithStorageKey, ChainId, ChannelStateWithNonce,
-    CrossDomainMessage, MessageId, MessageKey, Nonce as XdmNonce,
+    CrossDomainMessage, MessageId, MessageKey, MessagesWithStorageKey, Nonce as XdmNonce,
 };
 use sp_messenger::{ChannelNonce, XdmId};
 use sp_messenger_host_functions::{get_storage_key, StorageKeyRequest};
@@ -1142,7 +1142,7 @@ impl_runtime_apis! {
             Messenger::open_channels()
         }
 
-        fn block_messages_with_query(query: BlockMessagesQuery) -> BlockMessagesWithStorageKey {
+        fn block_messages_with_query(query: BlockMessagesQuery) -> MessagesWithStorageKey {
             Messenger::get_block_messages(query)
         }
 
@@ -1150,12 +1150,12 @@ impl_runtime_apis! {
             Messenger::channels_and_states()
         }
 
-        fn should_relay_outbox_messages(dst_chain_id: ChainId, channel_id: ChannelId, from_nonce: XdmNonce) -> Option<XdmNonce> {
-            Messenger::should_relay_outbox_messages(dst_chain_id, channel_id, from_nonce)
+        fn first_outbox_message_nonce_to_relay(dst_chain_id: ChainId, channel_id: ChannelId, from_nonce: XdmNonce) -> Option<XdmNonce> {
+            Messenger::first_outbox_message_nonce_to_relay(dst_chain_id, channel_id, from_nonce)
         }
 
-        fn should_relay_inbox_message_responses(dst_chain_id: ChainId, channel_id: ChannelId, from_nonce: XdmNonce) -> Option<XdmNonce> {
-            Messenger::should_relay_inbox_message_responses(dst_chain_id, channel_id, from_nonce)
+        fn first_inbox_message_response_nonce_to_relay(dst_chain_id: ChainId, channel_id: ChannelId, from_nonce: XdmNonce) -> Option<XdmNonce> {
+            Messenger::first_inbox_message_response_nonce_to_relay(dst_chain_id, channel_id, from_nonce)
         }
     }
 

--- a/domains/test/runtime/auto-id/src/lib.rs
+++ b/domains/test/runtime/auto-id/src/lib.rs
@@ -43,7 +43,7 @@ use sp_domains::{ChannelId, DomainAllowlistUpdates, DomainId, Transfers};
 use sp_messenger::endpoint::{Endpoint, EndpointHandler as EndpointHandlerT, EndpointId};
 use sp_messenger::messages::{
     BlockMessagesQuery, BlockMessagesWithStorageKey, ChainId, ChannelState, CrossDomainMessage,
-    MessageId, MessageKey,
+    MessageId, MessageKey, Nonce as XdmNonce,
 };
 use sp_messenger::{ChannelNonce, XdmId};
 use sp_messenger_host_functions::{get_storage_key, StorageKeyRequest};
@@ -1122,12 +1122,12 @@ impl_runtime_apis! {
             Messenger::inbox_response_message_unsigned(msg)
         }
 
-        fn should_relay_outbox_message(dst_chain_id: ChainId, msg_id: MessageId) -> bool {
-            Messenger::should_relay_outbox_message(dst_chain_id, msg_id)
+        fn should_relay_outbox_message(_: ChainId, _: MessageId) -> bool {
+            false
         }
 
-        fn should_relay_inbox_message_response(dst_chain_id: ChainId, msg_id: MessageId) -> bool {
-            Messenger::should_relay_inbox_message_response(dst_chain_id, msg_id)
+        fn should_relay_inbox_message_response(_: ChainId, _: MessageId) -> bool {
+            false
         }
 
         fn updated_channels() -> BTreeSet<(ChainId, ChannelId)> {
@@ -1146,8 +1146,16 @@ impl_runtime_apis! {
             Messenger::get_block_messages(query)
         }
 
-        fn channels_and_state() -> Vec<(ChainId, ChannelId, ChannelState)>{
+        fn channels_and_state() -> Vec<(ChainId, ChannelId, ChannelState)> {
             Messenger::channels_and_states()
+        }
+
+        fn should_relay_outbox_messages(dst_chain_id: ChainId, channel_id: ChannelId, from_nonce: XdmNonce) -> Option<XdmNonce> {
+            Messenger::should_relay_outbox_messages(dst_chain_id, channel_id, from_nonce)
+        }
+
+        fn should_relay_inbox_message_responses(dst_chain_id: ChainId, channel_id: ChannelId, from_nonce: XdmNonce) -> Option<XdmNonce> {
+            Messenger::should_relay_inbox_message_responses(dst_chain_id, channel_id, from_nonce)
         }
     }
 

--- a/domains/test/runtime/auto-id/src/lib.rs
+++ b/domains/test/runtime/auto-id/src/lib.rs
@@ -42,7 +42,8 @@ use sp_core::{Get, OpaqueMetadata};
 use sp_domains::{ChannelId, DomainAllowlistUpdates, DomainId, Transfers};
 use sp_messenger::endpoint::{Endpoint, EndpointHandler as EndpointHandlerT, EndpointId};
 use sp_messenger::messages::{
-    BlockMessagesWithStorageKey, ChainId, CrossDomainMessage, MessageId, MessageKey,
+    BlockMessagesQuery, BlockMessagesWithStorageKey, ChainId, ChannelState, CrossDomainMessage,
+    MessageId, MessageKey,
 };
 use sp_messenger::{ChannelNonce, XdmId};
 use sp_messenger_host_functions::{get_storage_key, StorageKeyRequest};
@@ -1110,7 +1111,7 @@ impl_runtime_apis! {
 
     impl sp_messenger::RelayerApi<Block, BlockNumber, ConsensusBlockNumber, ConsensusBlockHash> for Runtime {
         fn block_messages() -> BlockMessagesWithStorageKey {
-            Messenger::get_block_messages()
+            BlockMessagesWithStorageKey::default()
         }
 
         fn outbox_message_unsigned(msg: CrossDomainMessage<NumberFor<Block>, BlockHashFor<Block>, BlockHashFor<Block>>) -> Option<ExtrinsicFor<Block>> {
@@ -1139,6 +1140,14 @@ impl_runtime_apis! {
 
         fn open_channels() -> BTreeSet<(ChainId, ChannelId)> {
             Messenger::open_channels()
+        }
+
+        fn block_messages_with_query(query: BlockMessagesQuery) -> BlockMessagesWithStorageKey {
+            Messenger::get_block_messages(query)
+        }
+
+        fn channels_and_state() -> Vec<(ChainId, ChannelId, ChannelState)>{
+            Messenger::channels_and_states()
         }
     }
 

--- a/domains/test/runtime/auto-id/src/lib.rs
+++ b/domains/test/runtime/auto-id/src/lib.rs
@@ -42,8 +42,8 @@ use sp_core::{Get, OpaqueMetadata};
 use sp_domains::{ChannelId, DomainAllowlistUpdates, DomainId, Transfers};
 use sp_messenger::endpoint::{Endpoint, EndpointHandler as EndpointHandlerT, EndpointId};
 use sp_messenger::messages::{
-    BlockMessagesQuery, BlockMessagesWithStorageKey, ChainId, ChannelState, CrossDomainMessage,
-    MessageId, MessageKey, Nonce as XdmNonce,
+    BlockMessagesQuery, BlockMessagesWithStorageKey, ChainId, ChannelStateWithNonce,
+    CrossDomainMessage, MessageId, MessageKey, Nonce as XdmNonce,
 };
 use sp_messenger::{ChannelNonce, XdmId};
 use sp_messenger_host_functions::{get_storage_key, StorageKeyRequest};
@@ -1146,7 +1146,7 @@ impl_runtime_apis! {
             Messenger::get_block_messages(query)
         }
 
-        fn channels_and_state() -> Vec<(ChainId, ChannelId, ChannelState)> {
+        fn channels_and_state() -> Vec<(ChainId, ChannelId, ChannelStateWithNonce)> {
             Messenger::channels_and_states()
         }
 

--- a/domains/test/runtime/evm/src/lib.rs
+++ b/domains/test/runtime/evm/src/lib.rs
@@ -60,7 +60,8 @@ use sp_evm_tracker::{
 };
 use sp_messenger::endpoint::{Endpoint, EndpointHandler as EndpointHandlerT, EndpointId};
 use sp_messenger::messages::{
-    BlockMessagesWithStorageKey, ChainId, ChannelId, CrossDomainMessage, MessageId, MessageKey,
+    BlockMessagesQuery, BlockMessagesWithStorageKey, ChainId, ChannelId, ChannelState,
+    CrossDomainMessage, MessageId, MessageKey,
 };
 use sp_messenger::{ChannelNonce, XdmId};
 use sp_messenger_host_functions::{get_storage_key, StorageKeyRequest};
@@ -1562,7 +1563,7 @@ impl_runtime_apis! {
 
     impl sp_messenger::RelayerApi<Block, BlockNumber, ConsensusBlockNumber, ConsensusBlockHash> for Runtime {
         fn block_messages() -> BlockMessagesWithStorageKey {
-            Messenger::get_block_messages()
+            BlockMessagesWithStorageKey::default()
         }
 
         fn outbox_message_unsigned(msg: CrossDomainMessage<NumberFor<Block>, BlockHashFor<Block>, BlockHashFor<Block>>) -> Option<ExtrinsicFor<Block>> {
@@ -1591,6 +1592,14 @@ impl_runtime_apis! {
 
         fn open_channels() -> BTreeSet<(ChainId, ChannelId)> {
             Messenger::open_channels()
+        }
+
+        fn block_messages_with_query(query: BlockMessagesQuery) -> BlockMessagesWithStorageKey {
+            Messenger::get_block_messages(query)
+        }
+
+        fn channels_and_state() -> Vec<(ChainId, ChannelId, ChannelState)>{
+            Messenger::channels_and_states()
         }
     }
 

--- a/domains/test/runtime/evm/src/lib.rs
+++ b/domains/test/runtime/evm/src/lib.rs
@@ -61,7 +61,7 @@ use sp_evm_tracker::{
 use sp_messenger::endpoint::{Endpoint, EndpointHandler as EndpointHandlerT, EndpointId};
 use sp_messenger::messages::{
     BlockMessagesQuery, BlockMessagesWithStorageKey, ChainId, ChannelId, ChannelStateWithNonce,
-    CrossDomainMessage, MessageId, MessageKey, Nonce as XdmNonce,
+    CrossDomainMessage, MessageId, MessageKey, MessagesWithStorageKey, Nonce as XdmNonce,
 };
 use sp_messenger::{ChannelNonce, XdmId};
 use sp_messenger_host_functions::{get_storage_key, StorageKeyRequest};
@@ -1594,20 +1594,20 @@ impl_runtime_apis! {
             Messenger::open_channels()
         }
 
-        fn block_messages_with_query(query: BlockMessagesQuery) -> BlockMessagesWithStorageKey {
+        fn block_messages_with_query(query: BlockMessagesQuery) -> MessagesWithStorageKey {
             Messenger::get_block_messages(query)
         }
 
-        fn channels_and_state() -> Vec<(ChainId, ChannelId, ChannelStateWithNonce)>{
+        fn channels_and_state() -> Vec<(ChainId, ChannelId, ChannelStateWithNonce)> {
             Messenger::channels_and_states()
         }
 
-        fn should_relay_outbox_messages(dst_chain_id: ChainId, channel_id: ChannelId, from_nonce: XdmNonce) -> Option<XdmNonce> {
-            Messenger::should_relay_outbox_messages(dst_chain_id, channel_id, from_nonce)
+        fn first_outbox_message_nonce_to_relay(dst_chain_id: ChainId, channel_id: ChannelId, from_nonce: XdmNonce) -> Option<XdmNonce> {
+            Messenger::first_outbox_message_nonce_to_relay(dst_chain_id, channel_id, from_nonce)
         }
 
-        fn should_relay_inbox_message_responses(dst_chain_id: ChainId, channel_id: ChannelId, from_nonce: XdmNonce) -> Option<XdmNonce> {
-            Messenger::should_relay_inbox_message_responses(dst_chain_id, channel_id, from_nonce)
+        fn first_inbox_message_response_nonce_to_relay(dst_chain_id: ChainId, channel_id: ChannelId, from_nonce: XdmNonce) -> Option<XdmNonce> {
+            Messenger::first_inbox_message_response_nonce_to_relay(dst_chain_id, channel_id, from_nonce)
         }
     }
 

--- a/domains/test/runtime/evm/src/lib.rs
+++ b/domains/test/runtime/evm/src/lib.rs
@@ -60,7 +60,7 @@ use sp_evm_tracker::{
 };
 use sp_messenger::endpoint::{Endpoint, EndpointHandler as EndpointHandlerT, EndpointId};
 use sp_messenger::messages::{
-    BlockMessagesQuery, BlockMessagesWithStorageKey, ChainId, ChannelId, ChannelState,
+    BlockMessagesQuery, BlockMessagesWithStorageKey, ChainId, ChannelId, ChannelStateWithNonce,
     CrossDomainMessage, MessageId, MessageKey, Nonce as XdmNonce,
 };
 use sp_messenger::{ChannelNonce, XdmId};
@@ -1598,7 +1598,7 @@ impl_runtime_apis! {
             Messenger::get_block_messages(query)
         }
 
-        fn channels_and_state() -> Vec<(ChainId, ChannelId, ChannelState)>{
+        fn channels_and_state() -> Vec<(ChainId, ChannelId, ChannelStateWithNonce)>{
             Messenger::channels_and_states()
         }
 

--- a/domains/test/runtime/evm/src/lib.rs
+++ b/domains/test/runtime/evm/src/lib.rs
@@ -61,7 +61,7 @@ use sp_evm_tracker::{
 use sp_messenger::endpoint::{Endpoint, EndpointHandler as EndpointHandlerT, EndpointId};
 use sp_messenger::messages::{
     BlockMessagesQuery, BlockMessagesWithStorageKey, ChainId, ChannelId, ChannelState,
-    CrossDomainMessage, MessageId, MessageKey,
+    CrossDomainMessage, MessageId, MessageKey, Nonce as XdmNonce,
 };
 use sp_messenger::{ChannelNonce, XdmId};
 use sp_messenger_host_functions::{get_storage_key, StorageKeyRequest};
@@ -1574,12 +1574,12 @@ impl_runtime_apis! {
             Messenger::inbox_response_message_unsigned(msg)
         }
 
-        fn should_relay_outbox_message(dst_chain_id: ChainId, msg_id: MessageId) -> bool {
-            Messenger::should_relay_outbox_message(dst_chain_id, msg_id)
+        fn should_relay_outbox_message(_: ChainId, _: MessageId) -> bool {
+            false
         }
 
-        fn should_relay_inbox_message_response(dst_chain_id: ChainId, msg_id: MessageId) -> bool {
-            Messenger::should_relay_inbox_message_response(dst_chain_id, msg_id)
+        fn should_relay_inbox_message_response(_: ChainId, _: MessageId) -> bool {
+            false
         }
 
         fn updated_channels() -> BTreeSet<(ChainId, ChannelId)> {
@@ -1600,6 +1600,14 @@ impl_runtime_apis! {
 
         fn channels_and_state() -> Vec<(ChainId, ChannelId, ChannelState)>{
             Messenger::channels_and_states()
+        }
+
+        fn should_relay_outbox_messages(dst_chain_id: ChainId, channel_id: ChannelId, from_nonce: XdmNonce) -> Option<XdmNonce> {
+            Messenger::should_relay_outbox_messages(dst_chain_id, channel_id, from_nonce)
+        }
+
+        fn should_relay_inbox_message_responses(dst_chain_id: ChainId, channel_id: ChannelId, from_nonce: XdmNonce) -> Option<XdmNonce> {
+            Messenger::should_relay_inbox_message_responses(dst_chain_id, channel_id, from_nonce)
         }
     }
 

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -79,7 +79,7 @@ use sp_domains_fraud_proof::storage_proof::{
 };
 use sp_messenger::endpoint::{Endpoint, EndpointHandler as EndpointHandlerT, EndpointId};
 use sp_messenger::messages::{
-    BlockMessagesQuery, BlockMessagesWithStorageKey, ChainId, ChannelId, ChannelState,
+    BlockMessagesQuery, BlockMessagesWithStorageKey, ChainId, ChannelId, ChannelStateWithNonce,
     CrossDomainMessage, MessageId, MessageKey, Nonce as XdmNonce,
 };
 use sp_messenger::{ChannelNonce, XdmId};
@@ -1757,7 +1757,7 @@ impl_runtime_apis! {
             Messenger::get_block_messages(query)
         }
 
-        fn channels_and_state() -> Vec<(ChainId, ChannelId, ChannelState)>{
+        fn channels_and_state() -> Vec<(ChainId, ChannelId, ChannelStateWithNonce)>{
             Messenger::channels_and_states()
         }
 

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -79,7 +79,8 @@ use sp_domains_fraud_proof::storage_proof::{
 };
 use sp_messenger::endpoint::{Endpoint, EndpointHandler as EndpointHandlerT, EndpointId};
 use sp_messenger::messages::{
-    BlockMessagesWithStorageKey, ChainId, ChannelId, CrossDomainMessage, MessageId, MessageKey,
+    BlockMessagesQuery, BlockMessagesWithStorageKey, ChainId, ChannelId, ChannelState,
+    CrossDomainMessage, MessageId, MessageKey,
 };
 use sp_messenger::{ChannelNonce, XdmId};
 use sp_messenger_host_functions::{get_storage_key, StorageKeyRequest};
@@ -1721,7 +1722,7 @@ impl_runtime_apis! {
 
     impl sp_messenger::RelayerApi<Block, BlockNumber, BlockNumber, BlockHashFor<Block>> for Runtime {
         fn block_messages() -> BlockMessagesWithStorageKey {
-            Messenger::get_block_messages()
+            BlockMessagesWithStorageKey::default()
         }
 
         fn outbox_message_unsigned(msg: CrossDomainMessage<NumberFor<Block>, BlockHashFor<Block>, BlockHashFor<Block>>) -> Option<ExtrinsicFor<Block>> {
@@ -1750,6 +1751,14 @@ impl_runtime_apis! {
 
         fn open_channels() -> BTreeSet<(ChainId, ChannelId)> {
             Messenger::open_channels()
+        }
+
+        fn block_messages_with_query(query: BlockMessagesQuery) -> BlockMessagesWithStorageKey {
+            Messenger::get_block_messages(query)
+        }
+
+        fn channels_and_state() -> Vec<(ChainId, ChannelId, ChannelState)>{
+            Messenger::channels_and_states()
         }
     }
 

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -80,7 +80,7 @@ use sp_domains_fraud_proof::storage_proof::{
 use sp_messenger::endpoint::{Endpoint, EndpointHandler as EndpointHandlerT, EndpointId};
 use sp_messenger::messages::{
     BlockMessagesQuery, BlockMessagesWithStorageKey, ChainId, ChannelId, ChannelStateWithNonce,
-    CrossDomainMessage, MessageId, MessageKey, Nonce as XdmNonce,
+    CrossDomainMessage, MessageId, MessageKey, MessagesWithStorageKey, Nonce as XdmNonce,
 };
 use sp_messenger::{ChannelNonce, XdmId};
 use sp_messenger_host_functions::{get_storage_key, StorageKeyRequest};
@@ -1753,20 +1753,20 @@ impl_runtime_apis! {
             Messenger::open_channels()
         }
 
-        fn block_messages_with_query(query: BlockMessagesQuery) -> BlockMessagesWithStorageKey {
+        fn block_messages_with_query(query: BlockMessagesQuery) -> MessagesWithStorageKey {
             Messenger::get_block_messages(query)
         }
 
-        fn channels_and_state() -> Vec<(ChainId, ChannelId, ChannelStateWithNonce)>{
+        fn channels_and_state() -> Vec<(ChainId, ChannelId, ChannelStateWithNonce)> {
             Messenger::channels_and_states()
         }
 
-        fn should_relay_outbox_messages(dst_chain_id: ChainId, channel_id: ChannelId, from_nonce: XdmNonce) -> Option<XdmNonce> {
-            Messenger::should_relay_outbox_messages(dst_chain_id, channel_id, from_nonce)
+        fn first_outbox_message_nonce_to_relay(dst_chain_id: ChainId, channel_id: ChannelId, from_nonce: XdmNonce) -> Option<XdmNonce> {
+            Messenger::first_outbox_message_nonce_to_relay(dst_chain_id, channel_id, from_nonce)
         }
 
-        fn should_relay_inbox_message_responses(dst_chain_id: ChainId, channel_id: ChannelId, from_nonce: XdmNonce) -> Option<XdmNonce> {
-            Messenger::should_relay_inbox_message_responses(dst_chain_id, channel_id, from_nonce)
+        fn first_inbox_message_response_nonce_to_relay(dst_chain_id: ChainId, channel_id: ChannelId, from_nonce: XdmNonce) -> Option<XdmNonce> {
+            Messenger::first_inbox_message_response_nonce_to_relay(dst_chain_id, channel_id, from_nonce)
         }
     }
 

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -80,7 +80,7 @@ use sp_domains_fraud_proof::storage_proof::{
 use sp_messenger::endpoint::{Endpoint, EndpointHandler as EndpointHandlerT, EndpointId};
 use sp_messenger::messages::{
     BlockMessagesQuery, BlockMessagesWithStorageKey, ChainId, ChannelId, ChannelState,
-    CrossDomainMessage, MessageId, MessageKey,
+    CrossDomainMessage, MessageId, MessageKey, Nonce as XdmNonce,
 };
 use sp_messenger::{ChannelNonce, XdmId};
 use sp_messenger_host_functions::{get_storage_key, StorageKeyRequest};
@@ -1733,12 +1733,12 @@ impl_runtime_apis! {
             Messenger::inbox_response_message_unsigned(msg)
         }
 
-        fn should_relay_outbox_message(dst_chain_id: ChainId, msg_id: MessageId) -> bool {
-            Messenger::should_relay_outbox_message(dst_chain_id, msg_id)
+        fn should_relay_outbox_message(_: ChainId, _: MessageId) -> bool {
+            false
         }
 
-        fn should_relay_inbox_message_response(dst_chain_id: ChainId, msg_id: MessageId) -> bool {
-            Messenger::should_relay_inbox_message_response(dst_chain_id, msg_id)
+        fn should_relay_inbox_message_response(_: ChainId, _: MessageId) -> bool {
+            false
         }
 
         fn updated_channels() -> BTreeSet<(ChainId, ChannelId)> {
@@ -1759,6 +1759,14 @@ impl_runtime_apis! {
 
         fn channels_and_state() -> Vec<(ChainId, ChannelId, ChannelState)>{
             Messenger::channels_and_states()
+        }
+
+        fn should_relay_outbox_messages(dst_chain_id: ChainId, channel_id: ChannelId, from_nonce: XdmNonce) -> Option<XdmNonce> {
+            Messenger::should_relay_outbox_messages(dst_chain_id, channel_id, from_nonce)
+        }
+
+        fn should_relay_inbox_message_responses(dst_chain_id: ChainId, channel_id: ChannelId, from_nonce: XdmNonce) -> Option<XdmNonce> {
+            Messenger::should_relay_inbox_message_responses(dst_chain_id, channel_id, from_nonce)
         }
     }
 


### PR DESCRIPTION
Previously, the relayer 
- used to fetch all the pending messages for all channels
- check if the each message should be relayed
- Submit XDM messages

This has problems such as
- Fetching all messages for all channels of all chains leads to memory allocation issues as seen on Taurus. As the number of channels grow, so does the memory required.
- Excessive runtime calls while filtering messages as we check for each message. If there are 20,000 messages to process we make 20,000 runtime calls

This PR handles these issues in the following way
- Fetches only max allowed messages per channel i.e 256 at this point in time
- Handle randomly selected 15 channels for each block to be processed.
- One runtime call per channel to filter messages and this will be atmost 15 runtime calls irrespective number of channels.

## Calls and allocation
With the new change,
- Runtime will allocate at max of 512, 256 for each inbox response and outbox messages, which will be around 96,000 bytes
- Runtime calls to fetch and filter will be atmost 15 + 15 


## Commits
Review commit by commit for better understanding but 2nd commit changes are partly refactored in 3rd. I left the 2nd commit as is to provide better view of how it the change was implemented followed by concrete implementation in the 3rd.

## Notes
- Client with RelayerApi version < 3 will not process any XDMs as expected. 
- Once runtime is upgraded with version 3 of relayer Api, XDMs will be processed.
- I did not implement the any parallel processing of fetching messages as this felt unnecessary at the moment looking at how many runtime calls relayer did in the previous iteration compared to current iteration. Having that, we can monitor such parallel processing would provide any benefits

Closes: #3536 

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
