### PR TITLE
Always saturating add and subtract weights

### DIFF
--- a/crates/sc-consensus-subspace/src/block_import.rs
+++ b/crates/sc-consensus-subspace/src/block_import.rs
@@ -609,7 +609,7 @@ where
         };
 
         let added_weight = calculate_block_weight(subspace_digest_items.solution_range);
-        let total_weight = parent_weight + added_weight;
+        let total_weight = parent_weight.saturating_add(added_weight);
 
         aux_schema::write_block_weight(block_hash, total_weight, |values| {
             block

--- a/domains/pallets/domain-check-weight/src/lib.rs
+++ b/domains/pallets/domain-check-weight/src/lib.rs
@@ -81,7 +81,9 @@ where
     Call: Dispatchable<Info = DispatchInfo, PostInfo = PostDispatchInfo>,
 {
     // Also Consider extrinsic length as proof weight.
-    let extrinsic_weight = (info.call_weight + info.extension_weight)
+    let extrinsic_weight = info
+        .call_weight
+        .saturating_add(info.extension_weight)
         .saturating_add(maximum_weight.get(info.class).base_extrinsic)
         .saturating_add(Weight::from_parts(0, len as u64));
 

--- a/domains/pallets/domain-sudo/src/lib.rs
+++ b/domains/pallets/domain-sudo/src/lib.rs
@@ -63,7 +63,7 @@ mod pallet {
         #[pallet::call_index(0)]
         #[pallet::weight({
             let dispatch_info = call.get_dispatch_info();
-            (dispatch_info.call_weight + dispatch_info.extension_weight, DispatchClass::Mandatory)
+            (dispatch_info.call_weight.saturating_add(dispatch_info.extension_weight), DispatchClass::Mandatory)
         })]
         pub fn sudo(origin: OriginFor<T>, call: Box<<T as Config>::RuntimeCall>) -> DispatchResult {
             ensure_none(origin)?;

--- a/domains/primitives/runtime/src/lib.rs
+++ b/domains/primitives/runtime/src/lib.rs
@@ -153,7 +153,9 @@ pub fn block_weights() -> BlockWeights {
     // If the bundle slot probability is the same as the consensus slot probability then
     // there is one bundle per block, such a bundle is allowed to consume the whole domain
     // block weight
-    let max_extrinsic_weight = maximum_block_weight - ExtrinsicBaseWeight::get();
+    let max_extrinsic_weight = maximum_block_weight
+        .checked_sub(&ExtrinsicBaseWeight::get())
+        .expect("Unable to produce blocks unless maximum block weight is greater than base extrinsic weight");
 
     BlockWeights::builder()
         .base_block(BlockExecutionWeight::get())


### PR DESCRIPTION
This PR makes sure that weights are always added using `saturating_add()`, which prevents overflows that can lead to incorrect insecure low weight sums.

The subtraction fix is technically not needed because the weights are constant, but we want the tests to panic and fail if we ever set the maximum block weight too low (even if it's in a test network or test runtime, because that would give incorrect test results).

#### Did we get them all?

I searched the code for:
- weight.*+
- +.*weight
- and with -
- and with newlines before/after the +/-

It is unlikely there are any more raw weight additions/subtractions, but the only way to make sure is to use a weight type with saturating `+/-` operators (or no `+/-` or `add/sub` operators at all).

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
