### PR TITLE
Faster PoT verification without allocation or `std`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1972,9 +1972,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.14"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "608697df725056feaccfa42cffdaeeec3fccc4ffc38358ecd19b243e716a78e0"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
@@ -5192,7 +5192,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2 0.5.9",
  "tokio",
  "tower-service",
  "tracing",
@@ -13779,8 +13779,10 @@ version = "0.1.0"
 dependencies = [
  "aes 0.9.0-pre.2",
  "core_affinity",
+ "cpufeatures",
  "criterion",
- "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
  "subspace-core-primitives",
  "thiserror 2.0.12",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ cc = "1.1.23"
 chacha20 = { version = "0.9.1", default-features = false }
 clap = "4.5.18"
 core_affinity = "0.8.1"
+cpufeatures = "0.2.17"
 criterion = { version = "0.5.1", default-features = false }
 cross-domain-message-gossip = { version = "0.1.0", path = "domains/client/cross-domain-message-gossip" }
 derive_more = { version = "1.0.0", default-features = false }

--- a/crates/sc-proof-of-time/src/verifier.rs
+++ b/crates/sc-proof-of-time/src/verifier.rs
@@ -272,7 +272,7 @@ impl PotVerifier {
             drop(cache);
 
             let verified_successfully =
-                subspace_proof_of_time::verify(seed, slot_iterations, checkpoints.as_slice())
+                subspace_proof_of_time::verify(seed, slot_iterations, checkpoints)
                     .unwrap_or_default();
 
             if !verified_successfully {

--- a/crates/subspace-proof-of-time/Cargo.toml
+++ b/crates/subspace-proof-of-time/Cargo.toml
@@ -3,7 +3,7 @@ name = "subspace-proof-of-time"
 description = "Subspace proof of time implementation"
 license = "0BSD"
 version = "0.1.0"
-authors = ["Rahul Subramaniyam <rahulksnv@gmail.com>"]
+authors = ["Nazar Mokrynskyi <nazar@mokrynskyi.com>"]
 edition = "2021"
 include = [
     "/src",
@@ -19,13 +19,14 @@ aes.workspace = true
 subspace-core-primitives.workspace = true
 thiserror.workspace = true
 
-# This is required to for benchmark dependency features to work correctly
-rand = { workspace = true, optional = true }
+[target.'cfg(target_arch = "x86_64")'.dependencies]
+cpufeatures = { workspace = true }
 
 [dev-dependencies]
 core_affinity.workspace = true
 criterion.workspace = true
-rand.workspace = true
+rand_core = { workspace = true }
+rand_chacha = { workspace = true }
 
 [[bench]]
 name = "pot"
@@ -34,12 +35,3 @@ harness = false
 [[bench]]
 name = "pot-compare-cpu-cores"
 harness = false
-
-[features]
-default = ["std"]
-std = [
-    "subspace-core-primitives/std",
-    "thiserror/std",
-    "rand?/std",
-    "rand?/std_rng",
-]

--- a/crates/subspace-proof-of-time/benches/pot-compare-cpu-cores.rs
+++ b/crates/subspace-proof-of-time/benches/pot-compare-cpu-cores.rs
@@ -1,12 +1,15 @@
 use core::num::NonZeroU32;
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use rand::{thread_rng, Rng};
+use criterion::{criterion_group, criterion_main, Criterion};
+use rand_chacha::ChaCha8Rng;
+use rand_core::{RngCore, SeedableRng};
+use std::hint::black_box;
 use subspace_core_primitives::pot::PotSeed;
 use subspace_proof_of_time::prove;
 
 fn criterion_benchmark(c: &mut Criterion) {
+    let mut rng = ChaCha8Rng::from_seed(Default::default());
     let mut seed = PotSeed::default();
-    thread_rng().fill(seed.as_mut());
+    rng.fill_bytes(seed.as_mut());
     // About 1s on 6.0 GHz Raptor Lake CPU (14900K)
     let pot_iterations = NonZeroU32::new(200_032_000).expect("Not zero; qed");
 

--- a/crates/subspace-proof-of-time/benches/pot.rs
+++ b/crates/subspace-proof-of-time/benches/pot.rs
@@ -1,12 +1,15 @@
 use core::num::NonZeroU32;
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use rand::{thread_rng, Rng};
+use criterion::{criterion_group, criterion_main, Criterion};
+use rand_chacha::ChaCha8Rng;
+use rand_core::{RngCore, SeedableRng};
+use std::hint::black_box;
 use subspace_core_primitives::pot::PotSeed;
 use subspace_proof_of_time::{prove, verify};
 
 fn criterion_benchmark(c: &mut Criterion) {
+    let mut rng = ChaCha8Rng::from_seed(Default::default());
     let mut seed = PotSeed::default();
-    thread_rng().fill(seed.as_mut());
+    rng.fill_bytes(seed.as_mut());
     // About 1s on 6.0 GHz Raptor Lake CPU (14900K)
     let pot_iterations = NonZeroU32::new(200_032_000).expect("Not zero; qed");
 
@@ -23,7 +26,7 @@ fn criterion_benchmark(c: &mut Criterion) {
             black_box(verify(
                 black_box(seed),
                 black_box(pot_iterations),
-                black_box(&*checkpoints),
+                black_box(&checkpoints),
             ))
             .unwrap();
         })

--- a/crates/subspace-proof-of-time/src/lib.rs
+++ b/crates/subspace-proof-of-time/src/lib.rs
@@ -1,10 +1,11 @@
 //! Proof of time implementation.
 
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
+
 mod aes;
 
 use core::num::NonZeroU32;
-use subspace_core_primitives::pot::{PotCheckpoints, PotOutput, PotSeed};
+use subspace_core_primitives::pot::{PotCheckpoints, PotSeed};
 
 /// Proof of time error
 #[derive(Debug, thiserror::Error)]
@@ -46,7 +47,7 @@ pub fn prove(seed: PotSeed, iterations: NonZeroU32) -> Result<PotCheckpoints, Po
 pub fn verify(
     seed: PotSeed,
     iterations: NonZeroU32,
-    checkpoints: &[PotOutput],
+    checkpoints: &PotCheckpoints,
 ) -> Result<bool, PotError> {
     let num_checkpoints = checkpoints.len() as u32;
     if iterations.get() % (num_checkpoints * 2) != 0 {


### PR DESCRIPTION
PoT verification is a big part of the block verification cost, especially when syncing otherwise mostly empty blocks.


Before:
```
verify                  time:   [220.72 ms 225.27 ms 229.55 ms]
```
After:
```
verify                  time:   [204.92 ms 205.10 ms 205.30 ms]
```

Tested on Zen 4 CPU.

This change avoids `std` for AES-NI CPU feature detection on x86-64 and avoids heap allocation during verification, allowing for better data locality and overall better cache utilization, while also doing physically less work.

I also changed crate authorship since it was almost completely rewritten by me since its introduction in https://github.com/autonomys/subspace/pull/1601, only some of the tests are still mostly the same.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
