### PR TITLE
Add minimum transfer amount to transporting to different chain through XDM

### DIFF
--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -798,6 +798,7 @@ where
 
 parameter_types! {
     pub const TransporterEndpointId: EndpointId = 1;
+    pub const MinimumTransfer: Balance = SSC;
 }
 
 impl pallet_transporter::Config for Runtime {
@@ -809,6 +810,7 @@ impl pallet_transporter::Config for Runtime {
     type AccountIdConverter = AccountIdConverter;
     type WeightInfo = pallet_transporter::weights::SubstrateWeight<Runtime>;
     type SkipBalanceTransferChecks = pallet_domains::DomainsSkipBalanceChecks<Runtime>;
+    type MinimumTransfer = MinimumTransfer;
 }
 
 parameter_types! {

--- a/domains/pallets/messenger/src/mock.rs
+++ b/domains/pallets/messenger/src/mock.rs
@@ -153,6 +153,7 @@ macro_rules! impl_runtime {
 
         parameter_types! {
             pub const TransporterEndpointId: EndpointId = 100;
+            pub const MinimumTransfer: Balance = 1;
         }
 
         #[derive(Debug)]
@@ -182,6 +183,7 @@ macro_rules! impl_runtime {
             type AccountIdConverter = MockAccountIdConverter;
             type WeightInfo = ();
             type SkipBalanceTransferChecks = ();
+            type MinimumTransfer = MinimumTransfer;
         }
 
         impl pallet_domains::Config for $runtime {}

--- a/domains/pallets/transporter/src/lib.rs
+++ b/domains/pallets/transporter/src/lib.rs
@@ -117,6 +117,9 @@ mod pallet {
 
         /// Skip Balance transfer checks
         type SkipBalanceTransferChecks: SkipBalanceChecks;
+
+        /// Minimum transfer amount.
+        type MinimumTransfer: Get<BalanceOf<Self>>;
     }
 
     /// Pallet transporter to move funds between chains.
@@ -230,6 +233,8 @@ mod pallet {
         BalanceUnderflow,
         /// Emits when domain balance is already initialized
         DomainBalanceAlreadyInitialized,
+        /// Emits when the requested transfer amount is less than Minimum transfer amount.
+        MinimumTransferAmount,
     }
 
     #[pallet::call]
@@ -244,6 +249,10 @@ mod pallet {
             amount: BalanceOf<T>,
         ) -> DispatchResult {
             let sender = ensure_signed(origin)?;
+            ensure!(
+                amount >= T::MinimumTransfer::get(),
+                Error::<T>::MinimumTransferAmount
+            );
 
             // burn transfer amount
             let _imbalance = T::Currency::withdraw(

--- a/domains/pallets/transporter/src/mock.rs
+++ b/domains/pallets/transporter/src/mock.rs
@@ -157,6 +157,10 @@ impl TryConvertBack<AccountId, MultiAccountId> for MockAccountIdConverter {
     }
 }
 
+parameter_types! {
+    pub const MinimumTransfer: Balance = 1;
+}
+
 impl Config for MockRuntime {
     type RuntimeEvent = RuntimeEvent;
     type SelfChainId = SelfChainId;
@@ -169,6 +173,7 @@ impl Config for MockRuntime {
     type AccountIdConverter = MockAccountIdConverter;
     type WeightInfo = ();
     type SkipBalanceTransferChecks = ();
+    type MinimumTransfer = MinimumTransfer;
 }
 
 pub const USER_ACCOUNT: AccountId = 1;

--- a/domains/runtime/auto-id/src/lib.rs
+++ b/domains/runtime/auto-id/src/lib.rs
@@ -457,6 +457,7 @@ where
 
 parameter_types! {
     pub const TransporterEndpointId: EndpointId = 1;
+    pub const MinimumTransfer: Balance = SSC;
 }
 
 impl pallet_transporter::Config for Runtime {
@@ -468,6 +469,7 @@ impl pallet_transporter::Config for Runtime {
     type AccountIdConverter = domain_runtime_primitives::AccountIdConverter;
     type WeightInfo = pallet_transporter::weights::SubstrateWeight<Runtime>;
     type SkipBalanceTransferChecks = ();
+    type MinimumTransfer = MinimumTransfer;
 }
 
 impl pallet_domain_id::Config for Runtime {}

--- a/domains/runtime/evm/src/lib.rs
+++ b/domains/runtime/evm/src/lib.rs
@@ -609,6 +609,7 @@ where
 
 parameter_types! {
     pub const TransporterEndpointId: EndpointId = 1;
+    pub const MinimumTransfer: Balance = SSC;
 }
 
 impl pallet_transporter::Config for Runtime {
@@ -620,6 +621,7 @@ impl pallet_transporter::Config for Runtime {
     type AccountIdConverter = domain_runtime_primitives::AccountId20Converter;
     type WeightInfo = pallet_transporter::weights::SubstrateWeight<Runtime>;
     type SkipBalanceTransferChecks = ();
+    type MinimumTransfer = MinimumTransfer;
 }
 
 impl pallet_evm_chain_id::Config for Runtime {}

--- a/domains/test/runtime/auto-id/src/lib.rs
+++ b/domains/test/runtime/auto-id/src/lib.rs
@@ -455,6 +455,7 @@ where
 
 parameter_types! {
     pub const TransporterEndpointId: EndpointId = 1;
+    pub const MinimumTransfer: Balance = 1;
 }
 
 impl pallet_transporter::Config for Runtime {
@@ -466,6 +467,7 @@ impl pallet_transporter::Config for Runtime {
     type AccountIdConverter = domain_runtime_primitives::AccountIdConverter;
     type WeightInfo = pallet_transporter::weights::SubstrateWeight<Runtime>;
     type SkipBalanceTransferChecks = ();
+    type MinimumTransfer = MinimumTransfer;
 }
 
 impl pallet_domain_id::Config for Runtime {}

--- a/domains/test/runtime/evm/src/lib.rs
+++ b/domains/test/runtime/evm/src/lib.rs
@@ -643,6 +643,7 @@ where
 
 parameter_types! {
     pub const TransporterEndpointId: EndpointId = 1;
+    pub const MinimumTransfer: Balance = 1;
 }
 
 impl pallet_transporter::Config for Runtime {
@@ -654,6 +655,7 @@ impl pallet_transporter::Config for Runtime {
     type AccountIdConverter = domain_runtime_primitives::AccountId20Converter;
     type WeightInfo = pallet_transporter::weights::SubstrateWeight<Runtime>;
     type SkipBalanceTransferChecks = ();
+    type MinimumTransfer = MinimumTransfer;
 }
 
 impl pallet_evm_chain_id::Config for Runtime {}

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -751,6 +751,7 @@ where
 
 parameter_types! {
     pub const TransporterEndpointId: EndpointId = 1;
+    pub const MinimumTransfer: Balance = 1;
 }
 
 impl pallet_transporter::Config for Runtime {
@@ -762,6 +763,7 @@ impl pallet_transporter::Config for Runtime {
     type AccountIdConverter = AccountIdConverter;
     type WeightInfo = pallet_transporter::weights::SubstrateWeight<Runtime>;
     type SkipBalanceTransferChecks = ();
+    type MinimumTransfer = MinimumTransfer;
 }
 
 parameter_types! {


### PR DESCRIPTION
Currently we allow as little as 1 unit to transfer from one chain to another through XDM. As seen in taurus, anyone scripter with even small amount of balance can occupy a full channel and opening a new channel is costly.

With a minimum transfer, this could be alleviated and allow fair and actual usage of XDM.
Currently set it as 10 AI3 but this can be played around as well. 

Thoughts on the 10 Ai3 being less or more @jfrank-summit @jim-counter ?

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
