### PR TITLE
Cleanup `DepositOnHold` state for fully withdrawn nominator

### DIFF
--- a/crates/pallet-domains/src/staking.rs
+++ b/crates/pallet-domains/src/staking.rs
@@ -1153,12 +1153,23 @@ pub(crate) fn do_unlock_funds<T: Config>(
         if withdrawal.withdrawals.is_empty() && withdrawal.withdrawal_in_shares.is_none() {
             *maybe_withdrawal = None;
             // if there is no deposit or pending deposits, then clean up the deposit state as well
-            Deposits::<T>::mutate_exists(operator_id, nominator_id, |maybe_deposit| {
+            Deposits::<T>::mutate_exists(operator_id, nominator_id.clone(), |maybe_deposit| {
                 if let Some(deposit) = maybe_deposit
                     && deposit.known.shares.is_zero()
                     && deposit.pending.is_none()
                 {
-                    *maybe_deposit = None
+                    *maybe_deposit = None;
+
+                    DepositOnHold::<T>::mutate_exists(
+                        (operator_id, nominator_id),
+                        |maybe_deposit_on_hold| {
+                            if let Some(deposit_on_hold) = maybe_deposit_on_hold
+                                && deposit_on_hold.is_zero()
+                            {
+                                *maybe_deposit_on_hold = None
+                            }
+                        },
+                    );
                 }
             });
         }
@@ -1504,8 +1515,8 @@ pub(crate) fn do_mark_operators_as_slashed<T: Config>(
 pub(crate) mod tests {
     use crate::domain_registry::{DomainConfig, DomainObject};
     use crate::pallet::{
-        Config, Deposits, DomainRegistry, DomainStakingSummary, HeadDomainNumber, NextOperatorId,
-        NominatorCount, OperatorIdOwner, Operators, PendingSlashes, Withdrawals,
+        Config, DepositOnHold, Deposits, DomainRegistry, DomainStakingSummary, HeadDomainNumber,
+        NextOperatorId, NominatorCount, OperatorIdOwner, Operators, PendingSlashes, Withdrawals,
     };
     use crate::staking::{
         DomainEpoch, Error as StakingError, Operator, OperatorConfig, OperatorStatus,
@@ -2128,7 +2139,11 @@ pub(crate) mod tests {
 
             // if the nominator count reduced, then there should be no storage for deposits as well
             if new_nominator_count < nominator_count {
-                assert!(Deposits::<Test>::get(operator_id, nominator_id).is_none())
+                assert!(Deposits::<Test>::get(operator_id, nominator_id).is_none());
+                assert!(!DepositOnHold::<Test>::contains_key((
+                    operator_id,
+                    nominator_id
+                )))
             }
 
             // The total balance is distributed in different places but never changed

--- a/crates/pallet-domains/src/staking_epoch.rs
+++ b/crates/pallet-domains/src/staking_epoch.rs
@@ -563,8 +563,8 @@ pub(crate) fn do_slash_operator<T: Config>(
 mod tests {
     use crate::bundle_storage_fund::STORAGE_FEE_RESERVE;
     use crate::pallet::{
-        Deposits, DomainStakingSummary, HeadDomainNumber, LastEpochStakingDistribution,
-        NominatorCount, OperatorIdOwner, Operators, Withdrawals,
+        DepositOnHold, Deposits, DomainStakingSummary, HeadDomainNumber,
+        LastEpochStakingDistribution, NominatorCount, OperatorIdOwner, Operators, Withdrawals,
     };
     use crate::staking::tests::{Share, register_operator};
     use crate::staking::{
@@ -801,7 +801,11 @@ mod tests {
 
             do_finalize_domain_current_epoch::<Test>(domain_id).unwrap();
             for deposit in deposits {
-                Deposits::<Test>::contains_key(operator_id, deposit.0);
+                assert!(Deposits::<Test>::contains_key(operator_id, deposit.0));
+                assert!(DepositOnHold::<Test>::contains_key((
+                    operator_id,
+                    deposit.0
+                )));
             }
 
             // should also store the previous epoch details in-block


### PR DESCRIPTION
The `DepositOnHold` is previously only cleaned when a nominator is fully unlocked after the operator de-registered:
https://github.com/autonomys/subspace/blob/16b5eefbbe4fd7158db59b520cb34fd2b1b27086/crates/pallet-domains/src/staking.rs#L1272

This results in zero value `DepositOnHold` state left over for a fully withdrawn nominator.

This PR cleanup the `DepositOnHold` state when we cleanup the `Deposits` state for a fully withdrawn nominator.

Migration on Taurus is unnecessary since a zero value `DepositOnHold` state do no harm except occupy a few bytes of state.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
