### PR TITLE
Retry segment download at the start of snap sync

### DIFF
--- a/crates/subspace-farmer-components/src/segment_reconstruction.rs
+++ b/crates/subspace-farmer-components/src/segment_reconstruction.rs
@@ -38,7 +38,7 @@ where
     let segment_index = missing_piece_index.segment_index();
     let position = missing_piece_index.position();
 
-    let segment_pieces = download_segment_pieces(segment_index, piece_getter).await?;
+    let segment_pieces = download_segment_pieces(segment_index, piece_getter, 0, None).await?;
 
     let result = tokio::task::spawn_blocking(move || {
         let reconstructor = PiecesReconstructor::new(kzg, erasure_coding);

--- a/crates/subspace-service/src/sync_from_dsn/import_blocks.rs
+++ b/crates/subspace-service/src/sync_from_dsn/import_blocks.rs
@@ -153,7 +153,7 @@ where
             }
         }
 
-        let segment_pieces = download_segment_pieces(segment_index, piece_getter)
+        let segment_pieces = download_segment_pieces(segment_index, piece_getter, 0, None)
             .await
             .map_err(|error| format!("Failed to download segment pieces: {error}"))?;
         // CPU-intensive piece and segment reconstruction code can block the async executor.

--- a/shared/subspace-data-retrieval/Cargo.toml
+++ b/shared/subspace-data-retrieval/Cargo.toml
@@ -22,7 +22,7 @@ subspace-core-primitives = { workspace = true, features = ["std"] }
 subspace-erasure-coding.workspace = true
 # This crate can't depend on any runtime code, because it needs to be independent of Substrate.
 thiserror.workspace = true
-tokio = { workspace = true, features = ["sync", "rt"] }
+tokio = { workspace = true, features = ["sync", "rt", "time"] }
 tracing = { workspace = true, features = ["std"] }
 
 [dev-dependencies]

--- a/shared/subspace-data-retrieval/src/segment_downloading.rs
+++ b/shared/subspace-data-retrieval/src/segment_downloading.rs
@@ -14,11 +14,6 @@ use tokio::task::spawn_blocking;
 use tokio::time::sleep;
 use tracing::debug;
 
-/// An array representing no available pieces for a segment.
-/// Pass this to low-level methods that require existing pieces.
-pub const NO_EXISTING_PIECES: [Option<Piece>; ArchivedHistorySegment::NUM_PIECES] =
-    [const { None }; ArchivedHistorySegment::NUM_PIECES];
-
 /// Segment getter errors.
 #[derive(Debug, thiserror::Error)]
 pub enum SegmentDownloadingError {
@@ -92,7 +87,7 @@ pub async fn download_segment_pieces<PG>(
 where
     PG: PieceGetter,
 {
-    let mut existing_pieces = NO_EXISTING_PIECES;
+    let mut existing_pieces = [const { None }; ArchivedHistorySegment::NUM_PIECES];
 
     for retry in 0..=retries {
         match download_missing_segment_pieces(segment_index, piece_getter, existing_pieces).await {
@@ -133,12 +128,12 @@ where
 }
 
 /// Tries to download pieces of a segment once, so that segment can be reconstructed afterward.
-/// Pass existing pieces in `existing_pieces`, or use `NO_EXISTING_PIECES` if no pieces are
-/// available.
+/// Pass existing pieces in `existing_pieces`, or use
+/// `[const { None }; ArchivedHistorySegment::NUM_PIECES]` if no pieces are available.
 ///
 /// Prefers source pieces if available, on error returns the incomplete piece download (including
 /// existing pieces).
-pub async fn download_missing_segment_pieces<PG>(
+async fn download_missing_segment_pieces<PG>(
     segment_index: SegmentIndex,
     piece_getter: &PG,
     existing_pieces: [Option<Piece>; ArchivedHistorySegment::NUM_PIECES],


### PR DESCRIPTION
(This PR is a significant revision of PR #3538. GitHub won't let me re-open that PR because the branch was force-pushed.)

This PR is a performance improvement and mitigation for bug #3537, where some nodes can't download segments reliably on Taurus.

There are two places where segment downloads are used during snap sync:
1. the first segment download, which is only tried once, and is fatal to the entire node if it fails
2. the DSN sync, where segment downloads are retried after the next DSN sync notification

It seems like adding a retry to the first case would be useful. There's no good reason to exit immediately when we could retry a few times, and re-use the pieces we previously downloaded.

This PR also improves the interface to segment download functions, including a retryable function, a "download once" function, and a low-level function that only downloads missing pieces.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
