### PR TITLE
Reject trailing bytes during unchecked extrinsic decoding

### DIFF
--- a/domains/runtime/auto-id/src/lib.rs
+++ b/domains/runtime/auto-id/src/lib.rs
@@ -602,7 +602,7 @@ fn is_xdm_mmr_proof_valid(ext: &ExtrinsicFor<Block>) -> Option<bool> {
 
 /// Returns `true` if this is a validly encoded Sudo call.
 fn is_valid_sudo_call(encoded_ext: Vec<u8>) -> bool {
-    UncheckedExtrinsic::decode_with_depth_limit(
+    UncheckedExtrinsic::decode_all_with_depth_limit(
         MAX_CALL_RECURSION_DEPTH,
         &mut encoded_ext.as_slice(),
     )
@@ -977,7 +977,7 @@ impl_runtime_apis! {
         ) -> Result<ExtrinsicFor<Block>, DecodeExtrinsicError> {
             let encoded = opaque_extrinsic.encode();
 
-            UncheckedExtrinsic::decode_with_depth_limit(
+            UncheckedExtrinsic::decode_all_with_depth_limit(
                 MAX_CALL_RECURSION_DEPTH,
                 &mut encoded.as_slice(),
             ).map_err(|err| DecodeExtrinsicError(format!("{err}")))
@@ -988,7 +988,7 @@ impl_runtime_apis! {
         ) -> Vec<ExtrinsicFor<Block>> {
             let mut extrinsics = Vec::with_capacity(opaque_extrinsics.len());
             for opaque_ext in opaque_extrinsics {
-                match UncheckedExtrinsic::decode_with_depth_limit(
+                match UncheckedExtrinsic::decode_all_with_depth_limit(
                     MAX_CALL_RECURSION_DEPTH,
                     &mut opaque_ext.encode().as_slice(),
                 ) {

--- a/domains/runtime/evm/src/lib.rs
+++ b/domains/runtime/evm/src/lib.rs
@@ -925,7 +925,7 @@ fn is_xdm_mmr_proof_valid(ext: &ExtrinsicFor<Block>) -> Option<bool> {
 
 /// Returns `true` if this is a validly encoded Sudo call.
 fn is_valid_sudo_call(encoded_ext: Vec<u8>) -> bool {
-    UncheckedExtrinsic::decode_with_depth_limit(
+    UncheckedExtrinsic::decode_all_with_depth_limit(
         MAX_CALL_RECURSION_DEPTH,
         &mut encoded_ext.as_slice(),
     )
@@ -1436,7 +1436,7 @@ impl_runtime_apis! {
         ) -> Result<ExtrinsicFor<Block>, DecodeExtrinsicError> {
             let encoded = opaque_extrinsic.encode();
 
-            UncheckedExtrinsic::decode_with_depth_limit(
+            UncheckedExtrinsic::decode_all_with_depth_limit(
                 MAX_CALL_RECURSION_DEPTH,
                 &mut encoded.as_slice(),
             ).map_err(|err| DecodeExtrinsicError(format!("{err}")))
@@ -1447,7 +1447,7 @@ impl_runtime_apis! {
         ) -> Vec<ExtrinsicFor<Block>> {
             let mut extrinsics = Vec::with_capacity(opaque_extrinsics.len());
             for opaque_ext in opaque_extrinsics {
-                match UncheckedExtrinsic::decode_with_depth_limit(
+                match UncheckedExtrinsic::decode_all_with_depth_limit(
                     MAX_CALL_RECURSION_DEPTH,
                     &mut opaque_ext.encode().as_slice(),
                 ) {

--- a/domains/test/runtime/auto-id/src/lib.rs
+++ b/domains/test/runtime/auto-id/src/lib.rs
@@ -554,7 +554,7 @@ fn is_xdm_mmr_proof_valid(ext: &ExtrinsicFor<Block>) -> Option<bool> {
 
 /// Returns `true` if this is a validly encoded Sudo call.
 fn is_valid_sudo_call(encoded_ext: Vec<u8>) -> bool {
-    UncheckedExtrinsic::decode_with_depth_limit(
+    UncheckedExtrinsic::decode_all_with_depth_limit(
         MAX_CALL_RECURSION_DEPTH,
         &mut encoded_ext.as_slice(),
     )
@@ -961,7 +961,7 @@ impl_runtime_apis! {
         ) -> Result<ExtrinsicFor<Block>, DecodeExtrinsicError> {
             let encoded = opaque_extrinsic.encode();
 
-            UncheckedExtrinsic::decode_with_depth_limit(
+            UncheckedExtrinsic::decode_all_with_depth_limit(
                 MAX_CALL_RECURSION_DEPTH,
                 &mut encoded.as_slice(),
             ).map_err(|err| DecodeExtrinsicError(format!("{err}")))
@@ -972,7 +972,7 @@ impl_runtime_apis! {
         ) -> Vec<ExtrinsicFor<Block>> {
             let mut extrinsics = Vec::with_capacity(opaque_extrinsics.len());
             for opaque_ext in opaque_extrinsics {
-                match UncheckedExtrinsic::decode_with_depth_limit(
+                match UncheckedExtrinsic::decode_all_with_depth_limit(
                     MAX_CALL_RECURSION_DEPTH,
                     &mut opaque_ext.encode().as_slice(),
                 ) {

--- a/domains/test/runtime/evm/src/lib.rs
+++ b/domains/test/runtime/evm/src/lib.rs
@@ -1001,7 +1001,7 @@ fn is_xdm_mmr_proof_valid(ext: &ExtrinsicFor<Block>) -> Option<bool> {
 
 /// Returns `true`` if this is a validly encoded Sudo call.
 fn is_valid_sudo_call(encoded_ext: Vec<u8>) -> bool {
-    UncheckedExtrinsic::decode_with_depth_limit(
+    UncheckedExtrinsic::decode_all_with_depth_limit(
         MAX_CALL_RECURSION_DEPTH,
         &mut encoded_ext.as_slice(),
     )
@@ -1454,7 +1454,7 @@ impl_runtime_apis! {
         ) -> Result<ExtrinsicFor<Block>, DecodeExtrinsicError> {
             let encoded = opaque_extrinsic.encode();
 
-            UncheckedExtrinsic::decode_with_depth_limit(
+            UncheckedExtrinsic::decode_all_with_depth_limit(
                 MAX_CALL_RECURSION_DEPTH,
                 &mut encoded.as_slice(),
             ).map_err(|err| DecodeExtrinsicError(format!("{err}")))
@@ -1465,7 +1465,7 @@ impl_runtime_apis! {
         ) -> Vec<ExtrinsicFor<Block>> {
             let mut extrinsics = Vec::with_capacity(opaque_extrinsics.len());
             for opaque_ext in opaque_extrinsics {
-                match UncheckedExtrinsic::decode_with_depth_limit(
+                match UncheckedExtrinsic::decode_all_with_depth_limit(
                     MAX_CALL_RECURSION_DEPTH,
                     &mut opaque_ext.encode().as_slice(),
                 ) {


### PR DESCRIPTION
This PR rejects any trailing bytes during unchecked extrinsic decoding, by using `decode_all_with_depth_limit`.

This prevents accidental mistakes and any exploits that include large amounts of trailing data in unchecked extrinsics in:
- sudo calls
- fraud proofs
- domain block preprocessing

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
