### PR TITLE
Add extra unbans to test_domain_tx_propagate

### DIFF
--- a/domains/client/domain-operator/src/tests.rs
+++ b/domains/client/domain-operator/src/tests.rs
@@ -2135,6 +2135,8 @@ async fn test_domain_tx_propagate() -> Result<(), tokio::time::error::Elapsed> {
         ferdie,
         alice,
         {
+            alice.unban_peer(bob.addr.clone());
+            bob.unban_peer(alice.addr.clone());
             // ensure bob has reduced balance since alice might submit other transactions which cost
             // and so exact balance check is not feasible
             alice.free_balance(bob.key.to_account_id()) <= pre_bob_free_balance - 123

--- a/domains/client/domain-operator/src/tests.rs
+++ b/domains/client/domain-operator/src/tests.rs
@@ -79,7 +79,7 @@ use subspace_test_service::{
     produce_block_with, produce_blocks, produce_blocks_until, MockConsensusNode,
 };
 use tempfile::TempDir;
-use tracing::error;
+use tracing::{error, info};
 
 /// The general timeout for test operations that could hang.
 const TIMEOUT: Duration = Duration::from_mins(10);
@@ -229,13 +229,12 @@ async fn setup_evm_test_nodes(
     evm_owner: impl Into<Option<Sr25519Keyring>>,
 ) -> (TempDir, MockConsensusNode, EvmDomainNode) {
     let evm_owner = evm_owner.into();
-    println!(
-        "Setting up EVM test nodes with sudo: {:?}, ferdie: {:?}, \
-        and {} evm owner: {:?} (defaults to sudo)",
-        Sr25519Alice.to_account_id(),
-        ferdie_key.to_account_id(),
+    info!(
+        sudo = ?Sr25519Alice.to_account_id(),
+        ferdie = ?ferdie_key.to_account_id(),
+        evm_owner = ?evm_owner.map(|k| k.to_account_id()),
+        "Setting up EVM test nodes with {} evm (EVM ovner defaults to sudo)",
         if private_evm { "private" } else { "public" },
-        evm_owner.map(|k| k.to_account_id()),
     );
 
     let directory = TempDir::new().expect("Must be able to create temporary directory");
@@ -2089,9 +2088,12 @@ async fn collected_receipts_should_be_on_the_same_branch_with_current_best_block
 // TODO: when the test is fixed, decide if we want to remove the timeouts.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_domain_tx_propagate() -> Result<(), tokio::time::error::Elapsed> {
+    let test = "test_domain_tx_propagate";
+    info!("{test}: Setting up Ferdie and Alice nodes");
     let (directory, mut ferdie, alice) =
         setup_evm_test_nodes(Ferdie, false, None).timeout().await?;
 
+    info!("{test}: Setting up Bob Full node, and connecting to Alice");
     // Run Bob (a evm domain full node)
     let bob = domain_test_service::DomainNodeBuilder::new(
         tokio::runtime::Handle::current(),
@@ -2102,11 +2104,13 @@ async fn test_domain_tx_propagate() -> Result<(), tokio::time::error::Elapsed> {
     .timeout()
     .await?;
 
+    info!("{test}: Producing 5 blocks");
     produce_blocks!(ferdie, alice, 5, bob)
         .timeout()
         .await?
         .unwrap();
 
+    info!("{test}: Waiting for Alice and Bob to sync");
     async {
         while alice.sync_service.is_major_syncing() || bob.sync_service.is_major_syncing() {
             tokio::time::sleep(std::time::Duration::from_secs(1)).await;
@@ -2120,6 +2124,7 @@ async fn test_domain_tx_propagate() -> Result<(), tokio::time::error::Elapsed> {
     .timeout()
     .await?;
 
+    info!("{test}: Transferring balance on Bob");
     let pre_bob_free_balance = alice.free_balance(bob.key.to_account_id());
     // Construct and send an extrinsic to bob, as bob is not a authority node, the extrinsic has
     // to propagate to alice to get executed
@@ -2131,6 +2136,7 @@ async fn test_domain_tx_propagate() -> Result<(), tokio::time::error::Elapsed> {
     .await?
     .expect("Failed to send extrinsic");
 
+    info!("{test}: Waiting for transaction to propagate to Alice and be executed");
     produce_blocks_until!(
         ferdie,
         alice,

--- a/domains/test/service/src/domain.rs
+++ b/domains/test/service/src/domain.rs
@@ -601,8 +601,8 @@ impl DomainNodeBuilder {
 
     /// Make the node connect to the given domain node.
     ///
-    /// By default the node will not be connected to any node or will be able to discover any other
-    /// node.
+    /// By default the node will not be connected to any node, and won't be able to discover any
+    /// other nodes.
     pub fn connect_to_domain_node(mut self, addr: MultiaddrWithPeerId) -> Self {
         self.domain_nodes.push(addr);
         self


### PR DESCRIPTION
This test is still unstable, and it's causing CI and merge failures.

I've added some extra unbans and some logging, but there's a weird block import pipeline bug which I can't work out:
https://github.com/autonomys/subspace/issues/3370#issuecomment-2918028413

Either the unbans will fix it, or the logging might help diagnose it.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
