### PR TITLE
Update Starting EVM chainID and Rename SSC to AI3

### DIFF
--- a/crates/pallet-domains/src/domain_registry.rs
+++ b/crates/pallet-domains/src/domain_registry.rs
@@ -394,7 +394,7 @@ mod tests {
     use sp_runtime::traits::Convert;
     use sp_std::vec;
     use sp_version::{RuntimeVersion, create_apis_vec};
-    use subspace_runtime_primitives::SSC;
+    use subspace_runtime_primitives::AI3;
 
     type Balances = pallet_balances::Pallet<Test>;
 
@@ -571,7 +571,7 @@ mod tests {
             maybe_bundle_limit: None,
             bundle_slot_probability: (1, 1),
             operator_allow_list: OperatorAllowList::Anyone,
-            initial_balances: vec![(MultiAccountId::Raw(vec![0, 1, 2, 3, 4, 5]), 1_000_000 * SSC)],
+            initial_balances: vec![(MultiAccountId::Raw(vec![0, 1, 2, 3, 4, 5]), 1_000_000 * AI3)],
             domain_runtime_config: Default::default(),
         };
 
@@ -606,7 +606,7 @@ mod tests {
                 &creator,
                 <Test as Config>::DomainInstantiationDeposit::get()
                     // for domain total issuance
-                    + 1_000_000 * SSC
+                    + 1_000_000 * AI3
                     + <Test as pallet_balances::Config>::ExistentialDeposit::get(),
             );
 
@@ -624,13 +624,13 @@ mod tests {
                     AccountId20Converter::convert(AccountId20::from(hex!(
                         "f24FF3a9CF04c71Dbc94D0b566f7A27B94566cac"
                     ))),
-                    1_000_000 * SSC,
+                    1_000_000 * AI3,
                 ),
                 (
                     AccountId20Converter::convert(AccountId20::from(hex!(
                         "f24FF3a9CF04c71Dbc94D0b566f7A27B94566cac"
                     ))),
-                    1_000_000 * SSC,
+                    1_000_000 * AI3,
                 ),
             ];
 
@@ -645,37 +645,37 @@ mod tests {
                     AccountId20Converter::convert(AccountId20::from(hex!(
                         "f24FF3a9CF04c71Dbc94D0b566f7A27B94566cac"
                     ))),
-                    1_000_000 * SSC,
+                    1_000_000 * AI3,
                 ),
                 (
                     AccountId20Converter::convert(AccountId20::from(hex!(
                         "f24FF3a9CF04c71Dbc94D0b566f7A27B94566cbc"
                     ))),
-                    1_000_000 * SSC,
+                    1_000_000 * AI3,
                 ),
                 (
                     AccountId20Converter::convert(AccountId20::from(hex!(
                         "f24FF3a9CF04c71Dbc94D0b566f7A27B94566ccc"
                     ))),
-                    1_000_000 * SSC,
+                    1_000_000 * AI3,
                 ),
                 (
                     AccountId20Converter::convert(AccountId20::from(hex!(
                         "f24FF3a9CF04c71Dbc94D0b566f7A27B94566cdc"
                     ))),
-                    1_000_000 * SSC,
+                    1_000_000 * AI3,
                 ),
                 (
                     AccountId20Converter::convert(AccountId20::from(hex!(
                         "f24FF3a9CF04c71Dbc94D0b566f7A27B94566cec"
                     ))),
-                    1_000_000 * SSC,
+                    1_000_000 * AI3,
                 ),
                 (
                     AccountId20Converter::convert(AccountId20::from(hex!(
                         "f24FF3a9CF04c71Dbc94D0b566f7A27B94566cfc"
                     ))),
-                    1_000_000 * SSC,
+                    1_000_000 * AI3,
                 ),
             ];
 
@@ -701,7 +701,7 @@ mod tests {
                 AccountId20Converter::convert(AccountId20::from(hex!(
                     "f24FF3a9CF04c71Dbc94D0b566f7A27B94566cac"
                 ))),
-                1_000_000 * SSC,
+                1_000_000 * AI3,
             )];
 
             // Set enough fund to creator
@@ -709,7 +709,7 @@ mod tests {
                 &creator,
                 <Test as Config>::DomainInstantiationDeposit::get()
                     // for domain total issuance
-                    + 1_000_000 * SSC
+                    + 1_000_000 * AI3
                     + <Test as pallet_balances::Config>::ExistentialDeposit::get(),
             );
 
@@ -743,7 +743,7 @@ mod tests {
                 AccountId20Converter::convert(AccountId20::from(hex!(
                     "f24FF3a9CF04c71Dbc94D0b566f7A27B94566cac"
                 ))),
-                1_000_000 * SSC,
+                1_000_000 * AI3,
             )],
             domain_runtime_config: Default::default(),
         };
@@ -779,7 +779,7 @@ mod tests {
                 &creator,
                 <Test as Config>::DomainInstantiationDeposit::get()
                     // for domain total issuance
-                    + 1_000_000 * SSC
+                    + 1_000_000 * AI3
                     + <Test as pallet_balances::Config>::ExistentialDeposit::get(),
             );
 
@@ -815,7 +815,7 @@ mod tests {
                 &creator,
                 <Test as Config>::DomainInstantiationDeposit::get()
                                 // for domain total issuance
-                                + 1_000_000 * SSC
+                                + 1_000_000 * AI3
                                 + <Test as pallet_balances::Config>::ExistentialDeposit::get(),
             );
 
@@ -856,7 +856,7 @@ mod tests {
                 &creator,
                 <Test as Config>::DomainInstantiationDeposit::get()
                     // for domain total issuance
-                    + 1_000_000 * SSC
+                    + 1_000_000 * AI3
                     + <Test as pallet_balances::Config>::ExistentialDeposit::get(),
             );
 
@@ -897,7 +897,7 @@ mod tests {
                 &creator,
                 <Test as Config>::DomainInstantiationDeposit::get()
                     // for domain total issuance
-                    + 1_000_000 * SSC
+                    + 1_000_000 * AI3
                     + <Test as pallet_balances::Config>::ExistentialDeposit::get(),
             );
 
@@ -942,7 +942,7 @@ mod tests {
                 &creator,
                 <Test as Config>::DomainInstantiationDeposit::get()
                     // for domain total issuance
-                    + 1_000_000 * SSC
+                    + 1_000_000 * AI3
                     + <Test as pallet_balances::Config>::ExistentialDeposit::get(),
             );
 

--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -481,9 +481,8 @@ mod pallet {
 
     impl Get<EVMChainId> for StartingEVMChainId {
         fn get() -> EVMChainId {
-            // after looking at `https://chainlist.org/?testnets=false`
-            // we think starting with `490000` would not have much clashes
-            490000
+            // Starting EVM chainID for domains.
+            870
         }
     }
 

--- a/crates/pallet-domains/src/staking.rs
+++ b/crates/pallet-domains/src/staking.rs
@@ -36,8 +36,8 @@ pub(crate) struct Deposit<Share: Copy, Balance: Copy> {
     pub(crate) pending: Option<PendingDeposit<Balance>>,
 }
 
-/// A share price is parts per billion of shares/ssc.
-/// Note: Shares must always be equal to or lower than ssc.
+/// A share price is parts per billion of shares/ai3.
+/// Note: Shares must always be equal to or lower than ai3.
 #[derive(TypeInfo, Debug, Encode, Decode, Clone, PartialEq, Eq, Default)]
 pub struct SharePrice(Perbill);
 
@@ -98,7 +98,7 @@ pub(crate) struct KnownDeposit<Share: Copy, Balance: Copy> {
     pub(crate) storage_fee_deposit: Balance,
 }
 
-/// A nominators pending deposit in SSC that needs to be converted to shares once domain epoch is complete.
+/// A nominators pending deposit in AI3 that needs to be converted to shares once domain epoch is complete.
 #[derive(TypeInfo, Debug, Encode, Decode, Copy, Clone, PartialEq, Eq)]
 pub(crate) struct PendingDeposit<Balance: Copy> {
     pub(crate) effective_domain_epoch: DomainEpoch,
@@ -1218,7 +1218,7 @@ pub(crate) fn do_unlock_nominator<T: Config>(
         }
 
         // if there are any withdrawals from this operator, account for them
-        // if the withdrawals has share price noted, then convert them to SSC
+        // if the withdrawals has share price noted, then convert them to AI3
         // if no share price, then it must be intitated in the epoch before operator de-registered,
         // so get the shares as is and include them in the total staked shares.
         let (
@@ -1532,7 +1532,7 @@ pub(crate) mod tests {
     use sp_runtime::{PerThing, Perbill, Percent};
     use std::collections::{BTreeMap, BTreeSet};
     use std::vec;
-    use subspace_runtime_primitives::SSC;
+    use subspace_runtime_primitives::AI3;
 
     type Balances = pallet_balances::Pallet<Test>;
     type Domains = crate::Pallet<Test>;
@@ -1685,10 +1685,10 @@ pub(crate) mod tests {
     fn test_register_operator() {
         let domain_id = DomainId::new(0);
         let operator_account = 1;
-        let operator_free_balance = 2500 * SSC;
-        let operator_total_stake = 1000 * SSC;
-        let operator_stake = 800 * SSC;
-        let operator_storage_fee_deposit = 200 * SSC;
+        let operator_free_balance = 2500 * AI3;
+        let operator_total_stake = 1000 * AI3;
+        let operator_stake = 800 * AI3;
+        let operator_storage_fee_deposit = 200 * AI3;
         let pair = OperatorPair::from_seed(&[0; 32]);
 
         let mut ext = new_test_ext();
@@ -1698,7 +1698,7 @@ pub(crate) mod tests {
                 operator_account,
                 operator_free_balance,
                 operator_total_stake,
-                SSC,
+                AI3,
                 pair.public(),
                 BTreeMap::new(),
             );
@@ -1715,7 +1715,7 @@ pub(crate) mod tests {
                     signing_key: pair.public(),
                     current_domain_id: domain_id,
                     next_domain_id: domain_id,
-                    minimum_nominator_stake: SSC,
+                    minimum_nominator_stake: AI3,
                     nomination_tax: Default::default(),
                     current_total_stake: operator_stake,
                     current_total_shares: operator_stake,
@@ -1767,17 +1767,17 @@ pub(crate) mod tests {
     fn nominate_operator() {
         let domain_id = DomainId::new(0);
         let operator_account = 1;
-        let operator_free_balance = 1500 * SSC;
-        let operator_total_stake = 1000 * SSC;
-        let operator_stake = 800 * SSC;
-        let operator_storage_fee_deposit = 200 * SSC;
+        let operator_free_balance = 1500 * AI3;
+        let operator_total_stake = 1000 * AI3;
+        let operator_stake = 800 * AI3;
+        let operator_storage_fee_deposit = 200 * AI3;
         let pair = OperatorPair::from_seed(&[0; 32]);
 
         let nominator_account = 2;
-        let nominator_free_balance = 150 * SSC;
-        let nominator_total_stake = 100 * SSC;
-        let nominator_stake = 80 * SSC;
-        let nominator_storage_fee_deposit = 20 * SSC;
+        let nominator_free_balance = 150 * AI3;
+        let nominator_total_stake = 100 * AI3;
+        let nominator_stake = 80 * AI3;
+        let nominator_storage_fee_deposit = 20 * AI3;
 
         let mut ext = new_test_ext();
         ext.execute_with(|| {
@@ -1786,7 +1786,7 @@ pub(crate) mod tests {
                 operator_account,
                 operator_free_balance,
                 operator_total_stake,
-                10 * SSC,
+                10 * AI3,
                 pair.public(),
                 BTreeMap::from_iter(vec![(
                     nominator_account,
@@ -1823,9 +1823,9 @@ pub(crate) mod tests {
             );
 
             // another transfer with an existing transfer in place should lead to single
-            let addtional_nomination_total_stake = 40 * SSC;
-            let addtional_nomination_stake = 32 * SSC;
-            let addtional_nomination_storage_fee_deposit = 8 * SSC;
+            let addtional_nomination_total_stake = 40 * AI3;
+            let addtional_nomination_stake = 32 * AI3;
+            let addtional_nomination_storage_fee_deposit = 8 * AI3;
             let res = Domains::nominate_operator(
                 RuntimeOrigin::signed(nominator_account),
                 operator_id,
@@ -1882,8 +1882,8 @@ pub(crate) mod tests {
     fn operator_deregistration() {
         let domain_id = DomainId::new(0);
         let operator_account = 1;
-        let operator_stake = 200 * SSC;
-        let operator_free_balance = 250 * SSC;
+        let operator_stake = 200 * AI3;
+        let operator_free_balance = 250 * AI3;
         let pair = OperatorPair::from_seed(&[0; 32]);
         let mut ext = new_test_ext();
         ext.execute_with(|| {
@@ -1892,7 +1892,7 @@ pub(crate) mod tests {
                 operator_account,
                 operator_free_balance,
                 operator_stake,
-                SSC,
+                AI3,
                 pair.public(),
                 BTreeMap::new(),
             );
@@ -1953,7 +1953,7 @@ pub(crate) mod tests {
 
             // nominations will not work since the is frozen
             let nominator_account = 100;
-            let nominator_stake = 100 * SSC;
+            let nominator_stake = 100 * AI3;
             let res = Domains::nominate_operator(
                 RuntimeOrigin::signed(nominator_account),
                 operator_id,
@@ -1973,7 +1973,7 @@ pub(crate) mod tests {
     /// since ED is not holded back from usable balance when there are no holds on the account.
     type ExpectedWithdrawAmount = Option<(BalanceOf<Test>, bool)>;
 
-    /// The storage fund change in SSC, `true` means increase of the storage fund, `false` means decrease.
+    /// The storage fund change in AI3, `true` means increase of the storage fund, `false` means decrease.
     type StorageFundChange = (bool, u32);
 
     pub(crate) type Share = <Test as Config>::Share;
@@ -2059,15 +2059,15 @@ pub(crate) mod tests {
             let (is_storage_fund_increased, storage_fund_change_amount) = storage_fund_change;
             if is_storage_fund_increased {
                 bundle_storage_fund::refund_storage_fee::<Test>(
-                    storage_fund_change_amount as u128 * SSC,
+                    storage_fund_change_amount as u128 * AI3,
                     BTreeMap::from_iter([(operator_id, 1)]),
                 )
                 .unwrap();
                 assert_eq!(
-                    operator.total_storage_fee_deposit + storage_fund_change_amount as u128 * SSC,
+                    operator.total_storage_fee_deposit + storage_fund_change_amount as u128 * AI3,
                     bundle_storage_fund::total_balance::<Test>(operator_id)
                 );
-                total_balance += storage_fund_change_amount as u128 * SSC;
+                total_balance += storage_fund_change_amount as u128 * AI3;
             } else {
                 bundle_storage_fund::charge_bundle_storage_fee::<Test>(
                     operator_id,
@@ -2075,10 +2075,10 @@ pub(crate) mod tests {
                 )
                 .unwrap();
                 assert_eq!(
-                    operator.total_storage_fee_deposit - storage_fund_change_amount as u128 * SSC,
+                    operator.total_storage_fee_deposit - storage_fund_change_amount as u128 * AI3,
                     bundle_storage_fund::total_balance::<Test>(operator_id)
                 );
-                total_balance -= storage_fund_change_amount as u128 * SSC;
+                total_balance -= storage_fund_change_amount as u128 * AI3;
             }
 
             for (withdraw, expected_result) in withdraws {
@@ -2145,11 +2145,11 @@ pub(crate) mod tests {
     #[test]
     fn withdraw_stake_operator_all() {
         withdraw_stake(WithdrawParams {
-            minimum_nominator_stake: 10 * SSC,
-            nominators: vec![(0, 150 * SSC), (1, 50 * SSC), (2, 10 * SSC)],
-            operator_reward: 20 * SSC,
+            minimum_nominator_stake: 10 * AI3,
+            nominators: vec![(0, 150 * AI3), (1, 50 * AI3), (2, 10 * AI3)],
+            operator_reward: 20 * AI3,
             nominator_id: 0,
-            withdraws: vec![(150 * SSC, Err(StakingError::MinimumOperatorStake))],
+            withdraws: vec![(150 * AI3, Err(StakingError::MinimumOperatorStake))],
             maybe_deposit: None,
             expected_withdraw: None,
             expected_nominator_count_reduced_by: 0,
@@ -2160,11 +2160,11 @@ pub(crate) mod tests {
     #[test]
     fn withdraw_stake_operator_below_minimum() {
         withdraw_stake(WithdrawParams {
-            minimum_nominator_stake: 10 * SSC,
-            nominators: vec![(0, 150 * SSC), (1, 50 * SSC), (2, 10 * SSC)],
-            operator_reward: 20 * SSC,
+            minimum_nominator_stake: 10 * AI3,
+            nominators: vec![(0, 150 * AI3), (1, 50 * AI3), (2, 10 * AI3)],
+            operator_reward: 20 * AI3,
             nominator_id: 0,
-            withdraws: vec![(65 * SSC, Err(StakingError::MinimumOperatorStake))],
+            withdraws: vec![(65 * AI3, Err(StakingError::MinimumOperatorStake))],
             maybe_deposit: None,
             expected_withdraw: None,
             expected_nominator_count_reduced_by: 0,
@@ -2175,11 +2175,11 @@ pub(crate) mod tests {
     #[test]
     fn withdraw_stake_operator_below_minimum_no_rewards() {
         withdraw_stake(WithdrawParams {
-            minimum_nominator_stake: 10 * SSC,
-            nominators: vec![(0, 150 * SSC), (1, 50 * SSC), (2, 10 * SSC)],
+            minimum_nominator_stake: 10 * AI3,
+            nominators: vec![(0, 150 * AI3), (1, 50 * AI3), (2, 10 * AI3)],
             operator_reward: Zero::zero(),
             nominator_id: 0,
-            withdraws: vec![(51 * SSC, Err(StakingError::MinimumOperatorStake))],
+            withdraws: vec![(51 * AI3, Err(StakingError::MinimumOperatorStake))],
             maybe_deposit: None,
             expected_withdraw: None,
             expected_nominator_count_reduced_by: 0,
@@ -2190,12 +2190,12 @@ pub(crate) mod tests {
     #[test]
     fn withdraw_stake_operator_above_minimum() {
         withdraw_stake(WithdrawParams {
-            minimum_nominator_stake: 10 * SSC,
-            nominators: vec![(0, 150 * SSC), (1, 50 * SSC), (2, 10 * SSC)],
-            operator_reward: 20 * SSC,
+            minimum_nominator_stake: 10 * AI3,
+            nominators: vec![(0, 150 * AI3), (1, 50 * AI3), (2, 10 * AI3)],
+            operator_reward: 20 * AI3,
             nominator_id: 0,
-            withdraws: vec![(58 * SSC, Ok(()))],
-            // given the reward, operator will get 164.28 SSC
+            withdraws: vec![(58 * AI3, Ok(()))],
+            // given the reward, operator will get 164.28 AI3
             // taking 58 shares will give this following approximate amount.
             maybe_deposit: None,
             expected_withdraw: Some((63523809519881179143, false)),
@@ -2207,13 +2207,13 @@ pub(crate) mod tests {
     #[test]
     fn withdraw_stake_operator_above_minimum_multiple_withdraws_error() {
         withdraw_stake(WithdrawParams {
-            minimum_nominator_stake: 10 * SSC,
-            nominators: vec![(0, 150 * SSC), (1, 50 * SSC), (2, 10 * SSC)],
-            operator_reward: 20 * SSC,
+            minimum_nominator_stake: 10 * AI3,
+            nominators: vec![(0, 150 * AI3), (1, 50 * AI3), (2, 10 * AI3)],
+            operator_reward: 20 * AI3,
             nominator_id: 0,
             withdraws: vec![
-                (58 * SSC, Ok(())),
-                (5 * SSC, Err(StakingError::MinimumOperatorStake)),
+                (58 * AI3, Ok(())),
+                (5 * AI3, Err(StakingError::MinimumOperatorStake)),
             ],
             maybe_deposit: None,
             expected_withdraw: Some((63523809519881179143, false)),
@@ -2225,11 +2225,11 @@ pub(crate) mod tests {
     #[test]
     fn withdraw_stake_operator_above_minimum_multiple_withdraws() {
         withdraw_stake(WithdrawParams {
-            minimum_nominator_stake: 10 * SSC,
-            nominators: vec![(0, 150 * SSC), (1, 50 * SSC), (2, 10 * SSC)],
-            operator_reward: 20 * SSC,
+            minimum_nominator_stake: 10 * AI3,
+            nominators: vec![(0, 150 * AI3), (1, 50 * AI3), (2, 10 * AI3)],
+            operator_reward: 20 * AI3,
             nominator_id: 0,
-            withdraws: vec![(53 * SSC, Ok(())), (5 * SSC, Ok(()))],
+            withdraws: vec![(53 * AI3, Ok(())), (5 * AI3, Ok(()))],
             maybe_deposit: None,
             expected_withdraw: Some((63523809515796643053, false)),
             expected_nominator_count_reduced_by: 0,
@@ -2240,11 +2240,11 @@ pub(crate) mod tests {
     #[test]
     fn withdraw_stake_operator_above_minimum_no_rewards() {
         withdraw_stake(WithdrawParams {
-            minimum_nominator_stake: 10 * SSC,
-            nominators: vec![(0, 150 * SSC), (1, 50 * SSC), (2, 10 * SSC)],
+            minimum_nominator_stake: 10 * AI3,
+            nominators: vec![(0, 150 * AI3), (1, 50 * AI3), (2, 10 * AI3)],
             operator_reward: Zero::zero(),
             nominator_id: 0,
-            withdraws: vec![(49 * SSC, Ok(()))],
+            withdraws: vec![(49 * AI3, Ok(()))],
             maybe_deposit: None,
             expected_withdraw: Some((48999999980000000000, false)),
             expected_nominator_count_reduced_by: 0,
@@ -2255,11 +2255,11 @@ pub(crate) mod tests {
     #[test]
     fn withdraw_stake_operator_above_minimum_multiple_withdraws_no_rewards() {
         withdraw_stake(WithdrawParams {
-            minimum_nominator_stake: 10 * SSC,
-            nominators: vec![(0, 150 * SSC), (1, 50 * SSC), (2, 10 * SSC)],
+            minimum_nominator_stake: 10 * AI3,
+            nominators: vec![(0, 150 * AI3), (1, 50 * AI3), (2, 10 * AI3)],
             operator_reward: Zero::zero(),
             nominator_id: 0,
-            withdraws: vec![(29 * SSC, Ok(())), (20 * SSC, Ok(()))],
+            withdraws: vec![(29 * AI3, Ok(())), (20 * AI3, Ok(()))],
             maybe_deposit: None,
             expected_withdraw: Some((48999999986852892560, false)),
             expected_nominator_count_reduced_by: 0,
@@ -2270,14 +2270,14 @@ pub(crate) mod tests {
     #[test]
     fn withdraw_stake_operator_above_minimum_multiple_withdraws_no_rewards_with_errors() {
         withdraw_stake(WithdrawParams {
-            minimum_nominator_stake: 10 * SSC,
-            nominators: vec![(0, 150 * SSC), (1, 50 * SSC), (2, 10 * SSC)],
+            minimum_nominator_stake: 10 * AI3,
+            nominators: vec![(0, 150 * AI3), (1, 50 * AI3), (2, 10 * AI3)],
             operator_reward: Zero::zero(),
             nominator_id: 0,
             withdraws: vec![
-                (29 * SSC, Ok(())),
-                (20 * SSC, Ok(())),
-                (20 * SSC, Err(StakingError::MinimumOperatorStake)),
+                (29 * AI3, Ok(())),
+                (20 * AI3, Ok(())),
+                (20 * AI3, Err(StakingError::MinimumOperatorStake)),
             ],
             maybe_deposit: None,
             expected_withdraw: Some((48999999986852892560, false)),
@@ -2289,11 +2289,11 @@ pub(crate) mod tests {
     #[test]
     fn withdraw_stake_nominator_below_minimum_with_rewards() {
         withdraw_stake(WithdrawParams {
-            minimum_nominator_stake: 10 * SSC,
-            nominators: vec![(0, 150 * SSC), (1, 50 * SSC), (2, 10 * SSC)],
-            operator_reward: 20 * SSC,
+            minimum_nominator_stake: 10 * AI3,
+            nominators: vec![(0, 150 * AI3), (1, 50 * AI3), (2, 10 * AI3)],
+            operator_reward: 20 * AI3,
             nominator_id: 1,
-            withdraws: vec![(45 * SSC, Ok(()))],
+            withdraws: vec![(45 * AI3, Ok(()))],
             // given nominator remaining stake goes below minimum
             // we withdraw everything, so for their 50 shares with reward,
             // price would be following
@@ -2307,11 +2307,11 @@ pub(crate) mod tests {
     #[test]
     fn withdraw_stake_nominator_below_minimum_with_rewards_multiple_withdraws() {
         withdraw_stake(WithdrawParams {
-            minimum_nominator_stake: 10 * SSC,
-            nominators: vec![(0, 150 * SSC), (1, 50 * SSC), (2, 10 * SSC)],
-            operator_reward: 20 * SSC,
+            minimum_nominator_stake: 10 * AI3,
+            nominators: vec![(0, 150 * AI3), (1, 50 * AI3), (2, 10 * AI3)],
+            operator_reward: 20 * AI3,
             nominator_id: 1,
-            withdraws: vec![(25 * SSC, Ok(())), (20 * SSC, Ok(()))],
+            withdraws: vec![(25 * AI3, Ok(())), (20 * AI3, Ok(()))],
             // given nominator remaining stake goes below minimum
             // we withdraw everything, so for their 50 shares with reward,
             // price would be following
@@ -2325,14 +2325,14 @@ pub(crate) mod tests {
     #[test]
     fn withdraw_stake_nominator_below_minimum_with_rewards_multiple_withdraws_with_errors() {
         withdraw_stake(WithdrawParams {
-            minimum_nominator_stake: 10 * SSC,
-            nominators: vec![(0, 150 * SSC), (1, 50 * SSC), (2, 10 * SSC)],
-            operator_reward: 20 * SSC,
+            minimum_nominator_stake: 10 * AI3,
+            nominators: vec![(0, 150 * AI3), (1, 50 * AI3), (2, 10 * AI3)],
+            operator_reward: 20 * AI3,
             nominator_id: 1,
             withdraws: vec![
-                (25 * SSC, Ok(())),
-                (20 * SSC, Ok(())),
-                (20 * SSC, Err(StakingError::InsufficientShares)),
+                (25 * AI3, Ok(())),
+                (20 * AI3, Ok(())),
+                (20 * AI3, Err(StakingError::InsufficientShares)),
             ],
             // given nominator remaining stake goes below minimum
             // we withdraw everything, so for their 50 shares with reward,
@@ -2347,13 +2347,13 @@ pub(crate) mod tests {
     #[test]
     fn withdraw_stake_nominator_below_minimum_no_reward() {
         withdraw_stake(WithdrawParams {
-            minimum_nominator_stake: 10 * SSC,
-            nominators: vec![(0, 150 * SSC), (1, 50 * SSC), (2, 10 * SSC)],
+            minimum_nominator_stake: 10 * AI3,
+            nominators: vec![(0, 150 * AI3), (1, 50 * AI3), (2, 10 * AI3)],
             operator_reward: Zero::zero(),
             nominator_id: 1,
-            withdraws: vec![(45 * SSC, Ok(()))],
+            withdraws: vec![(45 * AI3, Ok(()))],
             maybe_deposit: None,
-            expected_withdraw: Some((50 * SSC, true)),
+            expected_withdraw: Some((50 * AI3, true)),
             expected_nominator_count_reduced_by: 1,
             storage_fund_change: (true, 0),
         })
@@ -2362,13 +2362,13 @@ pub(crate) mod tests {
     #[test]
     fn withdraw_stake_nominator_below_minimum_no_reward_multiple_rewards() {
         withdraw_stake(WithdrawParams {
-            minimum_nominator_stake: 10 * SSC,
-            nominators: vec![(0, 150 * SSC), (1, 50 * SSC), (2, 10 * SSC)],
+            minimum_nominator_stake: 10 * AI3,
+            nominators: vec![(0, 150 * AI3), (1, 50 * AI3), (2, 10 * AI3)],
             operator_reward: Zero::zero(),
             nominator_id: 1,
-            withdraws: vec![(25 * SSC, Ok(())), (20 * SSC, Ok(()))],
+            withdraws: vec![(25 * AI3, Ok(())), (20 * AI3, Ok(()))],
             maybe_deposit: None,
-            expected_withdraw: Some((50 * SSC, true)),
+            expected_withdraw: Some((50 * AI3, true)),
             expected_nominator_count_reduced_by: 1,
             storage_fund_change: (true, 0),
         })
@@ -2377,17 +2377,17 @@ pub(crate) mod tests {
     #[test]
     fn withdraw_stake_nominator_below_minimum_no_reward_multiple_rewards_with_errors() {
         withdraw_stake(WithdrawParams {
-            minimum_nominator_stake: 10 * SSC,
-            nominators: vec![(0, 150 * SSC), (1, 50 * SSC), (2, 10 * SSC)],
+            minimum_nominator_stake: 10 * AI3,
+            nominators: vec![(0, 150 * AI3), (1, 50 * AI3), (2, 10 * AI3)],
             operator_reward: Zero::zero(),
             nominator_id: 1,
             withdraws: vec![
-                (25 * SSC, Ok(())),
-                (20 * SSC, Ok(())),
-                (20 * SSC, Err(StakingError::InsufficientShares)),
+                (25 * AI3, Ok(())),
+                (20 * AI3, Ok(())),
+                (20 * AI3, Err(StakingError::InsufficientShares)),
             ],
             maybe_deposit: None,
-            expected_withdraw: Some((50 * SSC, true)),
+            expected_withdraw: Some((50 * AI3, true)),
             expected_nominator_count_reduced_by: 1,
             storage_fund_change: (true, 0),
         })
@@ -2396,11 +2396,11 @@ pub(crate) mod tests {
     #[test]
     fn withdraw_stake_nominator_above_minimum() {
         withdraw_stake(WithdrawParams {
-            minimum_nominator_stake: 10 * SSC,
-            nominators: vec![(0, 150 * SSC), (1, 50 * SSC), (2, 10 * SSC)],
-            operator_reward: 20 * SSC,
+            minimum_nominator_stake: 10 * AI3,
+            nominators: vec![(0, 150 * AI3), (1, 50 * AI3), (2, 10 * AI3)],
+            operator_reward: 20 * AI3,
             nominator_id: 1,
-            withdraws: vec![(40 * SSC, Ok(()))],
+            withdraws: vec![(40 * AI3, Ok(()))],
             maybe_deposit: None,
             expected_withdraw: Some((43809523820607709753, false)),
             expected_nominator_count_reduced_by: 0,
@@ -2411,11 +2411,11 @@ pub(crate) mod tests {
     #[test]
     fn withdraw_stake_nominator_above_minimum_multiple_withdraws() {
         withdraw_stake(WithdrawParams {
-            minimum_nominator_stake: 10 * SSC,
-            nominators: vec![(0, 150 * SSC), (1, 50 * SSC), (2, 10 * SSC)],
-            operator_reward: 20 * SSC,
+            minimum_nominator_stake: 10 * AI3,
+            nominators: vec![(0, 150 * AI3), (1, 50 * AI3), (2, 10 * AI3)],
+            operator_reward: 20 * AI3,
             nominator_id: 1,
-            withdraws: vec![(35 * SSC, Ok(())), (5 * SSC, Ok(()))],
+            withdraws: vec![(35 * AI3, Ok(())), (5 * AI3, Ok(()))],
             maybe_deposit: None,
             expected_withdraw: Some((43809523819607709753, false)),
             expected_nominator_count_reduced_by: 0,
@@ -2426,14 +2426,14 @@ pub(crate) mod tests {
     #[test]
     fn withdraw_stake_nominator_above_minimum_withdraw_all_multiple_withdraws_error() {
         withdraw_stake(WithdrawParams {
-            minimum_nominator_stake: 10 * SSC,
-            nominators: vec![(0, 150 * SSC), (1, 50 * SSC), (2, 10 * SSC)],
-            operator_reward: 20 * SSC,
+            minimum_nominator_stake: 10 * AI3,
+            nominators: vec![(0, 150 * AI3), (1, 50 * AI3), (2, 10 * AI3)],
+            operator_reward: 20 * AI3,
             nominator_id: 1,
             withdraws: vec![
-                (35 * SSC, Ok(())),
-                (5 * SSC, Ok(())),
-                (15 * SSC, Err(StakingError::InsufficientShares)),
+                (35 * AI3, Ok(())),
+                (5 * AI3, Ok(())),
+                (15 * AI3, Err(StakingError::InsufficientShares)),
             ],
             maybe_deposit: None,
             expected_withdraw: Some((43809523819607709753, false)),
@@ -2445,13 +2445,13 @@ pub(crate) mod tests {
     #[test]
     fn withdraw_stake_nominator_above_minimum_no_rewards() {
         withdraw_stake(WithdrawParams {
-            minimum_nominator_stake: 10 * SSC,
-            nominators: vec![(0, 150 * SSC), (1, 50 * SSC), (2, 10 * SSC)],
+            minimum_nominator_stake: 10 * AI3,
+            nominators: vec![(0, 150 * AI3), (1, 50 * AI3), (2, 10 * AI3)],
             operator_reward: Zero::zero(),
             nominator_id: 1,
-            withdraws: vec![(39 * SSC, Ok(()))],
+            withdraws: vec![(39 * AI3, Ok(()))],
             maybe_deposit: None,
-            expected_withdraw: Some((39 * SSC, false)),
+            expected_withdraw: Some((39 * AI3, false)),
             expected_nominator_count_reduced_by: 0,
             storage_fund_change: (true, 0),
         })
@@ -2460,11 +2460,11 @@ pub(crate) mod tests {
     #[test]
     fn withdraw_stake_nominator_above_minimum_no_rewards_multiple_withdraws() {
         withdraw_stake(WithdrawParams {
-            minimum_nominator_stake: 10 * SSC,
-            nominators: vec![(0, 150 * SSC), (1, 50 * SSC), (2, 10 * SSC)],
+            minimum_nominator_stake: 10 * AI3,
+            nominators: vec![(0, 150 * AI3), (1, 50 * AI3), (2, 10 * AI3)],
             operator_reward: Zero::zero(),
             nominator_id: 1,
-            withdraws: vec![(35 * SSC, Ok(())), (5 * SSC - 100000000000, Ok(()))],
+            withdraws: vec![(35 * AI3, Ok(())), (5 * AI3 - 100000000000, Ok(()))],
             maybe_deposit: None,
             expected_withdraw: Some((39999999898000000000, false)),
             expected_nominator_count_reduced_by: 0,
@@ -2475,14 +2475,14 @@ pub(crate) mod tests {
     #[test]
     fn withdraw_stake_nominator_above_minimum_no_rewards_multiple_withdraws_with_errors() {
         withdraw_stake(WithdrawParams {
-            minimum_nominator_stake: 10 * SSC,
-            nominators: vec![(0, 150 * SSC), (1, 50 * SSC), (2, 10 * SSC)],
+            minimum_nominator_stake: 10 * AI3,
+            nominators: vec![(0, 150 * AI3), (1, 50 * AI3), (2, 10 * AI3)],
             operator_reward: Zero::zero(),
             nominator_id: 1,
             withdraws: vec![
-                (35 * SSC, Ok(())),
-                (5 * SSC - 100000000000, Ok(())),
-                (15 * SSC, Err(StakingError::InsufficientShares)),
+                (35 * AI3, Ok(())),
+                (5 * AI3 - 100000000000, Ok(())),
+                (15 * AI3, Err(StakingError::InsufficientShares)),
             ],
             maybe_deposit: None,
             expected_withdraw: Some((39999999898000000000, false)),
@@ -2494,16 +2494,16 @@ pub(crate) mod tests {
     #[test]
     fn withdraw_stake_nominator_no_rewards_multiple_withdraws_with_error_min_nominator_stake() {
         withdraw_stake(WithdrawParams {
-            minimum_nominator_stake: 10 * SSC,
-            nominators: vec![(0, 150 * SSC), (1, 50 * SSC), (2, 10 * SSC)],
+            minimum_nominator_stake: 10 * AI3,
+            nominators: vec![(0, 150 * AI3), (1, 50 * AI3), (2, 10 * AI3)],
             operator_reward: Zero::zero(),
             nominator_id: 1,
             withdraws: vec![
-                (35 * SSC, Ok(())),
-                (5 * SSC - 100000000000, Ok(())),
-                (10 * SSC, Err(StakingError::MinimumNominatorStake)),
+                (35 * AI3, Ok(())),
+                (5 * AI3 - 100000000000, Ok(())),
+                (10 * AI3, Err(StakingError::MinimumNominatorStake)),
             ],
-            maybe_deposit: Some(2 * SSC),
+            maybe_deposit: Some(2 * AI3),
             expected_withdraw: Some((39999999898000000000, false)),
             expected_nominator_count_reduced_by: 0,
             storage_fund_change: (true, 0),
@@ -2513,19 +2513,19 @@ pub(crate) mod tests {
     #[test]
     fn withdraw_stake_nominator_with_rewards_multiple_withdraws_with_error_min_nominator_stake() {
         withdraw_stake(WithdrawParams {
-            minimum_nominator_stake: 10 * SSC,
-            nominators: vec![(0, 150 * SSC), (1, 50 * SSC), (2, 10 * SSC)],
-            operator_reward: 20 * SSC,
+            minimum_nominator_stake: 10 * AI3,
+            nominators: vec![(0, 150 * AI3), (1, 50 * AI3), (2, 10 * AI3)],
+            operator_reward: 20 * AI3,
             nominator_id: 1,
             withdraws: vec![
-                (35 * SSC, Ok(())),
-                (5 * SSC, Ok(())),
-                (10 * SSC, Err(StakingError::MinimumNominatorStake)),
+                (35 * AI3, Ok(())),
+                (5 * AI3, Ok(())),
+                (10 * AI3, Err(StakingError::MinimumNominatorStake)),
             ],
             // given nominator remaining stake goes below minimum
             // we withdraw everything, so for their 50 shares with reward,
             // price would be following
-            maybe_deposit: Some(2 * SSC),
+            maybe_deposit: Some(2 * AI3),
             expected_withdraw: Some((43809523819607709753, false)),
             expected_nominator_count_reduced_by: 0,
             storage_fund_change: (true, 0),
@@ -2535,8 +2535,8 @@ pub(crate) mod tests {
     #[test]
     fn withdraw_stake_nominator_zero_amount() {
         withdraw_stake(WithdrawParams {
-            minimum_nominator_stake: 10 * SSC,
-            nominators: vec![(0, 150 * SSC), (1, 50 * SSC), (2, 10 * SSC)],
+            minimum_nominator_stake: 10 * AI3,
+            nominators: vec![(0, 150 * AI3), (1, 50 * AI3), (2, 10 * AI3)],
             operator_reward: Zero::zero(),
             nominator_id: 1,
             withdraws: vec![(0, Err(StakingError::ZeroWithdraw))],
@@ -2550,14 +2550,14 @@ pub(crate) mod tests {
     #[test]
     fn withdraw_stake_nominator_all_with_storage_fee_profit() {
         withdraw_stake(WithdrawParams {
-            minimum_nominator_stake: 10 * SSC,
-            nominators: vec![(0, 150 * SSC), (1, 50 * SSC), (2, 10 * SSC)],
+            minimum_nominator_stake: 10 * AI3,
+            nominators: vec![(0, 150 * AI3), (1, 50 * AI3), (2, 10 * AI3)],
             operator_reward: Zero::zero(),
             nominator_id: 1,
-            withdraws: vec![(50 * SSC, Ok(()))],
+            withdraws: vec![(50 * AI3, Ok(()))],
             maybe_deposit: None,
-            // The storage fund increased 50% (i.e. 21 * SSC) thus the nominator make 50%
-            // storage fee profit i.e. 5 * SSC with rounding dust deducted
+            // The storage fund increased 50% (i.e. 21 * AI3) thus the nominator make 50%
+            // storage fee profit i.e. 5 * AI3 with rounding dust deducted
             storage_fund_change: (true, 21),
             expected_withdraw: Some((54999999994000000000, true)),
             expected_nominator_count_reduced_by: 1,
@@ -2567,14 +2567,14 @@ pub(crate) mod tests {
     #[test]
     fn withdraw_stake_nominator_all_with_storage_fee_loss() {
         withdraw_stake(WithdrawParams {
-            minimum_nominator_stake: 10 * SSC,
-            nominators: vec![(0, 150 * SSC), (1, 50 * SSC), (2, 10 * SSC)],
+            minimum_nominator_stake: 10 * AI3,
+            nominators: vec![(0, 150 * AI3), (1, 50 * AI3), (2, 10 * AI3)],
             operator_reward: Zero::zero(),
             nominator_id: 1,
-            withdraws: vec![(50 * SSC, Ok(()))],
+            withdraws: vec![(50 * AI3, Ok(()))],
             maybe_deposit: None,
-            // The storage fund decreased 50% (i.e. 21 * SSC) thus the nominator loss 50%
-            // storage fee deposit i.e. 5 * SSC with rounding dust deducted
+            // The storage fund decreased 50% (i.e. 21 * AI3) thus the nominator loss 50%
+            // storage fee deposit i.e. 5 * AI3 with rounding dust deducted
             storage_fund_change: (false, 21),
             expected_withdraw: Some((44999999998000000000, true)),
             expected_nominator_count_reduced_by: 1,
@@ -2584,16 +2584,16 @@ pub(crate) mod tests {
     #[test]
     fn withdraw_stake_nominator_all_with_storage_fee_loss_all() {
         withdraw_stake(WithdrawParams {
-            minimum_nominator_stake: 10 * SSC,
-            nominators: vec![(0, 150 * SSC), (1, 50 * SSC), (2, 10 * SSC)],
+            minimum_nominator_stake: 10 * AI3,
+            nominators: vec![(0, 150 * AI3), (1, 50 * AI3), (2, 10 * AI3)],
             operator_reward: Zero::zero(),
             nominator_id: 1,
-            withdraws: vec![(50 * SSC, Ok(()))],
+            withdraws: vec![(50 * AI3, Ok(()))],
             maybe_deposit: None,
-            // The storage fund decreased 100% (i.e. 42 * SSC) thus the nominator loss 100%
-            // storage fee deposit i.e. 10 * SSC
+            // The storage fund decreased 100% (i.e. 42 * AI3) thus the nominator loss 100%
+            // storage fee deposit i.e. 10 * AI3
             storage_fund_change: (false, 42),
-            expected_withdraw: Some((40 * SSC, true)),
+            expected_withdraw: Some((40 * AI3, true)),
             expected_nominator_count_reduced_by: 1,
         })
     }
@@ -2601,17 +2601,17 @@ pub(crate) mod tests {
     #[test]
     fn withdraw_stake_nominator_multiple_withdraws_with_storage_fee_profit() {
         withdraw_stake(WithdrawParams {
-            minimum_nominator_stake: 10 * SSC,
-            nominators: vec![(0, 150 * SSC), (1, 50 * SSC), (2, 10 * SSC)],
+            minimum_nominator_stake: 10 * AI3,
+            nominators: vec![(0, 150 * AI3), (1, 50 * AI3), (2, 10 * AI3)],
             operator_reward: Zero::zero(),
             nominator_id: 1,
-            withdraws: vec![(5 * SSC, Ok(())), (10 * SSC, Ok(())), (15 * SSC, Ok(()))],
+            withdraws: vec![(5 * AI3, Ok(())), (10 * AI3, Ok(())), (15 * AI3, Ok(()))],
             maybe_deposit: None,
-            // The storage fund increased 50% (i.e. 21 * SSC) thus the nominator make 50%
-            // storage fee profit i.e. 5 * SSC with rounding dust deducted, withdraw 60% of
+            // The storage fund increased 50% (i.e. 21 * AI3) thus the nominator make 50%
+            // storage fee profit i.e. 5 * AI3 with rounding dust deducted, withdraw 60% of
             // the stake and the storage fee profit
             storage_fund_change: (true, 21),
-            expected_withdraw: Some((30 * SSC + 2999999855527204374, false)),
+            expected_withdraw: Some((30 * AI3 + 2999999855527204374, false)),
             expected_nominator_count_reduced_by: 0,
         })
     }
@@ -2619,17 +2619,17 @@ pub(crate) mod tests {
     #[test]
     fn withdraw_stake_nominator_multiple_withdraws_with_storage_fee_loss() {
         withdraw_stake(WithdrawParams {
-            minimum_nominator_stake: 10 * SSC,
-            nominators: vec![(0, 150 * SSC), (1, 50 * SSC), (2, 10 * SSC)],
+            minimum_nominator_stake: 10 * AI3,
+            nominators: vec![(0, 150 * AI3), (1, 50 * AI3), (2, 10 * AI3)],
             operator_reward: Zero::zero(),
             nominator_id: 1,
-            withdraws: vec![(5 * SSC, Ok(())), (5 * SSC, Ok(())), (10 * SSC, Ok(()))],
+            withdraws: vec![(5 * AI3, Ok(())), (5 * AI3, Ok(())), (10 * AI3, Ok(()))],
             maybe_deposit: None,
-            // The storage fund increased 50% (i.e. 21 * SSC) thus the nominator loss 50%
-            // storage fee i.e. 5 * SSC with rounding dust deducted, withdraw 40% of
+            // The storage fund increased 50% (i.e. 21 * AI3) thus the nominator loss 50%
+            // storage fee i.e. 5 * AI3 with rounding dust deducted, withdraw 40% of
             // the stake and 40% of the storage fee loss are deducted
             storage_fund_change: (false, 21),
-            expected_withdraw: Some((20 * SSC - 2 * SSC - 33331097576, false)),
+            expected_withdraw: Some((20 * AI3 - 2 * AI3 - 33331097576, false)),
             expected_nominator_count_reduced_by: 0,
         })
     }
@@ -2638,19 +2638,19 @@ pub(crate) mod tests {
     fn unlock_multiple_withdrawals() {
         let domain_id = DomainId::new(0);
         let operator_account = 1;
-        let operator_free_balance = 250 * SSC;
-        let operator_stake = 200 * SSC;
+        let operator_free_balance = 250 * AI3;
+        let operator_stake = 200 * AI3;
         let pair = OperatorPair::from_seed(&[0; 32]);
         let nominator_account = 2;
-        let nominator_free_balance = 150 * SSC;
-        let nominator_stake = 100 * SSC;
+        let nominator_free_balance = 150 * AI3;
+        let nominator_stake = 100 * AI3;
 
         let nominators = vec![
             (operator_account, (operator_free_balance, operator_stake)),
             (nominator_account, (nominator_free_balance, nominator_stake)),
         ];
 
-        let total_deposit = 300 * SSC;
+        let total_deposit = 300 * AI3;
         let init_total_stake = STORAGE_FEE_RESERVE.left_from_one() * total_deposit;
         let init_total_storage_fund = STORAGE_FEE_RESERVE * total_deposit;
 
@@ -2661,7 +2661,7 @@ pub(crate) mod tests {
                 operator_account,
                 operator_free_balance,
                 operator_stake,
-                10 * SSC,
+                10 * AI3,
                 pair.public(),
                 BTreeMap::from_iter(nominators),
             );
@@ -2769,29 +2769,29 @@ pub(crate) mod tests {
     fn slash_operator() {
         let domain_id = DomainId::new(0);
         let operator_account = 1;
-        let operator_free_balance = 250 * SSC;
-        let operator_stake = 200 * SSC;
-        let operator_extra_deposit = 40 * SSC;
+        let operator_free_balance = 250 * AI3;
+        let operator_stake = 200 * AI3;
+        let operator_extra_deposit = 40 * AI3;
         let pair = OperatorPair::from_seed(&[0; 32]);
         let nominator_account = 2;
-        let nominator_free_balance = 150 * SSC;
-        let nominator_stake = 100 * SSC;
-        let nominator_extra_deposit = 40 * SSC;
+        let nominator_free_balance = 150 * AI3;
+        let nominator_stake = 100 * AI3;
+        let nominator_extra_deposit = 40 * AI3;
 
         let nominators = vec![
             (operator_account, (operator_free_balance, operator_stake)),
             (nominator_account, (nominator_free_balance, nominator_stake)),
         ];
 
-        let unlocking = vec![(operator_account, 10 * SSC), (nominator_account, 10 * SSC)];
+        let unlocking = vec![(operator_account, 10 * AI3), (nominator_account, 10 * AI3)];
 
         let deposits = vec![
             (operator_account, operator_extra_deposit),
             (nominator_account, nominator_extra_deposit),
         ];
 
-        let init_total_stake = STORAGE_FEE_RESERVE.left_from_one() * 300 * SSC;
-        let init_total_storage_fund = STORAGE_FEE_RESERVE * 300 * SSC;
+        let init_total_stake = STORAGE_FEE_RESERVE.left_from_one() * 300 * AI3;
+        let init_total_storage_fund = STORAGE_FEE_RESERVE * 300 * AI3;
 
         let mut ext = new_test_ext();
         ext.execute_with(|| {
@@ -2800,7 +2800,7 @@ pub(crate) mod tests {
                 operator_account,
                 operator_free_balance,
                 operator_stake,
-                10 * SSC,
+                10 * AI3,
                 pair.public(),
                 BTreeMap::from_iter(nominators),
             );
@@ -2826,7 +2826,7 @@ pub(crate) mod tests {
                 domain_id,
                 OperatorRewardSource::Dummy,
                 vec![operator_id].into_iter(),
-                20 * SSC,
+                20 * AI3,
             )
             .unwrap();
             do_finalize_domain_current_epoch::<Test>(domain_id).unwrap();
@@ -2864,7 +2864,7 @@ pub(crate) mod tests {
             assert_eq!(21666666668472222222, total_stake_withdrawal);
             assert_eq!(5000000000000000000, total_storage_fee_withdrawal);
             assert_eq!(
-                320 * SSC,
+                320 * AI3,
                 total_deposit + total_stake_withdrawal + total_storage_fee_withdrawal
             );
             assert_eq!(
@@ -2913,7 +2913,7 @@ pub(crate) mod tests {
                 nominator_free_balance - nominator_stake
             );
 
-            assert!(Balances::total_balance(&crate::tests::TreasuryAccount::get()) >= 320 * SSC);
+            assert!(Balances::total_balance(&crate::tests::TreasuryAccount::get()) >= 320 * AI3);
             assert_eq!(bundle_storage_fund::total_balance::<Test>(operator_id), 0);
         });
     }
@@ -2922,17 +2922,17 @@ pub(crate) mod tests {
     fn slash_operator_with_more_than_max_nominators_to_slash() {
         let domain_id = DomainId::new(0);
         let operator_account = 1;
-        let operator_free_balance = 250 * SSC;
-        let operator_stake = 200 * SSC;
-        let operator_extra_deposit = 40 * SSC;
-        let operator_extra_withdraw = 5 * SSC;
+        let operator_free_balance = 250 * AI3;
+        let operator_stake = 200 * AI3;
+        let operator_extra_deposit = 40 * AI3;
+        let operator_extra_withdraw = 5 * AI3;
         let pair = OperatorPair::from_seed(&[0; 32]);
 
         let nominator_accounts: Vec<crate::tests::AccountId> = (2..22).collect();
-        let nominator_free_balance = 150 * SSC;
-        let nominator_stake = 100 * SSC;
-        let nominator_extra_deposit = 40 * SSC;
-        let nominator_extra_withdraw = 5 * SSC;
+        let nominator_free_balance = 150 * AI3;
+        let nominator_stake = 100 * AI3;
+        let nominator_extra_deposit = 40 * AI3;
+        let nominator_extra_withdraw = 5 * AI3;
 
         let mut nominators = vec![(operator_account, (operator_free_balance, operator_stake))];
         for nominator_account in nominator_accounts.clone() {
@@ -2941,8 +2941,8 @@ pub(crate) mod tests {
 
         let last_nominator_account = nominator_accounts.last().cloned().unwrap();
         let unlocking = vec![
-            (operator_account, 10 * SSC),
-            (last_nominator_account, 10 * SSC),
+            (operator_account, 10 * AI3),
+            (last_nominator_account, 10 * AI3),
         ];
 
         let deposits = vec![
@@ -2956,9 +2956,9 @@ pub(crate) mod tests {
 
         let init_total_stake = STORAGE_FEE_RESERVE.left_from_one()
             * (200 + (100 * nominator_accounts.len() as u128))
-            * SSC;
+            * AI3;
         let init_total_storage_fund =
-            STORAGE_FEE_RESERVE * (200 + (100 * nominator_accounts.len() as u128)) * SSC;
+            STORAGE_FEE_RESERVE * (200 + (100 * nominator_accounts.len() as u128)) * AI3;
 
         let mut ext = new_test_ext();
         ext.execute_with(|| {
@@ -2967,7 +2967,7 @@ pub(crate) mod tests {
                 operator_account,
                 operator_free_balance,
                 operator_stake,
-                10 * SSC,
+                10 * AI3,
                 pair.public(),
                 BTreeMap::from_iter(nominators),
             );
@@ -2993,7 +2993,7 @@ pub(crate) mod tests {
                 domain_id,
                 OperatorRewardSource::Dummy,
                 vec![operator_id].into_iter(),
-                20 * SSC,
+                20 * AI3,
             )
             .unwrap();
             do_finalize_domain_current_epoch::<Test>(domain_id).unwrap();
@@ -3031,7 +3031,7 @@ pub(crate) mod tests {
             assert_eq!(20227272746580578530, total_stake_withdrawal);
             assert_eq!(5000000000000000000, total_storage_fee_withdrawal);
             assert_eq!(
-                2220 * SSC,
+                2220 * AI3,
                 total_deposit + total_stake_withdrawal + total_storage_fee_withdrawal
             );
 
@@ -3098,7 +3098,7 @@ pub(crate) mod tests {
                 );
             }
 
-            assert!(Balances::total_balance(&crate::tests::TreasuryAccount::get()) >= 2220 * SSC);
+            assert!(Balances::total_balance(&crate::tests::TreasuryAccount::get()) >= 2220 * AI3);
             assert_eq!(bundle_storage_fund::total_balance::<Test>(operator_id), 0);
         });
     }
@@ -3106,8 +3106,8 @@ pub(crate) mod tests {
     #[test]
     fn slash_operators() {
         let domain_id = DomainId::new(0);
-        let operator_free_balance = 250 * SSC;
-        let operator_stake = 200 * SSC;
+        let operator_free_balance = 250 * AI3;
+        let operator_stake = 200 * AI3;
 
         let operator_account_1 = 1;
         let operator_account_2 = 2;
@@ -3124,7 +3124,7 @@ pub(crate) mod tests {
                 operator_account_1,
                 operator_free_balance,
                 operator_stake,
-                10 * SSC,
+                10 * AI3,
                 pair_1.public(),
                 Default::default(),
             );
@@ -3134,7 +3134,7 @@ pub(crate) mod tests {
                 operator_account_2,
                 operator_free_balance,
                 operator_stake,
-                10 * SSC,
+                10 * AI3,
                 pair_2.public(),
                 Default::default(),
             );
@@ -3144,7 +3144,7 @@ pub(crate) mod tests {
                 operator_account_3,
                 operator_free_balance,
                 operator_stake,
-                10 * SSC,
+                10 * AI3,
                 pair_3.public(),
                 Default::default(),
             );
@@ -3156,7 +3156,7 @@ pub(crate) mod tests {
             assert!(domain_stake_summary.next_operators.contains(&operator_id_3));
             assert_eq!(
                 domain_stake_summary.current_total_stake,
-                STORAGE_FEE_RESERVE.left_from_one() * 600 * SSC
+                STORAGE_FEE_RESERVE.left_from_one() * 600 * AI3
             );
             for operator_id in [operator_id_1, operator_id_2, operator_id_3] {
                 let operator = Operators::<Test>::get(operator_id).unwrap();
@@ -3229,7 +3229,7 @@ pub(crate) mod tests {
 
             assert_eq!(
                 Balances::total_balance(&crate::tests::TreasuryAccount::get()),
-                600 * SSC
+                600 * AI3
             );
             for operator_id in [operator_id_1, operator_id_2, operator_id_3] {
                 assert_eq!(bundle_storage_fund::total_balance::<Test>(operator_id), 0);
@@ -3241,10 +3241,10 @@ pub(crate) mod tests {
     fn bundle_storage_fund_charged_and_refund_storege_fee() {
         let domain_id = DomainId::new(0);
         let operator_account = 1;
-        let operator_free_balance = 150 * SSC;
-        let operator_total_stake = 100 * SSC;
-        let operator_stake = 80 * SSC;
-        let operator_storage_fee_deposit = 20 * SSC;
+        let operator_free_balance = 150 * AI3;
+        let operator_total_stake = 100 * AI3;
+        let operator_stake = 80 * AI3;
+        let operator_storage_fee_deposit = 20 * AI3;
         let pair = OperatorPair::from_seed(&[0; 32]);
         let nominator_account = 2;
 
@@ -3255,7 +3255,7 @@ pub(crate) mod tests {
                 operator_account,
                 operator_free_balance,
                 operator_total_stake,
-                SSC,
+                AI3,
                 pair.public(),
                 BTreeMap::default(),
             );
@@ -3274,8 +3274,8 @@ pub(crate) mod tests {
             // Drain the bundle storage fund
             bundle_storage_fund::charge_bundle_storage_fee::<Test>(
                 operator_id,
-                // the transaction fee is one SSC per byte thus div SSC here
-                (operator_storage_fee_deposit / SSC) as u32,
+                // the transaction fee is one AI3 per byte thus div AI3 here
+                (operator_storage_fee_deposit / AI3) as u32,
             )
             .unwrap();
             assert_eq!(bundle_storage_fund::total_balance::<Test>(operator_id), 0);
@@ -3285,32 +3285,32 @@ pub(crate) mod tests {
             );
 
             // The operator add more stake thus add deposit to the bundle storage fund
-            do_nominate_operator::<Test>(operator_id, operator_account, 5 * SSC).unwrap();
-            assert_eq!(bundle_storage_fund::total_balance::<Test>(operator_id), SSC);
+            do_nominate_operator::<Test>(operator_id, operator_account, 5 * AI3).unwrap();
+            assert_eq!(bundle_storage_fund::total_balance::<Test>(operator_id), AI3);
 
             bundle_storage_fund::charge_bundle_storage_fee::<Test>(operator_id, 1).unwrap();
             assert_eq!(bundle_storage_fund::total_balance::<Test>(operator_id), 0);
 
             // New nominator add deposit to the bundle storage fund
-            Balances::set_balance(&nominator_account, 100 * SSC);
-            do_nominate_operator::<Test>(operator_id, nominator_account, 5 * SSC).unwrap();
-            assert_eq!(bundle_storage_fund::total_balance::<Test>(operator_id), SSC);
+            Balances::set_balance(&nominator_account, 100 * AI3);
+            do_nominate_operator::<Test>(operator_id, nominator_account, 5 * AI3).unwrap();
+            assert_eq!(bundle_storage_fund::total_balance::<Test>(operator_id), AI3);
 
             bundle_storage_fund::charge_bundle_storage_fee::<Test>(operator_id, 1).unwrap();
             assert_eq!(bundle_storage_fund::total_balance::<Test>(operator_id), 0);
 
             // Refund of the storage fee add deposit to the bundle storage fund
             bundle_storage_fund::refund_storage_fee::<Test>(
-                10 * SSC,
+                10 * AI3,
                 BTreeMap::from_iter([(operator_id, 1), (operator_id + 1, 9)]),
             )
             .unwrap();
-            assert_eq!(bundle_storage_fund::total_balance::<Test>(operator_id), SSC);
+            assert_eq!(bundle_storage_fund::total_balance::<Test>(operator_id), AI3);
 
             // The operator `operator_id + 1` not exist thus the refund storage fee added to treasury
             assert_eq!(
                 Balances::total_balance(&crate::tests::TreasuryAccount::get()),
-                9 * SSC
+                9 * AI3
             );
 
             bundle_storage_fund::charge_bundle_storage_fee::<Test>(operator_id, 1).unwrap();
@@ -3322,19 +3322,19 @@ pub(crate) mod tests {
     fn zero_amount_deposit_and_withdraw() {
         let domain_id = DomainId::new(0);
         let operator_account = 1;
-        let operator_free_balance = 250 * SSC;
-        let operator_stake = 200 * SSC;
+        let operator_free_balance = 250 * AI3;
+        let operator_stake = 200 * AI3;
         let pair = OperatorPair::from_seed(&[0; 32]);
         let nominator_account = 2;
-        let nominator_free_balance = 150 * SSC;
-        let nominator_stake = 100 * SSC;
+        let nominator_free_balance = 150 * AI3;
+        let nominator_stake = 100 * AI3;
 
         let nominators = vec![
             (operator_account, (operator_free_balance, operator_stake)),
             (nominator_account, (nominator_free_balance, nominator_stake)),
         ];
 
-        let total_deposit = 300 * SSC;
+        let total_deposit = 300 * AI3;
         let init_total_stake = STORAGE_FEE_RESERVE.left_from_one() * total_deposit;
 
         let mut ext = new_test_ext();
@@ -3344,7 +3344,7 @@ pub(crate) mod tests {
                 operator_account,
                 operator_free_balance,
                 operator_stake,
-                10 * SSC,
+                10 * AI3,
                 pair.public(),
                 BTreeMap::from_iter(nominators),
             );
@@ -3401,19 +3401,19 @@ pub(crate) mod tests {
     fn deposit_and_withdraw_should_be_rejected_due_to_missing_share_price() {
         let domain_id = DomainId::new(0);
         let operator_account = 1;
-        let operator_free_balance = 250 * SSC;
-        let operator_stake = 200 * SSC;
+        let operator_free_balance = 250 * AI3;
+        let operator_stake = 200 * AI3;
         let pair = OperatorPair::from_seed(&[0; 32]);
         let nominator_account = 2;
-        let nominator_free_balance = 150 * SSC;
-        let nominator_stake = 100 * SSC;
+        let nominator_free_balance = 150 * AI3;
+        let nominator_stake = 100 * AI3;
 
         let nominators = vec![
             (operator_account, (operator_free_balance, operator_stake)),
             (nominator_account, (nominator_free_balance, nominator_stake)),
         ];
 
-        let total_deposit = 300 * SSC;
+        let total_deposit = 300 * AI3;
         let init_total_stake = STORAGE_FEE_RESERVE.left_from_one() * total_deposit;
 
         let mut ext = new_test_ext();
@@ -3423,7 +3423,7 @@ pub(crate) mod tests {
                 operator_account,
                 operator_free_balance,
                 operator_stake,
-                10 * SSC,
+                10 * AI3,
                 pair.public(),
                 BTreeMap::from_iter(nominators),
             );
@@ -3432,11 +3432,11 @@ pub(crate) mod tests {
             let domain_stake_summary = DomainStakingSummary::<Test>::get(domain_id).unwrap();
             assert_eq!(domain_stake_summary.current_total_stake, init_total_stake);
 
-            do_nominate_operator::<Test>(operator_id, nominator_account, 5 * SSC).unwrap();
+            do_nominate_operator::<Test>(operator_id, nominator_account, 5 * AI3).unwrap();
             do_withdraw_stake::<Test>(
                 operator_id,
                 nominator_account,
-                WithdrawStake::Stake(3 * SSC),
+                WithdrawStake::Stake(3 * AI3),
             )
             .unwrap();
 
@@ -3450,7 +3450,7 @@ pub(crate) mod tests {
 
             // Both deposit and withdraw should fail due to the share price is missing unexpectly
             assert_err!(
-                do_nominate_operator::<Test>(operator_id, nominator_account, SSC),
+                do_nominate_operator::<Test>(operator_id, nominator_account, AI3),
                 StakingError::MissingOperatorEpochSharePrice
             );
             assert_err!(
@@ -3468,19 +3468,19 @@ pub(crate) mod tests {
     fn allowed_use_default_share_price_if_missing() {
         let domain_id = DomainId::new(0);
         let operator_account = 1;
-        let operator_free_balance = 250 * SSC;
-        let operator_stake = 200 * SSC;
+        let operator_free_balance = 250 * AI3;
+        let operator_stake = 200 * AI3;
         let pair = OperatorPair::from_seed(&[0; 32]);
         let nominator_account = 2;
-        let nominator_free_balance = 150 * SSC;
-        let nominator_stake = 100 * SSC;
+        let nominator_free_balance = 150 * AI3;
+        let nominator_stake = 100 * AI3;
 
         let nominators = vec![
             (operator_account, (operator_free_balance, operator_stake)),
             (nominator_account, (nominator_free_balance, nominator_stake)),
         ];
 
-        let total_deposit = 300 * SSC;
+        let total_deposit = 300 * AI3;
         let init_total_stake = STORAGE_FEE_RESERVE.left_from_one() * total_deposit;
 
         let mut ext = new_test_ext();
@@ -3490,7 +3490,7 @@ pub(crate) mod tests {
                 operator_account,
                 operator_free_balance,
                 operator_stake,
-                10 * SSC,
+                10 * AI3,
                 pair.public(),
                 BTreeMap::from_iter(nominators),
             );
@@ -3503,7 +3503,7 @@ pub(crate) mod tests {
             do_withdraw_stake::<Test>(
                 operator_id,
                 nominator_account,
-                WithdrawStake::Stake(3 * SSC),
+                WithdrawStake::Stake(3 * AI3),
             )
             .unwrap();
 

--- a/crates/pallet-domains/src/staking_epoch.rs
+++ b/crates/pallet-domains/src/staking_epoch.rs
@@ -553,7 +553,7 @@ mod tests {
     use sp_runtime::traits::Zero;
     use sp_runtime::{PerThing, Percent};
     use std::collections::BTreeMap;
-    use subspace_runtime_primitives::SSC;
+    use subspace_runtime_primitives::AI3;
 
     type Balances = pallet_balances::Pallet<Test>;
 
@@ -567,7 +567,7 @@ mod tests {
         let domain_id = DomainId::new(0);
         let operator_account = 1;
         let pair = OperatorPair::from_seed(&[0; 32]);
-        let minimum_free_balance = 10 * SSC;
+        let minimum_free_balance = 10 * AI3;
         let mut nominators = BTreeMap::from_iter(
             nominators
                 .into_iter()
@@ -593,7 +593,7 @@ mod tests {
                 operator_account,
                 operator_free_balance,
                 operator_stake,
-                10 * SSC,
+                10 * AI3,
                 pair.public(),
                 BTreeMap::from_iter(nominators.clone()),
             );
@@ -627,7 +627,7 @@ mod tests {
 
             // After de-register both deposit and withdraw will be rejected
             assert_err!(
-                do_nominate_operator::<Test>(operator_id, operator_account, SSC),
+                do_nominate_operator::<Test>(operator_id, operator_account, AI3),
                 TransitionError::OperatorNotRegistered
             );
             assert_err!(
@@ -678,10 +678,10 @@ mod tests {
     #[test]
     fn unlock_operator_with_no_rewards() {
         unlock_nominator(
-            vec![(1, 150 * SSC), (2, 50 * SSC), (3, 10 * SSC)],
-            vec![(2, 10 * SSC), (4, 10 * SSC)],
-            vec![(1, 20 * SSC), (2, 10 * SSC)],
-            vec![(1, 150 * SSC), (2, 60 * SSC), (3, 10 * SSC), (4, 10 * SSC)],
+            vec![(1, 150 * AI3), (2, 50 * AI3), (3, 10 * AI3)],
+            vec![(2, 10 * AI3), (4, 10 * AI3)],
+            vec![(1, 20 * AI3), (2, 10 * AI3)],
+            vec![(1, 150 * AI3), (2, 60 * AI3), (3, 10 * AI3), (4, 10 * AI3)],
             0,
         );
     }
@@ -689,16 +689,16 @@ mod tests {
     #[test]
     fn unlock_operator_with_rewards() {
         unlock_nominator(
-            vec![(1, 150 * SSC), (2, 50 * SSC), (3, 10 * SSC)],
-            vec![(2, 10 * SSC), (4, 10 * SSC)],
-            vec![(1, 20 * SSC), (2, 10 * SSC)],
+            vec![(1, 150 * AI3), (2, 50 * AI3), (3, 10 * AI3)],
+            vec![(2, 10 * AI3), (4, 10 * AI3)],
+            vec![(1, 20 * AI3), (2, 10 * AI3)],
             vec![
                 (1, 164285714327278911577),
                 (2, 64761904775759637192),
                 (3, 10952380955151927438),
-                (4, 10 * SSC),
+                (4, 10 * AI3),
             ],
-            20 * SSC,
+            20 * AI3,
         );
     }
 
@@ -720,7 +720,7 @@ mod tests {
             deposits,
         } = params;
 
-        let minimum_free_balance = 10 * SSC;
+        let minimum_free_balance = 10 * AI3;
         let mut nominators = BTreeMap::from_iter(
             nominators
                 .into_iter()
@@ -744,7 +744,7 @@ mod tests {
                 operator_account,
                 operator_free_balance,
                 operator_stake,
-                10 * SSC,
+                10 * AI3,
                 pair.public(),
                 BTreeMap::from_iter(nominators),
             );
@@ -801,20 +801,20 @@ mod tests {
     #[test]
     fn finalize_domain_epoch_no_rewards() {
         finalize_domain_epoch(FinalizeDomainParams {
-            total_deposit: 210 * SSC,
+            total_deposit: 210 * AI3,
             rewards: 0,
-            nominators: vec![(0, 150 * SSC), (1, 50 * SSC), (2, 10 * SSC)],
-            deposits: vec![(1, 50 * SSC), (3, 10 * SSC)],
+            nominators: vec![(0, 150 * AI3), (1, 50 * AI3), (2, 10 * AI3)],
+            deposits: vec![(1, 50 * AI3), (3, 10 * AI3)],
         })
     }
 
     #[test]
     fn finalize_domain_epoch_with_rewards() {
         finalize_domain_epoch(FinalizeDomainParams {
-            total_deposit: 210 * SSC,
-            rewards: 20 * SSC,
-            nominators: vec![(0, 150 * SSC), (1, 50 * SSC), (2, 10 * SSC)],
-            deposits: vec![(1, 50 * SSC), (3, 10 * SSC)],
+            total_deposit: 210 * AI3,
+            rewards: 20 * AI3,
+            nominators: vec![(0, 150 * AI3), (1, 50 * AI3), (2, 10 * AI3)],
+            deposits: vec![(1, 50 * AI3), (3, 10 * AI3)],
         })
     }
 
@@ -823,9 +823,9 @@ mod tests {
         let domain_id = DomainId::new(0);
         let operator_account = 1;
         let pair = OperatorPair::from_seed(&[0; 32]);
-        let operator_rewards = 10 * SSC;
+        let operator_rewards = 10 * AI3;
         let mut nominators =
-            BTreeMap::from_iter(vec![(1, (110 * SSC, 100 * SSC)), (2, (60 * SSC, 50 * SSC))]);
+            BTreeMap::from_iter(vec![(1, (110 * AI3, 100 * AI3)), (2, (60 * AI3, 50 * AI3))]);
 
         let mut ext = new_test_ext();
         ext.execute_with(|| {
@@ -836,7 +836,7 @@ mod tests {
                 operator_account,
                 operator_free_balance,
                 operator_stake,
-                10 * SSC,
+                10 * AI3,
                 pair.public(),
                 BTreeMap::from_iter(nominators),
             );
@@ -866,7 +866,7 @@ mod tests {
                 operator.total_storage_fee_deposit - pre_storage_fund_deposit;
             assert_eq!(
                 operator.current_total_stake - pre_total_stake,
-                (10 * SSC - expected_operator_tax)
+                (10 * AI3 - expected_operator_tax)
             );
 
             let staking_deposit = Deposits::<Test>::get(operator_id, operator_account)

--- a/crates/pallet-domains/src/tests.rs
+++ b/crates/pallet-domains/src/tests.rs
@@ -48,7 +48,7 @@ use subspace_core_primitives::segments::HistorySize;
 use subspace_core_primitives::solutions::SolutionRange;
 use subspace_core_primitives::{SlotNumber, U256 as P256};
 use subspace_runtime_primitives::{
-    ConsensusEventSegmentSize, HoldIdentifier, Moment, Nonce, SSC, StorageFee,
+    AI3, ConsensusEventSegmentSize, HoldIdentifier, Moment, Nonce, StorageFee,
 };
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
@@ -155,17 +155,17 @@ impl pallet_balances::Config for Test {
 }
 
 parameter_types! {
-    pub const MinOperatorStake: Balance = 100 * SSC;
-    pub const MinNominatorStake: Balance = SSC;
+    pub const MinOperatorStake: Balance = 100 * AI3;
+    pub const MinNominatorStake: Balance = AI3;
     pub const StakeWithdrawalLockingPeriod: DomainBlockNumber = 5;
     pub const StakeEpochDuration: DomainBlockNumber = 5;
     pub TreasuryAccount: u128 = PalletId(*b"treasury").into_account_truncating();
-    pub const BlockReward: Balance = 10 * SSC;
+    pub const BlockReward: Balance = 10 * AI3;
     pub const MaxPendingStakingOperation: u32 = 512;
     pub const DomainsPalletId: PalletId = PalletId(*b"domains_");
     pub const DomainChainByteFee: Balance = 1;
     pub const MaxInitialDomainAccounts: u32 = 5;
-    pub const MinInitialDomainAccountBalance: Balance = SSC;
+    pub const MinInitialDomainAccountBalance: Balance = AI3;
     pub const BundleLongevity: u32 = 5;
     pub const WithdrawalLimit: u32 = 10;
 }
@@ -192,7 +192,7 @@ pub struct DummyStorageFee;
 
 impl StorageFee<Balance> for DummyStorageFee {
     fn transaction_byte_fee() -> Balance {
-        SSC
+        AI3
     }
     fn note_storage_fees(_fee: Balance) {}
 }
@@ -550,7 +550,7 @@ pub(crate) fn register_genesis_domain(creator: u128, operator_ids: Vec<OperatorI
 
     let pair = OperatorPair::from_seed(&[0; 32]);
     for operator_id in operator_ids {
-        Operators::<Test>::insert(operator_id, Operator::dummy(domain_id, pair.public(), SSC));
+        Operators::<Test>::insert(operator_id, Operator::dummy(domain_id, pair.public(), AI3));
         OperatorIdOwner::<Test>::insert(operator_id, creator);
     }
 

--- a/crates/sp-domains-fraud-proof/benches/fraud_proof_verification.rs
+++ b/crates/sp-domains-fraud-proof/benches/fraud_proof_verification.rs
@@ -26,7 +26,7 @@ use sp_subspace_mmr::{ConsensusChainMmrLeafProof, MmrProofVerifier as _};
 use std::collections::BTreeMap;
 use std::sync::Arc;
 use subspace_runtime_primitives::opaque::Block;
-use subspace_runtime_primitives::{Balance, BlockHashFor, BlockHashingFor, HeaderFor, SSC};
+use subspace_runtime_primitives::{AI3, Balance, BlockHashFor, BlockHashingFor, HeaderFor};
 use subspace_test_runtime::{MmrProofVerifier, Runtime, StorageKeyProvider, mmr};
 use subspace_test_service::{MockConsensusNode, produce_block_with, produce_blocks};
 use tempfile::TempDir;
@@ -557,8 +557,8 @@ fn invalid_transfers_fraud_proof_verification(c: &mut Criterion) {
     let (_placeholder, mut ext, _, bad_receipt, _, domain_runtime_code, fp) = tokio_handle
         .block_on(prepare_fraud_proof(tokio_handle.clone(), |receipt| {
             receipt.transfers = Transfers {
-                transfers_in: BTreeMap::from([(ChainId::Consensus, 10 * SSC)]),
-                transfers_out: BTreeMap::from([(ChainId::Consensus, 10 * SSC)]),
+                transfers_in: BTreeMap::from([(ChainId::Consensus, 10 * AI3)]),
+                transfers_out: BTreeMap::from([(ChainId::Consensus, 10 * AI3)]),
                 rejected_transfers_claimed: Default::default(),
                 transfers_rejected: Default::default(),
             }

--- a/crates/sp-domains/src/test_ethereum_tx.rs
+++ b/crates/sp-domains/src/test_ethereum_tx.rs
@@ -14,8 +14,8 @@ use sp_core::crypto::AccountId32;
 use sp_core::{H160, H256, U256, keccak_256};
 
 parameter_types! {
-    // `490000` is the genesis evm domain chain id
-    pub const ChainId: u64 = 490000;
+    // `870` is the genesis evm domain chain id
+    pub const ChainId: u64 = 870;
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/crates/subspace-malicious-operator/src/chain_spec.rs
+++ b/crates/subspace-malicious-operator/src/chain_spec.rs
@@ -20,7 +20,7 @@ use subspace_runtime::{
     RewardsConfig, RuntimeConfigsConfig, SubspaceConfig,
 };
 use subspace_runtime_primitives::{
-    AccountId, Balance, BlockNumber, CouncilDemocracyConfigParams, SSC,
+    AI3, AccountId, Balance, BlockNumber, CouncilDemocracyConfigParams,
 };
 
 fn endowed_accounts() -> Vec<(MultiAccountId, Balance)> {
@@ -35,7 +35,7 @@ fn endowed_accounts() -> Vec<(MultiAccountId, Balance)> {
         AccountId20::from(hex!("773539d4Ac0e786233D90A233654ccEE26a613D9")),
     ]
     .into_iter()
-    .map(|k| (AccountId20Converter::convert(k), 1_000_000 * SSC))
+    .map(|k| (AccountId20Converter::convert(k), 1_000_000 * AI3))
     .collect()
 }
 
@@ -166,9 +166,9 @@ pub fn dev_config() -> Result<GenericChainSpec, String> {
                 // Pre-funded accounts
                 vec![
                     (get_account_id_from_seed("Alice"), Balance::MAX / 2),
-                    (get_account_id_from_seed("Bob"), 1_000 * SSC),
-                    (get_account_id_from_seed("Alice//stash"), 1_000 * SSC),
-                    (get_account_id_from_seed("Bob//stash"), 1_000 * SSC),
+                    (get_account_id_from_seed("Bob"), 1_000 * AI3),
+                    (get_account_id_from_seed("Alice//stash"), 1_000 * AI3),
+                    (get_account_id_from_seed("Bob//stash"), 1_000 * AI3),
                 ],
                 GenesisParams {
                     enable_rewards_at: EnableRewardsAt::Manually,
@@ -179,7 +179,7 @@ pub fn dev_config() -> Result<GenericChainSpec, String> {
                     enable_balance_transfers: true,
                     confirmation_depth_k: 5,
                     rewards_config: RewardsConfig {
-                        remaining_issuance: 1_000_000 * SSC,
+                        remaining_issuance: 1_000_000 * AI3,
                         proposer_subsidy_points: Default::default(),
                         voter_subsidy_points: Default::default(),
                     },
@@ -259,7 +259,7 @@ fn subspace_genesis_config(
                 operator_allow_list: genesis_domain_params.operator_allow_list,
                 signing_key: genesis_domain_params.operator_signing_key,
                 nomination_tax: Percent::from_percent(5),
-                minimum_nominator_stake: 100 * SSC,
+                minimum_nominator_stake: 100 * AI3,
                 initial_balances: genesis_domain_params.initial_balances,
                 domain_runtime_config: genesis_domain_params.domain_runtime_config,
             }],

--- a/crates/subspace-node/src/chain_spec.rs
+++ b/crates/subspace-node/src/chain_spec.rs
@@ -22,7 +22,7 @@ use subspace_runtime::{
     SubspaceConfig, SudoConfig, SystemConfig, WASM_BINARY,
 };
 use subspace_runtime_primitives::{
-    AccountId, Balance, BlockNumber, CouncilDemocracyConfigParams, SSC,
+    AI3, AccountId, Balance, BlockNumber, CouncilDemocracyConfigParams,
 };
 
 const SUBSPACE_TELEMETRY_URL: &str = "wss://telemetry.subspace.foundation/submit/";
@@ -56,7 +56,7 @@ fn get_genesis_allocations(contents: &str) -> Vec<(AccountId, Balance)> {
 
     allocations
         .into_iter()
-        .map(|GenesisAllocation(account, balance)| (account, balance.get() * SSC))
+        .map(|GenesisAllocation(account, balance)| (account, balance.get() * AI3))
         .collect()
 }
 
@@ -125,7 +125,7 @@ pub fn mainnet_compiled() -> Result<GenericChainSpec, String> {
                 // TODO: Proper value here
                 confirmation_depth_k: 100,
                 rewards_config: RewardsConfig {
-                    remaining_issuance: 350_000_000 * SSC,
+                    remaining_issuance: 350_000_000 * AI3,
                     proposer_subsidy_points: BoundedVec::try_from(vec![
                         RewardPoint {
                             block: 0,
@@ -289,7 +289,7 @@ pub fn devnet_config_compiled() -> Result<GenericChainSpec, String> {
                 confirmation_depth_k: 100,
                 // TODO: Proper value here
                 rewards_config: RewardsConfig {
-                    remaining_issuance: 1_000_000_000 * SSC,
+                    remaining_issuance: 1_000_000_000 * AI3,
                     proposer_subsidy_points: Default::default(),
                     voter_subsidy_points: Default::default(),
                 },
@@ -334,9 +334,9 @@ pub fn dev_config() -> Result<GenericChainSpec, String> {
                 // Pre-funded accounts
                 vec![
                     (sudo_account.clone(), Balance::MAX / 2),
-                    (get_account_id_from_seed("Bob"), 1_000 * SSC),
-                    (get_account_id_from_seed("Alice//stash"), 1_000 * SSC),
-                    (get_account_id_from_seed("Bob//stash"), 1_000 * SSC),
+                    (get_account_id_from_seed("Bob"), 1_000 * AI3),
+                    (get_account_id_from_seed("Alice//stash"), 1_000 * AI3),
+                    (get_account_id_from_seed("Bob//stash"), 1_000 * AI3),
                 ],
                 GenesisParams {
                     enable_rewards_at: EnableRewardsAt::Manually,
@@ -347,7 +347,7 @@ pub fn dev_config() -> Result<GenericChainSpec, String> {
                     enable_balance_transfers: true,
                     confirmation_depth_k: 5,
                     rewards_config: RewardsConfig {
-                        remaining_issuance: 1_000_000 * SSC,
+                        remaining_issuance: 1_000_000 * AI3,
                         proposer_subsidy_points: Default::default(),
                         voter_subsidy_points: Default::default(),
                     },
@@ -412,7 +412,7 @@ fn subspace_genesis_config(
                     operator_allow_list: genesis_domain.operator_allow_list.clone(),
                     signing_key: genesis_domain.operator_signing_key.clone(),
                     nomination_tax: Percent::from_percent(5),
-                    minimum_nominator_stake: 100 * SSC,
+                    minimum_nominator_stake: 100 * AI3,
                     initial_balances: genesis_domain.initial_balances,
                     domain_runtime_config: genesis_domain.domain_runtime_config,
                 }

--- a/crates/subspace-node/src/domain/auto_id_chain_spec.rs
+++ b/crates/subspace-node/src/domain/auto_id_chain_spec.rs
@@ -16,7 +16,7 @@ use sp_domains::{DomainRuntimeConfig, OperatorAllowList, OperatorPublicKey, Runt
 use sp_runtime::BuildStorage;
 use sp_runtime::traits::Convert;
 use std::collections::BTreeSet;
-use subspace_runtime_primitives::{Balance, SSC};
+use subspace_runtime_primitives::{AI3, Balance};
 
 /// Development keys that will be injected automatically on polkadotjs apps
 fn get_dev_accounts() -> Vec<AccountId32> {
@@ -106,12 +106,12 @@ pub fn get_testnet_endowed_accounts_by_spec_id(spec_id: SpecId) -> Vec<(MultiAcc
     match spec_id {
         SpecId::Dev => get_dev_accounts()
             .into_iter()
-            .map(|acc| (AccountIdConverter::convert(acc), 1_000_000 * SSC))
+            .map(|acc| (AccountIdConverter::convert(acc), 1_000_000 * AI3))
             .collect(),
         SpecId::DevNet => {
             let accounts = get_dev_accounts();
             let alice_account = accounts[0].clone();
-            vec![(AccountIdConverter::convert(alice_account), 1_000_000 * SSC)]
+            vec![(AccountIdConverter::convert(alice_account), 1_000_000 * AI3)]
         }
         SpecId::Taurus => vec![],
     }

--- a/crates/subspace-node/src/domain/evm_chain_spec.rs
+++ b/crates/subspace-node/src/domain/evm_chain_spec.rs
@@ -19,7 +19,7 @@ use sp_domains::{
 use sp_runtime::BuildStorage;
 use sp_runtime::traits::Convert;
 use std::collections::BTreeSet;
-use subspace_runtime_primitives::{Balance, SSC};
+use subspace_runtime_primitives::{AI3, Balance};
 
 /// Development keys that will be injected automatically on polkadotjs apps
 fn get_dev_accounts() -> Vec<AccountId> {
@@ -113,7 +113,7 @@ pub fn get_testnet_endowed_accounts_by_spec_id(spec_id: SpecId) -> Vec<(MultiAcc
     match spec_id {
         SpecId::Dev => get_dev_accounts()
             .into_iter()
-            .map(|acc| (AccountId20Converter::convert(acc), 1_000_000 * SSC))
+            .map(|acc| (AccountId20Converter::convert(acc), 1_000_000 * AI3))
             .collect(),
         SpecId::DevNet | SpecId::Taurus => vec![],
     }

--- a/crates/subspace-runtime-primitives/src/lib.rs
+++ b/crates/subspace-runtime-primitives/src/lib.rs
@@ -37,7 +37,7 @@ pub const SHANNON: Balance = 1;
 /// Subspace Credits have 18 decimal places.
 pub const DECIMAL_PLACES: u8 = 18;
 /// One Subspace Credit.
-pub const SSC: Balance = (10 * SHANNON).pow(DECIMAL_PLACES as u32);
+pub const AI3: Balance = (10 * SHANNON).pow(DECIMAL_PLACES as u32);
 /// A ratio of `Normal` dispatch class within block, for `BlockWeight` and `BlockLength`.
 pub const NORMAL_DISPATCH_RATIO: Perbill = Perbill::from_percent(75);
 /// 1 in 6 slots (on average, not counting collisions) will have a block.

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -104,12 +104,11 @@ use subspace_runtime_primitives::utility::{
     DefaultNonceProvider, MaybeMultisigCall, MaybeNestedCall, MaybeUtilityCall,
 };
 use subspace_runtime_primitives::{
-    AccountId, BLOCK_WEIGHT_FOR_2_SEC, Balance, BlockHashFor, BlockNumber,
+    AI3, AccountId, BLOCK_WEIGHT_FOR_2_SEC, Balance, BlockHashFor, BlockNumber,
     ConsensusEventSegmentSize, DOMAINS_BLOCK_PRUNING_DEPTH, ExtrinsicFor, FindBlockRewardAddress,
     Hash, HeaderFor, HoldIdentifier, MAX_BLOCK_LENGTH, MIN_REPLICATION_FACTOR, Moment,
-    NORMAL_DISPATCH_RATIO, Nonce, SHANNON, SLOT_PROBABILITY, SSC, Signature,
-    SlowAdjustingFeeUpdate, TargetBlockFullness, XdmAdjustedWeightToFee, XdmFeeMultipler,
-    maximum_normal_block_length,
+    NORMAL_DISPATCH_RATIO, Nonce, SHANNON, SLOT_PROBABILITY, Signature, SlowAdjustingFeeUpdate,
+    TargetBlockFullness, XdmAdjustedWeightToFee, XdmFeeMultipler, maximum_normal_block_length,
 };
 
 sp_runtime::impl_opaque_keys! {
@@ -517,8 +516,8 @@ impl pallet_collective::Config<CouncilCollective> for Runtime {
 
 // TODO: update params for mainnnet
 parameter_types! {
-    pub PreimageBaseDeposit: Balance = 100 * SSC;
-    pub PreimageByteDeposit: Balance = SSC;
+    pub PreimageBaseDeposit: Balance = 100 * AI3;
+    pub PreimageByteDeposit: Balance = AI3;
     pub const PreImageHoldReason: HoldIdentifierWrapper = HoldIdentifierWrapper(HoldIdentifier::Preimage);
 }
 
@@ -620,7 +619,7 @@ impl pallet_democracy::Config for Runtime {
     type MaxVotes = ConstU32<100>;
     /// The minimum amount to be used as a deposit for a public referendum
     /// proposal.
-    type MinimumDeposit = ConstU128<{ 1000 * SSC }>;
+    type MinimumDeposit = ConstU128<{ 1000 * AI3 }>;
     type PalletsOrigin = OriginCaller;
     type Preimages = Preimage;
     type RuntimeEvent = RuntimeEvent;
@@ -720,7 +719,7 @@ impl sp_messenger::StorageKeys for StorageKeys {
 
 parameter_types! {
     // TODO: update value
-    pub const ChannelReserveFee: Balance = 100 * SSC;
+    pub const ChannelReserveFee: Balance = 100 * AI3;
     pub const ChannelInitReservePortion: Perbill = Perbill::from_percent(20);
     pub const MaxOutgoingMessages: u32 = MAX_OUTGOING_MESSAGES;
 }
@@ -798,7 +797,7 @@ where
 
 parameter_types! {
     pub const TransporterEndpointId: EndpointId = 1;
-    pub const MinimumTransfer: Balance = SSC;
+    pub const MinimumTransfer: Balance = AI3;
 }
 
 impl pallet_transporter::Config for Runtime {
@@ -819,15 +818,15 @@ parameter_types! {
     pub const DomainTxRangeAdjustmentInterval: u64 = TX_RANGE_ADJUSTMENT_INTERVAL_BLOCKS;
     /// Minimum operator stake to become an operator.
     // TODO: this value should be properly updated before mainnet
-    pub const MinOperatorStake: Balance = 100 * SSC;
+    pub const MinOperatorStake: Balance = 100 * AI3;
     /// Minimum nominator stake to nominate and operator.
     // TODO: this value should be properly updated before mainnet
-    pub const MinNominatorStake: Balance = SSC;
+    pub const MinNominatorStake: Balance = AI3;
     /// Use the consensus chain's `Normal` extrinsics block size limit as the domain block size limit
     pub MaxDomainBlockSize: u32 = NORMAL_DISPATCH_RATIO * MAX_BLOCK_LENGTH;
     /// Use the consensus chain's `Normal` extrinsics block weight limit as the domain block weight limit
     pub MaxDomainBlockWeight: Weight = maximum_domain_block_weight();
-    pub const DomainInstantiationDeposit: Balance = 100 * SSC;
+    pub const DomainInstantiationDeposit: Balance = 100 * AI3;
     pub const MaxDomainNameLength: u32 = 32;
     pub const BlockTreePruningDepth: u32 = DOMAINS_BLOCK_PRUNING_DEPTH;
     pub const StakeWithdrawalLockingPeriod: DomainNumber = 14_400;
@@ -838,7 +837,7 @@ parameter_types! {
     pub const MaxPendingStakingOperation: u32 = 512;
     pub const DomainsPalletId: PalletId = PalletId(*b"domains_");
     pub const MaxInitialDomainAccounts: u32 = 10;
-    pub const MinInitialDomainAccountBalance: Balance = SSC;
+    pub const MinInitialDomainAccountBalance: Balance = AI3;
     pub const BundleLongevity: u32 = 5;
     pub const WithdrawalLimit: u32 = 32;
 }
@@ -1019,8 +1018,8 @@ macro_rules! deposit {
 }
 
 // One storage item; key size is 32; value is size 4+4+16+32 bytes = 56 bytes.
-// Each multisig costs 20 SSC + bytes_of_storge * TransactionByteFee
-deposit!(DepositBaseFee, 20 * SSC, 1u32, 88u32);
+// Each multisig costs 20 AI3 + bytes_of_storge * TransactionByteFee
+deposit!(DepositBaseFee, 20 * AI3, 1u32, 88u32);
 
 // Additional storage item size of 32 bytes.
 deposit!(DepositFactor, 0u128, 0u32, 32u32);

--- a/domains/client/domain-operator/src/tests.rs
+++ b/domains/client/domain-operator/src/tests.rs
@@ -71,7 +71,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use subspace_core_primitives::pot::PotOutput;
 use subspace_runtime_primitives::opaque::Block as CBlock;
-use subspace_runtime_primitives::{Balance, BlockHashFor, HeaderFor, SSC};
+use subspace_runtime_primitives::{AI3, Balance, BlockHashFor, HeaderFor};
 use subspace_test_primitives::{DOMAINS_BLOCK_PRUNING_DEPTH, OnchainStateApi as _};
 use subspace_test_runtime::Runtime;
 use subspace_test_service::{
@@ -4330,8 +4330,8 @@ async fn test_invalid_transfers_fraud_proof() {
     let (bad_receipt_hash, bad_submit_bundle_tx) = {
         let receipt = &mut opaque_bundle.sealed_header.header.receipt;
         receipt.transfers = Transfers {
-            transfers_in: BTreeMap::from([(ChainId::Consensus, 10 * SSC)]),
-            transfers_out: BTreeMap::from([(ChainId::Consensus, 10 * SSC)]),
+            transfers_in: BTreeMap::from([(ChainId::Consensus, 10 * AI3)]),
+            transfers_out: BTreeMap::from([(ChainId::Consensus, 10 * AI3)]),
             rejected_transfers_claimed: Default::default(),
             transfers_rejected: Default::default(),
         };
@@ -6565,7 +6565,7 @@ async fn test_bad_receipt_chain() {
     ferdie
         .construct_and_send_extrinsic_with(pallet_domains::Call::register_operator {
             domain_id: EVM_DOMAIN_ID,
-            amount: 1000 * SSC,
+            amount: 1000 * AI3,
             config: OperatorConfig {
                 signing_key: Sr25519Keyring::Charlie.public().into(),
                 minimum_nominator_stake: Balance::MAX,

--- a/domains/runtime/auto-id/src/lib.rs
+++ b/domains/runtime/auto-id/src/lib.rs
@@ -71,8 +71,8 @@ use sp_version::RuntimeVersion;
 use static_assertions::const_assert;
 use subspace_runtime_primitives::utility::DefaultNonceProvider;
 use subspace_runtime_primitives::{
-    BlockHashFor, BlockNumber as ConsensusBlockNumber, DomainEventSegmentSize, ExtrinsicFor,
-    Hash as ConsensusBlockHash, HeaderFor, MAX_CALL_RECURSION_DEPTH, Moment, SHANNON, SSC,
+    AI3, BlockHashFor, BlockNumber as ConsensusBlockNumber, DomainEventSegmentSize, ExtrinsicFor,
+    Hash as ConsensusBlockHash, HeaderFor, MAX_CALL_RECURSION_DEPTH, Moment, SHANNON,
     SlowAdjustingFeeUpdate, XdmAdjustedWeightToFee, XdmFeeMultipler,
 };
 
@@ -223,7 +223,7 @@ parameter_types! {
     pub const MaxReserves: u32 = 50;
 }
 
-/// `DustRemovalHandler` used to collect all the SSC dust left when the account is reaped.
+/// `DustRemovalHandler` used to collect all the AI3 dust left when the account is reaped.
 pub struct DustRemovalHandler;
 
 impl OnUnbalanced<Credit<AccountId, Balances>> for DustRemovalHandler {
@@ -407,7 +407,7 @@ impl pallet_messenger::HoldIdentifier<Runtime> for HoldIdentifierWrapper {
 }
 
 parameter_types! {
-    pub const ChannelReserveFee: Balance = 100 * SSC;
+    pub const ChannelReserveFee: Balance = 100 * AI3;
     pub const ChannelInitReservePortion: Perbill = Perbill::from_percent(20);
     pub const MaxOutgoingMessages: u32 = MAX_OUTGOING_MESSAGES;
 }
@@ -457,7 +457,7 @@ where
 
 parameter_types! {
     pub const TransporterEndpointId: EndpointId = 1;
-    pub const MinimumTransfer: Balance = SSC;
+    pub const MinimumTransfer: Balance = AI3;
 }
 
 impl pallet_transporter::Config for Runtime {

--- a/domains/runtime/evm/src/lib.rs
+++ b/domains/runtime/evm/src/lib.rs
@@ -97,8 +97,8 @@ use sp_version::RuntimeVersion;
 use static_assertions::const_assert;
 use subspace_runtime_primitives::utility::{MaybeNestedCall, MaybeUtilityCall};
 use subspace_runtime_primitives::{
-    BlockHashFor, BlockNumber as ConsensusBlockNumber, DomainEventSegmentSize, ExtrinsicFor,
-    Hash as ConsensusBlockHash, HeaderFor, MAX_CALL_RECURSION_DEPTH, Moment, SHANNON, SSC,
+    AI3, BlockHashFor, BlockNumber as ConsensusBlockNumber, DomainEventSegmentSize, ExtrinsicFor,
+    Hash as ConsensusBlockHash, HeaderFor, MAX_CALL_RECURSION_DEPTH, Moment, SHANNON,
     SlowAdjustingFeeUpdate, XdmAdjustedWeightToFee, XdmFeeMultipler,
 };
 
@@ -377,7 +377,7 @@ parameter_types! {
     pub const MaxReserves: u32 = 50;
 }
 
-/// `DustRemovalHandler` used to collect all the SSC dust left when the account is reaped.
+/// `DustRemovalHandler` used to collect all the AI3 dust left when the account is reaped.
 pub struct DustRemovalHandler;
 
 impl OnUnbalanced<Credit<AccountId, Balances>> for DustRemovalHandler {
@@ -556,7 +556,7 @@ impl pallet_messenger::HoldIdentifier<Runtime> for HoldIdentifierWrapper {
 }
 
 parameter_types! {
-    pub const ChannelReserveFee: Balance = 100 * SSC;
+    pub const ChannelReserveFee: Balance = 100 * AI3;
     pub const ChannelInitReservePortion: Perbill = Perbill::from_percent(20);
     pub const MaxOutgoingMessages: u32 = MAX_OUTGOING_MESSAGES;
 }
@@ -609,7 +609,7 @@ where
 
 parameter_types! {
     pub const TransporterEndpointId: EndpointId = 1;
-    pub const MinimumTransfer: Balance = SSC;
+    pub const MinimumTransfer: Balance = AI3;
 }
 
 impl pallet_transporter::Config for Runtime {

--- a/domains/test/runtime/auto-id/src/lib.rs
+++ b/domains/test/runtime/auto-id/src/lib.rs
@@ -71,8 +71,8 @@ use sp_version::RuntimeVersion;
 use static_assertions::const_assert;
 use subspace_runtime_primitives::utility::DefaultNonceProvider;
 use subspace_runtime_primitives::{
-    BlockHashFor, BlockNumber as ConsensusBlockNumber, DomainEventSegmentSize, ExtrinsicFor,
-    Hash as ConsensusBlockHash, HeaderFor, MAX_CALL_RECURSION_DEPTH, Moment, SSC,
+    AI3, BlockHashFor, BlockNumber as ConsensusBlockNumber, DomainEventSegmentSize, ExtrinsicFor,
+    Hash as ConsensusBlockHash, HeaderFor, MAX_CALL_RECURSION_DEPTH, Moment,
     SlowAdjustingFeeUpdate, XdmAdjustedWeightToFee, XdmFeeMultipler,
 };
 
@@ -222,7 +222,7 @@ parameter_types! {
     pub const MaxReserves: u32 = 50;
 }
 
-/// `DustRemovalHandler` used to collect all the SSC dust left when the account is reaped.
+/// `DustRemovalHandler` used to collect all the AI3 dust left when the account is reaped.
 pub struct DustRemovalHandler;
 
 impl OnUnbalanced<Credit<AccountId, Balances>> for DustRemovalHandler {
@@ -405,7 +405,7 @@ impl pallet_messenger::HoldIdentifier<Runtime> for HoldIdentifierWrapper {
 }
 
 parameter_types! {
-    pub const ChannelReserveFee: Balance = 100 * SSC;
+    pub const ChannelReserveFee: Balance = 100 * AI3;
     pub const ChannelInitReservePortion: Perbill = Perbill::from_percent(20);
     pub const MaxOutgoingMessages: u32 = MAX_OUTGOING_MESSAGES;
 }

--- a/domains/test/runtime/evm/src/lib.rs
+++ b/domains/test/runtime/evm/src/lib.rs
@@ -94,8 +94,8 @@ use sp_version::RuntimeVersion;
 use static_assertions::const_assert;
 use subspace_runtime_primitives::utility::{MaybeNestedCall, MaybeUtilityCall};
 use subspace_runtime_primitives::{
-    BlockHashFor, BlockNumber as ConsensusBlockNumber, DomainEventSegmentSize, ExtrinsicFor,
-    Hash as ConsensusBlockHash, HeaderFor, MAX_CALL_RECURSION_DEPTH, Moment, SHANNON, SSC,
+    AI3, BlockHashFor, BlockNumber as ConsensusBlockNumber, DomainEventSegmentSize, ExtrinsicFor,
+    Hash as ConsensusBlockHash, HeaderFor, MAX_CALL_RECURSION_DEPTH, Moment, SHANNON,
     SlowAdjustingFeeUpdate, XdmAdjustedWeightToFee, XdmFeeMultipler,
 };
 
@@ -572,7 +572,7 @@ impl pallet_messenger::HoldIdentifier<Runtime> for HoldIdentifierWrapper {
 }
 
 parameter_types! {
-    pub const ChannelReserveFee: Balance = SSC;
+    pub const ChannelReserveFee: Balance = AI3;
     pub const ChannelInitReservePortion: Perbill = Perbill::from_percent(20);
     pub const MaxOutgoingMessages: u32 = MAX_OUTGOING_MESSAGES;
 }

--- a/test/subspace-test-client/src/auto_id_domain_chain_spec.rs
+++ b/test/subspace-test-client/src/auto_id_domain_chain_spec.rs
@@ -13,7 +13,7 @@ use sp_domains::{
 };
 use sp_runtime::traits::{Convert, IdentifyAccount};
 use sp_runtime::{BuildStorage, MultiSigner, Percent};
-use subspace_runtime_primitives::{AccountId, Balance, SSC};
+use subspace_runtime_primitives::{AI3, AccountId, Balance};
 
 /// Get public key from keypair seed.
 pub(crate) fn get_public_key_from_seed<TPublic: Public>(
@@ -89,12 +89,12 @@ pub fn get_genesis_domain(
         operator_allow_list: OperatorAllowList::Anyone,
 
         signing_key: get_from_seed::<OperatorPublicKey>("Bob"),
-        minimum_nominator_stake: 100 * SSC,
+        minimum_nominator_stake: 100 * AI3,
         nomination_tax: Percent::from_percent(5),
         initial_balances: endowed_accounts()
             .iter()
             .cloned()
-            .map(|k| (AccountIdConverter::convert(k), 2_000_000 * SSC))
+            .map(|k| (AccountIdConverter::convert(k), 2_000_000 * AI3))
             .collect(),
 
         domain_runtime_config: DomainRuntimeConfig::default_auto_id(),

--- a/test/subspace-test-client/src/chain_spec.rs
+++ b/test/subspace-test-client/src/chain_spec.rs
@@ -6,7 +6,7 @@ use sp_domains::{EvmType, PermissionedActionAllowedBy};
 use sp_runtime::traits::{IdentifyAccount, Verify};
 use std::marker::PhantomData;
 use std::num::NonZeroU32;
-use subspace_runtime_primitives::{AccountId, Balance, SSC, Signature};
+use subspace_runtime_primitives::{AI3, AccountId, Balance, Signature};
 use subspace_test_runtime::{
     AllowAuthoringBy, BalancesConfig, DomainsConfig, EnableRewardsAt, RewardsConfig,
     RuntimeGenesisConfig, SubspaceConfig, SudoConfig, SystemConfig, WASM_BINARY,
@@ -50,27 +50,27 @@ pub fn subspace_local_testnet_config(
     // Pre-funded accounts
     // Alice and the EVM owner get more funds that are used during domain instantiation
     let mut balances = vec![
-        (get_account_id_from_seed("Alice"), 1_000_000_000 * SSC),
-        (get_account_id_from_seed("Bob"), 1_000 * SSC),
-        (get_account_id_from_seed("Charlie"), 1_000 * SSC),
-        (get_account_id_from_seed("Dave"), 1_000 * SSC),
-        (get_account_id_from_seed("Eve"), 1_000 * SSC),
-        (get_account_id_from_seed("Ferdie"), 1_000 * SSC),
-        (get_account_id_from_seed("Alice//stash"), 1_000 * SSC),
-        (get_account_id_from_seed("Bob//stash"), 1_000 * SSC),
-        (get_account_id_from_seed("Charlie//stash"), 1_000 * SSC),
-        (get_account_id_from_seed("Dave//stash"), 1_000 * SSC),
-        (get_account_id_from_seed("Eve//stash"), 1_000 * SSC),
-        (get_account_id_from_seed("Ferdie//stash"), 1_000 * SSC),
+        (get_account_id_from_seed("Alice"), 1_000_000_000 * AI3),
+        (get_account_id_from_seed("Bob"), 1_000 * AI3),
+        (get_account_id_from_seed("Charlie"), 1_000 * AI3),
+        (get_account_id_from_seed("Dave"), 1_000 * AI3),
+        (get_account_id_from_seed("Eve"), 1_000 * AI3),
+        (get_account_id_from_seed("Ferdie"), 1_000 * AI3),
+        (get_account_id_from_seed("Alice//stash"), 1_000 * AI3),
+        (get_account_id_from_seed("Bob//stash"), 1_000 * AI3),
+        (get_account_id_from_seed("Charlie//stash"), 1_000 * AI3),
+        (get_account_id_from_seed("Dave//stash"), 1_000 * AI3),
+        (get_account_id_from_seed("Eve//stash"), 1_000 * AI3),
+        (get_account_id_from_seed("Ferdie//stash"), 1_000 * AI3),
     ];
 
     if let Some((_existing_account, balance)) = balances
         .iter_mut()
         .find(|(account_id, _balance)| account_id == &evm_owner_account)
     {
-        *balance = 1_000_000_000 * SSC;
+        *balance = 1_000_000_000 * AI3;
     } else {
-        balances.push((evm_owner_account.clone(), 1_000_000_000 * SSC));
+        balances.push((evm_owner_account.clone(), 1_000_000_000 * AI3));
     }
 
     Ok(GenericChainSpec::builder(
@@ -116,7 +116,7 @@ fn create_genesis_config(
             phantom: PhantomData,
         },
         rewards: RewardsConfig {
-            remaining_issuance: 1_000_000 * SSC,
+            remaining_issuance: 1_000_000 * AI3,
             proposer_subsidy_points: Default::default(),
             voter_subsidy_points: Default::default(),
         },

--- a/test/subspace-test-client/src/evm_domain_chain_spec.rs
+++ b/test/subspace-test-client/src/evm_domain_chain_spec.rs
@@ -15,7 +15,7 @@ use sp_domains::{
 };
 use sp_runtime::traits::{Convert, IdentifyAccount, Verify};
 use sp_runtime::{BuildStorage, Percent};
-use subspace_runtime_primitives::{AccountId, Balance, SSC};
+use subspace_runtime_primitives::{AI3, AccountId, Balance};
 
 type AccountPublic = <Signature as Verify>::Signer;
 
@@ -129,12 +129,12 @@ pub fn get_genesis_domain(
         operator_allow_list: OperatorAllowList::Anyone,
 
         signing_key: get_from_seed::<OperatorPublicKey>("Alice"),
-        minimum_nominator_stake: 100 * SSC,
+        minimum_nominator_stake: 100 * AI3,
         nomination_tax: Percent::from_percent(5),
         initial_balances: endowed_accounts()
             .iter()
             .cloned()
-            .map(|k| (AccountId20Converter::convert(k), 2_000_000 * SSC))
+            .map(|k| (AccountId20Converter::convert(k), 2_000_000 * AI3))
             .collect(),
 
         domain_runtime_config: EvmDomainRuntimeConfig { evm_type }.into(),

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -117,9 +117,9 @@ use subspace_runtime_primitives::utility::{
     DefaultNonceProvider, MaybeMultisigCall, MaybeNestedCall, MaybeUtilityCall, nested_call_iter,
 };
 use subspace_runtime_primitives::{
-    AccountId, Balance, BlockHashFor, BlockNumber, ConsensusEventSegmentSize, ExtrinsicFor,
+    AI3, AccountId, Balance, BlockHashFor, BlockNumber, ConsensusEventSegmentSize, ExtrinsicFor,
     FindBlockRewardAddress, Hash, HeaderFor, HoldIdentifier, MAX_BLOCK_LENGTH,
-    MAX_CALL_RECURSION_DEPTH, MIN_REPLICATION_FACTOR, Moment, Nonce, SHANNON, SSC, Signature,
+    MAX_CALL_RECURSION_DEPTH, MIN_REPLICATION_FACTOR, Moment, Nonce, SHANNON, Signature,
     SlowAdjustingFeeUpdate, TargetBlockFullness, XdmAdjustedWeightToFee, XdmFeeMultipler,
 };
 use subspace_test_primitives::DOMAINS_BLOCK_PRUNING_DEPTH;
@@ -674,7 +674,7 @@ impl sp_messenger::DomainRegistration for DomainRegistration {
 }
 
 parameter_types! {
-    pub const ChannelReserveFee: Balance = SSC;
+    pub const ChannelReserveFee: Balance = AI3;
     pub const ChannelInitReservePortion: Perbill = Perbill::from_percent(20);
     pub const MaxOutgoingMessages: u32 = MAX_OUTGOING_MESSAGES;
 }
@@ -770,13 +770,13 @@ parameter_types! {
     pub const MaximumReceiptDrift: BlockNumber = 2;
     pub const InitialDomainTxRange: u64 = INITIAL_DOMAIN_TX_RANGE;
     pub const DomainTxRangeAdjustmentInterval: u64 = 100;
-    pub const MinOperatorStake: Balance = 100 * SSC;
-    pub const MinNominatorStake: Balance = SSC;
+    pub const MinOperatorStake: Balance = 100 * AI3;
+    pub const MinNominatorStake: Balance = AI3;
     /// Use the consensus chain's `Normal` extrinsics block size limit as the domain block size limit
     pub MaxDomainBlockSize: u32 = NORMAL_DISPATCH_RATIO * MAX_BLOCK_LENGTH;
     /// Use the consensus chain's `Normal` extrinsics block weight limit as the domain block weight limit
     pub MaxDomainBlockWeight: Weight = NORMAL_DISPATCH_RATIO * BLOCK_WEIGHT_FOR_2_SEC;
-    pub const DomainInstantiationDeposit: Balance = 100 * SSC;
+    pub const DomainInstantiationDeposit: Balance = 100 * AI3;
     pub const MaxDomainNameLength: u32 = 32;
     pub const BlockTreePruningDepth: u32 = DOMAINS_BLOCK_PRUNING_DEPTH;
     pub const StakeWithdrawalLockingPeriod: BlockNumber = 20;
@@ -785,7 +785,7 @@ parameter_types! {
     pub const MaxPendingStakingOperation: u32 = 512;
     pub const DomainsPalletId: PalletId = PalletId(*b"domains_");
     pub const MaxInitialDomainAccounts: u32 = 20;
-    pub const MinInitialDomainAccountBalance: Balance = SSC;
+    pub const MinInitialDomainAccountBalance: Balance = AI3;
     pub const BundleLongevity: u32 = 5;
     pub const WithdrawalLimit: u32 = 32;
 }
@@ -964,8 +964,8 @@ macro_rules! deposit {
 }
 
 // One storage item; key size is 32; value is size 4+4+16+32 bytes = 56 bytes.
-// Each multisig costs 20 SSC + bytes_of_storge * TransactionByteFee
-deposit!(DepositBaseFee, 20 * SSC, 1u32, 88u32);
+// Each multisig costs 20 AI3 + bytes_of_storge * TransactionByteFee
+deposit!(DepositBaseFee, 20 * AI3, 1u32, 88u32);
 
 // Additional storage item size of 32 bytes.
 deposit!(DepositFactor, 0u128, 0u32, 32u32);


### PR DESCRIPTION
Changing starting EVM ChainID will have no effect on Taurus as we already have a set the storage `NextEVMChainID` and continue to use 490000 series with next ID being 490001

Not further logical changes

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
