### PR TITLE
Cleanup EVM test code and dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12518,6 +12518,7 @@ dependencies = [
  "memory-db",
  "num-traits",
  "pallet-evm",
+ "pallet-utility",
  "parity-scale-codec",
  "rand 0.8.5",
  "rand_chacha 0.3.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2768,7 +2768,7 @@ name = "domain-block-builder"
 version = "0.1.0"
 dependencies = [
  "hash-db",
- "hexlit",
+ "hex-literal",
  "parity-scale-codec",
  "sc-chain-spec",
  "sc-client-api",
@@ -4943,12 +4943,6 @@ name = "hex_fmt"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b07f60793ff0a4d9cef0f18e63b5357e06209987153a64648c972c1e5aff336f"
-
-[[package]]
-name = "hexlit"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b6e75c860d4216ac53f9ac88b25c99eaedba075b3a7b2ed31f2adc51a74fffd"
 
 [[package]]
 name = "hickory-proto"
@@ -7956,7 +7950,6 @@ dependencies = [
  "frame-support",
  "frame-system",
  "hex-literal",
- "hexlit",
  "log",
  "pallet-balances",
  "pallet-block-fees",
@@ -12520,7 +12513,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "hash-db",
- "hexlit",
+ "hex-literal",
  "libsecp256k1",
  "memory-db",
  "num-traits",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2886,7 +2886,6 @@ dependencies = [
  "futures",
  "futures-timer",
  "hex",
- "hex-literal",
  "pallet-balances",
  "pallet-domain-sudo",
  "pallet-domains",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,6 @@ futures-timer = "3.0.3"
 hash-db = { version = "0.16.0", default-features = false }
 hex = { version = "0.4.3", default-features = false }
 hex-literal = "0.4.1"
-hexlit = "0.5.5"
 hwlocality = "1.0.0-alpha.6"
 jsonrpsee = "0.24.5"
 kzg = { git = "https://github.com/grandinetech/rust-kzg", rev = "6c8fcc623df3d7e8c0f30951a49bfea764f90bf4", default-features = false }

--- a/crates/pallet-domains/Cargo.toml
+++ b/crates/pallet-domains/Cargo.toml
@@ -17,7 +17,6 @@ domain-runtime-primitives.workspace = true
 frame-benchmarking = { workspace = true, optional = true }
 frame-support.workspace = true
 frame-system.workspace = true
-hexlit.workspace = true
 hex-literal = { workspace = true, optional = true }
 log.workspace = true
 pallet-balances.workspace = true

--- a/crates/sp-domains/Cargo.toml
+++ b/crates/sp-domains/Cargo.toml
@@ -17,7 +17,7 @@ domain-runtime-primitives.workspace = true
 frame-support.workspace = true
 hash-db.workspace = true
 memory-db.workspace = true
-hexlit.workspace = true
+hex-literal.workspace = true
 parity-scale-codec = { workspace = true, features = ["derive"] }
 rand.workspace = true
 rand_chacha.workspace = true

--- a/crates/sp-domains/Cargo.toml
+++ b/crates/sp-domains/Cargo.toml
@@ -44,6 +44,7 @@ fp-self-contained = { workspace = true, features = ["default"], optional = true 
 frame-system = { workspace = true, optional = true }
 libsecp256k1 = { workspace = true, features = ["static-context", "hmac"], optional = true }
 pallet-evm = { workspace = true, optional = true }
+pallet-utility = { workspace = true, optional = true }
 rlp = { workspace = true, optional = true }
 
 [dev-dependencies]
@@ -56,6 +57,7 @@ fp-self-contained = { workspace = true, features = ["default"] }
 frame-system.workspace = true
 libsecp256k1 = { workspace = true, features = ["static-context", "hmac"] }
 pallet-evm.workspace = true
+pallet-utility.workspace = true
 rlp.workspace = true
 
 [features]
@@ -99,5 +101,6 @@ test-ethereum = [
     "frame-system",
     "libsecp256k1",
     "pallet-evm",
+    "pallet-utility",
     "rlp",
 ]

--- a/crates/sp-domains/src/lib.rs
+++ b/crates/sp-domains/src/lib.rs
@@ -33,7 +33,7 @@ use core::str::FromStr;
 use domain_runtime_primitives::{EthereumAccountId, MultiAccountId};
 use frame_support::storage::storage_prefix;
 use frame_support::{Blake2_128Concat, StorageHasher};
-use hexlit::hex;
+use hex_literal::hex;
 use parity_scale_codec::{Codec, Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
 use serde::{Deserialize, Serialize};

--- a/crates/sp-domains/src/test_ethereum.rs
+++ b/crates/sp-domains/src/test_ethereum.rs
@@ -3,10 +3,46 @@
 use crate::test_ethereum_tx::{
     AccountInfo, EIP1559UnsignedTransaction, EIP2930UnsignedTransaction, LegacyUnsignedTransaction,
 };
+use crate::{EthereumAccountId, PermissionedActionAllowedBy};
 use ethereum::TransactionV2 as Transaction;
 use frame_support::pallet_prelude::DispatchClass;
+use hexlit::hex;
 use pallet_evm::GasWeightMapping;
 use sp_core::{Get, U256};
+
+/// The kind of account list to generate.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum EvmAccountList {
+    Anyone,
+    NoOne,
+    One,
+    Multiple,
+}
+
+/// Generate the supplied kind of account list.
+pub fn generate_evm_account_list(
+    account_infos: &[AccountInfo],
+    account_list_type: EvmAccountList,
+) -> PermissionedActionAllowedBy<EthereumAccountId> {
+    // The signer of pallet-evm transactions is the EVM domain in some tests, so we also add it to
+    // the account lists.
+    let evm_domain_account = hex!("e04cc55ebee1cbce552f250e85c57b70b2e2625b");
+
+    match account_list_type {
+        EvmAccountList::Anyone => PermissionedActionAllowedBy::Anyone,
+        EvmAccountList::NoOne => PermissionedActionAllowedBy::Accounts(Vec::new()),
+        EvmAccountList::One => PermissionedActionAllowedBy::Accounts(vec![
+            EthereumAccountId::from(evm_domain_account),
+            EthereumAccountId::from(account_infos[0].address),
+        ]),
+        EvmAccountList::Multiple => PermissionedActionAllowedBy::Accounts(vec![
+            EthereumAccountId::from(evm_domain_account),
+            EthereumAccountId::from(account_infos[0].address),
+            EthereumAccountId::from(account_infos[1].address),
+            EthereumAccountId::from(account_infos[2].address),
+        ]),
+    }
+}
 
 pub fn max_extrinsic_gas<TestRuntime: frame_system::Config + pallet_evm::Config>(
     multiplier: u64,

--- a/crates/sp-domains/src/test_ethereum.rs
+++ b/crates/sp-domains/src/test_ethereum.rs
@@ -6,7 +6,7 @@ use crate::test_ethereum_tx::{
 use crate::{EthereumAccountId, PermissionedActionAllowedBy};
 use ethereum::TransactionV2 as Transaction;
 use frame_support::pallet_prelude::DispatchClass;
-use hexlit::hex;
+use hex_literal::hex;
 use pallet_evm::GasWeightMapping;
 use sp_core::{Get, U256};
 

--- a/domains/client/block-builder/Cargo.toml
+++ b/domains/client/block-builder/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 parity-scale-codec = { workspace = true, features = ["derive"] }
 hash-db.workspace = true
-hexlit.workspace = true
+hex-literal.workspace = true
 sc-chain-spec.workspace = true
 sc-client-api.workspace = true
 sc-executor.workspace = true

--- a/domains/client/block-builder/src/genesis_block_builder.rs
+++ b/domains/client/block-builder/src/genesis_block_builder.rs
@@ -1,6 +1,6 @@
 //! Custom genesis block builder to inject correct genesis block.
 
-use hexlit::hex;
+use hex_literal::hex;
 use sc_chain_spec::{construct_genesis_block, resolve_state_version_from_wasm, BuildGenesisBlock};
 use sc_client_api::{Backend, BlockImportOperation};
 use sc_executor::RuntimeVersionOf;
@@ -94,15 +94,15 @@ where
                     // upgraded, so instead return the known domain-0's state root.
                     if consensus_client.info().genesis_hash
                         == H256::from(hex!(
-                            "0x295aeafca762a304d92ee1505548695091f6082d3f0aa4d092ac3cd6397a6c5e"
+                            "295aeafca762a304d92ee1505548695091f6082d3f0aa4d092ac3cd6397a6c5e"
                         ))
                         .into()
                         && domain_id == DomainId::new(0)
                     {
                         Some(
                             H256::from(hex!(
-                            "0x530eae1878202aa0ab5997eadf2b7245ee78f44a35ab25ff84151fab489aa334"
-                        ))
+                                "530eae1878202aa0ab5997eadf2b7245ee78f44a35ab25ff84151fab489aa334"
+                            ))
                             .into(),
                         )
                     } else {

--- a/domains/client/domain-operator/Cargo.toml
+++ b/domains/client/domain-operator/Cargo.toml
@@ -61,7 +61,6 @@ evm-domain-test-runtime.workspace = true
 fp-rpc.workspace = true
 fp-self-contained.workspace = true
 frame-system.workspace = true
-hex-literal.workspace = true
 pallet-balances.workspace = true
 pallet-domains.workspace = true
 pallet-domain-sudo.workspace = true


### PR DESCRIPTION
This PR contains some refactors that aren't needed for #3530, but I only found out they weren't needed once I'd almost finished:
- move EVM test code to a common crate and make some of it generic
- stop using two similar hex literal crates, just use the one substrate already depends on

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
