### PR TITLE
Log DSN peer stats at info level

### DIFF
--- a/crates/subspace-networking/src/behavior/persistent_parameters.rs
+++ b/crates/subspace-networking/src/behavior/persistent_parameters.rs
@@ -201,6 +201,9 @@ pub trait KnownPeersRegistry: Send + Sync {
     /// Returns all known peers and their addresses without P2P suffix at the end
     async fn all_known_peers(&mut self) -> Vec<(PeerId, Vec<Multiaddr>)>;
 
+    /// Returns the number of known peers, and the number of addresses known for those peers.
+    fn count_known_peers(&mut self) -> (usize, usize);
+
     /// Drive async work in the persistence provider
     async fn run(&mut self);
 
@@ -235,6 +238,10 @@ impl KnownPeersRegistry for StubNetworkingParametersManager {
 
     async fn all_known_peers(&mut self) -> Vec<(PeerId, Vec<Multiaddr>)> {
         Vec::new()
+    }
+
+    fn count_known_peers(&mut self) -> (usize, usize) {
+        (0, 0)
     }
 
     async fn run(&mut self) {
@@ -627,6 +634,20 @@ impl KnownPeersRegistry for KnownPeersManager {
                 )
             })
             .collect()
+    }
+
+    fn count_known_peers(&mut self) -> (usize, usize) {
+        if !self.config.enable_known_peers_source {
+            return (0, 0);
+        }
+
+        (
+            self.known_peers.len(),
+            self.known_peers
+                .iter()
+                .map(|(_peer, addresses)| addresses.len())
+                .sum(),
+        )
     }
 
     async fn run(&mut self) {


### PR DESCRIPTION
We're having some issues with low DSN peer numbers on Taurus.

Substrate and domains info log their peer numbers every 5 seconds, but the DSN only logs them at debug level. This makes it difficult to diagnose issues on the bootstrap nodes, gateway, and other node types.

This PR logs some DSN stats at info level every 30 seconds, and adds more stats at debug level. We can tweak exactly what's logged when we know what's useful, and where the issue is.

Close #3560.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
