### PR TITLE
fix runtime version tests with mandatory CoreApi version

### DIFF
--- a/crates/pallet-domains/src/domain_registry.rs
+++ b/crates/pallet-domains/src/domain_registry.rs
@@ -384,7 +384,7 @@ pub(crate) fn do_update_domain_allow_list<T: Config>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tests::{new_test_ext, Test};
+    use crate::tests::{new_test_ext, Test, TEST_RUNTIME_APIS};
     use domain_runtime_primitives::{AccountId20, AccountId20Converter};
     use frame_support::traits::Currency;
     use frame_support::{assert_err, assert_ok};
@@ -393,7 +393,7 @@ mod tests {
     use sp_domains::{EvmDomainRuntimeConfig, EvmType, PermissionedActionAllowedBy, RuntimeObject};
     use sp_runtime::traits::Convert;
     use sp_std::vec;
-    use sp_version::RuntimeVersion;
+    use sp_version::{create_apis_vec, RuntimeVersion};
     use subspace_runtime_primitives::SSC;
 
     type Balances = pallet_balances::Pallet<Test>;
@@ -470,6 +470,7 @@ mod tests {
                         spec_version: 1,
                         impl_version: 1,
                         transaction_version: 1,
+                        apis: create_apis_vec!(TEST_RUNTIME_APIS),
                         ..Default::default()
                     },
                     created_at: Default::default(),
@@ -591,6 +592,7 @@ mod tests {
                         spec_version: 1,
                         impl_version: 1,
                         transaction_version: 1,
+                        apis: create_apis_vec!(TEST_RUNTIME_APIS),
                         ..Default::default()
                     },
                     created_at: Default::default(),
@@ -763,6 +765,7 @@ mod tests {
                         spec_version: 1,
                         impl_version: 1,
                         transaction_version: 1,
+                        apis: create_apis_vec!(TEST_RUNTIME_APIS),
                         ..Default::default()
                     },
                     created_at: Default::default(),

--- a/crates/pallet-domains/src/runtime_registry.rs
+++ b/crates/pallet-domains/src/runtime_registry.rs
@@ -399,10 +399,11 @@ mod tests {
         new_test_ext, Domains, ReadRuntimeVersion, System, Test, TEST_RUNTIME_APIS,
     };
     use crate::Error;
+    use domain_runtime_primitives::Hash;
     use frame_support::dispatch::RawOrigin;
     use frame_support::traits::OnInitialize;
     use frame_support::{assert_err, assert_ok};
-    use parity_scale_codec::Encode;
+    use parity_scale_codec::{Decode, Encode};
     use sp_domains::storage::RawGenesis;
     use sp_domains::{DomainsDigestItem, RuntimeId, RuntimeObject, RuntimeType};
     use sp_runtime::traits::BlockNumberProvider;
@@ -659,5 +660,56 @@ mod tests {
             let digest = System::digest();
             assert_eq!(Some(0), fetch_upgraded_runtime_from_digest(digest))
         });
+    }
+
+    #[test]
+    fn test_runtime_version_encode_decode_with_core_api() {
+        let runtime_obj = RuntimeObject {
+            runtime_name: "evm".to_owned(),
+            runtime_type: Default::default(),
+            runtime_upgrades: 100,
+            hash: Default::default(),
+            raw_genesis: RawGenesis::dummy(vec![1, 2, 3, 4]),
+            version: RuntimeVersion {
+                spec_name: "test".into(),
+                spec_version: 100,
+                impl_version: 34,
+                transaction_version: 256,
+                apis: create_apis_vec!(TEST_RUNTIME_APIS),
+                ..Default::default()
+            },
+            created_at: 100,
+            updated_at: 200,
+            instance_count: 500,
+        };
+
+        let encoded = runtime_obj.encode();
+        let decoded = RuntimeObject::<u32, Hash>::decode(&mut &encoded[..]).unwrap();
+        assert_eq!(decoded, runtime_obj);
+    }
+
+    #[test]
+    fn test_runtime_version_encode_decode_without_core_api() {
+        let runtime_obj = RuntimeObject {
+            runtime_name: "evm".to_owned(),
+            runtime_type: Default::default(),
+            runtime_upgrades: 100,
+            hash: Default::default(),
+            raw_genesis: RawGenesis::dummy(vec![1, 2, 3, 4]),
+            version: RuntimeVersion {
+                spec_name: "test".into(),
+                spec_version: 100,
+                impl_version: 34,
+                transaction_version: 256,
+                ..Default::default()
+            },
+            created_at: 100,
+            updated_at: 200,
+            instance_count: 500,
+        };
+
+        let encoded = runtime_obj.encode();
+        let decoded = RuntimeObject::<u32, Hash>::decode(&mut &encoded[..]).unwrap();
+        assert_ne!(decoded, runtime_obj);
     }
 }

--- a/crates/pallet-domains/src/runtime_registry.rs
+++ b/crates/pallet-domains/src/runtime_registry.rs
@@ -395,7 +395,9 @@ pub(crate) fn do_upgrade_runtimes<T: Config>(at: BlockNumberFor<T>) {
 mod tests {
     use crate::pallet::{NextRuntimeId, RuntimeRegistry, ScheduledRuntimeUpgrades};
     use crate::runtime_registry::Error as RuntimeRegistryError;
-    use crate::tests::{new_test_ext, Domains, ReadRuntimeVersion, System, Test};
+    use crate::tests::{
+        new_test_ext, Domains, ReadRuntimeVersion, System, Test, TEST_RUNTIME_APIS,
+    };
     use crate::Error;
     use frame_support::dispatch::RawOrigin;
     use frame_support::traits::OnInitialize;
@@ -405,7 +407,7 @@ mod tests {
     use sp_domains::{DomainsDigestItem, RuntimeId, RuntimeObject, RuntimeType};
     use sp_runtime::traits::BlockNumberProvider;
     use sp_runtime::{Digest, DispatchError};
-    use sp_version::RuntimeVersion;
+    use sp_version::{create_apis_vec, RuntimeVersion};
 
     #[test]
     fn create_domain_runtime() {
@@ -458,6 +460,7 @@ mod tests {
                         spec_version: 1,
                         impl_version: 1,
                         transaction_version: 1,
+                        apis: create_apis_vec!(TEST_RUNTIME_APIS),
                         ..Default::default()
                     },
                     created_at: Default::default(),
@@ -493,6 +496,7 @@ mod tests {
                 spec_version,
                 impl_version: 1,
                 transaction_version: 1,
+                apis: create_apis_vec!(TEST_RUNTIME_APIS),
                 ..Default::default()
             };
             let read_runtime_version = ReadRuntimeVersion(version.encode());
@@ -539,6 +543,7 @@ mod tests {
                     spec_version: 1,
                     impl_version: 1,
                     transaction_version: 1,
+                    apis: create_apis_vec!(TEST_RUNTIME_APIS),
                     ..Default::default()
                 }
             );
@@ -556,6 +561,7 @@ mod tests {
                     spec_version: 2,
                     impl_version: 1,
                     transaction_version: 1,
+                    apis: create_apis_vec!(TEST_RUNTIME_APIS),
                     ..Default::default()
                 }
             )
@@ -598,7 +604,7 @@ mod tests {
             authoring_version: 0,
             spec_version: 1,
             impl_version: 1,
-            apis: Default::default(),
+            apis: create_apis_vec!(TEST_RUNTIME_APIS),
             transaction_version: 1,
             system_version: 0,
         };
@@ -647,6 +653,8 @@ mod tests {
 
             let runtime_obj = RuntimeRegistry::<Test>::get(0).unwrap();
             assert_eq!(runtime_obj.version, version);
+            assert_eq!(runtime_obj.created_at, 0);
+            assert_eq!(runtime_obj.updated_at, 1);
 
             let digest = System::digest();
             assert_eq!(Some(0), fetch_upgraded_runtime_from_digest(digest))

--- a/crates/pallet-domains/src/tests.rs
+++ b/crates/pallet-domains/src/tests.rs
@@ -62,6 +62,12 @@ const DOMAIN_ID: DomainId = DomainId::new(0);
 const OPERATOR_ID: OperatorId = 0u64;
 
 // Core Api version ID and default APIs
+// RuntimeVersion's Decode is handwritten to accommodate Backward Compatibility for very old
+// RuntimeVersion that do not have TransactionVersion or SystemVersion.
+// So the Decode function always assume apis being present, at least CoreApi,
+// to derive the correct TransactionVersion and SystemVersion.
+// So we should always add the TEST_RUNTIME_APIS to the RuntimeVersion to ensure it is decoded correctly.
+// More here - https://github.com/paritytech/polkadot-sdk/blob/master/substrate/primitives/version/src/lib.rs#L637
 pub(crate) const CORE_API_ID: [u8; 8] = [223, 106, 203, 104, 153, 7, 96, 155];
 pub(crate) const TEST_RUNTIME_APIS: [(ApiId, u32); 1] = [(CORE_API_ID, 5)];
 

--- a/crates/pallet-domains/src/tests.rs
+++ b/crates/pallet-domains/src/tests.rs
@@ -41,7 +41,7 @@ use sp_runtime::traits::{
 use sp_runtime::transaction_validity::TransactionValidityError;
 use sp_runtime::type_with_default::TypeWithDefault;
 use sp_runtime::{BuildStorage, OpaqueExtrinsic};
-use sp_version::RuntimeVersion;
+use sp_version::{create_apis_vec, ApiId, RuntimeVersion};
 use std::num::NonZeroU64;
 use subspace_core_primitives::pieces::Piece;
 use subspace_core_primitives::segments::HistorySize;
@@ -60,6 +60,10 @@ const DOMAIN_ID: DomainId = DomainId::new(0);
 
 // Operator id used for testing
 const OPERATOR_ID: OperatorId = 0u64;
+
+// Core Api version ID and default APIs
+pub(crate) const CORE_API_ID: [u8; 8] = [223, 106, 203, 104, 153, 7, 96, 155];
+pub(crate) const TEST_RUNTIME_APIS: [(ApiId, u32); 1] = [(CORE_API_ID, 5)];
 
 frame_support::construct_runtime!(
     pub struct Test {
@@ -382,7 +386,7 @@ pub(crate) fn new_test_ext_with_extensions() -> sp_io::TestExternalities {
         authoring_version: 0,
         spec_version: 1,
         impl_version: 1,
-        apis: Default::default(),
+        apis: create_apis_vec!(TEST_RUNTIME_APIS),
         transaction_version: 1,
         system_version: 2,
     };


### PR DESCRIPTION
Updates tests to use the Test APIs with CoreApi version as mandatory.

Closes: #3547
### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
