### PR TITLE
increase memory for linux runners

### DIFF
--- a/.github/runs-on.yml
+++ b/.github/runs-on.yml
@@ -1,7 +1,7 @@
 runners:
   self-hosted-ubuntu-22.04-x86-64:
     cpu: [16, 32, 64]
-    ram: [32, 64, 128]
+    ram: [64, 128, 192]
     disk: default
     family: ["c7a", "c7i", "m7a", "m7i"]
     spot: capacity-optimized


### PR DESCRIPTION
A lot of jobs are failing with "the operation was canceled" and no useful debug output, the OOM is the main suspect here. Increasing the memory of GH runners instances to see if it resolves the problem.

### Code contributor checklist:
* [X] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
