### PR TITLE
Do checked arithmetic during CheckNonce

### DIFF
--- a/domains/pallets/messenger/src/lib.rs
+++ b/domains/pallets/messenger/src/lib.rs
@@ -57,12 +57,14 @@ pub use weights::WeightInfo;
 /// If the extrinsic is not included in the bundle, extrinsic is removed from the TxPool.
 const XDM_TRANSACTION_LONGEVITY: u64 = 10;
 
+/// XDM verification errors.
 pub(crate) mod verification_errors {
     // When updating these error codes, check for clashes between:
     // <https://github.com/autonomys/subspace/blob/main/domains/primitives/runtime/src/lib.rs#L85-L88>
     // <https://github.com/autonomys/subspace/blob/main/crates/sp-domains-fraud-proof/src/lib.rs#L49-L64>
     pub(crate) const INVALID_NONCE: u8 = 201;
-    pub(crate) const NONCE_OVERFLOW: u8 = 202;
+    // Custom error code when a messenger nonce overflows.
+    pub(crate) const XDM_NONCE_OVERFLOW: u8 = 202;
     // This error code was previously 200, but that clashed with ERR_BALANCE_OVERFLOW.
     pub(crate) const INVALID_CHANNEL: u8 = 203;
     pub(crate) const IN_FUTURE_NONCE: u8 = 204;
@@ -1241,7 +1243,9 @@ mod pallet {
                     Some(channel) => match channel.latest_response_received_message_nonce {
                         None => Nonce::zero(),
                         Some(last_nonce) => last_nonce.checked_add(Nonce::one()).ok_or(
-                            InvalidTransaction::Custom(crate::verification_errors::NONCE_OVERFLOW),
+                            InvalidTransaction::Custom(
+                                crate::verification_errors::XDM_NONCE_OVERFLOW,
+                            ),
                         )?,
                     },
                 };

--- a/domains/primitives/runtime/src/lib.rs
+++ b/domains/primitives/runtime/src/lib.rs
@@ -104,8 +104,8 @@ pub fn maximum_domain_block_weight() -> Weight {
 // <https://github.com/autonomys/subspace/blob/main/crates/sp-domains-fraud-proof/src/lib.rs#L49-L64>
 // <https://github.com/autonomys/subspace/blob/main/domains/pallets/messenger/src/lib.rs#L49-L53>
 
-/// Custom error when nonce overflow occurs.
-pub const ERR_NONCE_OVERFLOW: u8 = 100;
+/// Custom error when an EVM nonce overflow occurs.
+pub const ERR_EVM_NONCE_OVERFLOW: u8 = 100;
 /// Custom error when balance overflow occurs.
 pub const ERR_BALANCE_OVERFLOW: u8 = 200;
 /// Custom error when a user tries to create a contract, but their account is not on the allow

--- a/domains/runtime/evm/src/lib.rs
+++ b/domains/runtime/evm/src/lib.rs
@@ -19,8 +19,8 @@ use core::mem;
 use domain_runtime_primitives::opaque::Header;
 use domain_runtime_primitives::{
     AccountId20, CheckExtrinsicsValidityError, DEFAULT_EXTENSION_VERSION, DecodeExtrinsicError,
-    ERR_BALANCE_OVERFLOW, ERR_CONTRACT_CREATION_NOT_ALLOWED, ERR_NONCE_OVERFLOW, HoldIdentifier,
-    MAX_OUTGOING_MESSAGES, SLOT_DURATION, TargetBlockFullness,
+    ERR_BALANCE_OVERFLOW, ERR_CONTRACT_CREATION_NOT_ALLOWED, ERR_EVM_NONCE_OVERFLOW,
+    HoldIdentifier, MAX_OUTGOING_MESSAGES, SLOT_DURATION, TargetBlockFullness,
 };
 pub use domain_runtime_primitives::{
     Balance, BlockNumber, EXISTENTIAL_DEPOSIT, EthereumAccountId as AccountId,
@@ -1068,7 +1068,7 @@ fn pre_dispatch_evm_transaction(
 
                 let next_nonce = account_nonce
                     .checked_add(U256::one())
-                    .ok_or(InvalidTransaction::Custom(ERR_NONCE_OVERFLOW))?;
+                    .ok_or(InvalidTransaction::Custom(ERR_EVM_NONCE_OVERFLOW))?;
 
                 EVMNoncetracker::set_account_nonce(AccountId::from(account_id), next_nonce);
             }

--- a/domains/test/runtime/evm/src/lib.rs
+++ b/domains/test/runtime/evm/src/lib.rs
@@ -18,8 +18,9 @@ use core::mem;
 pub use domain_runtime_primitives::opaque::Header;
 use domain_runtime_primitives::{
     AccountId20, DEFAULT_EXTENSION_VERSION, ERR_BALANCE_OVERFLOW,
-    ERR_CONTRACT_CREATION_NOT_ALLOWED, ERR_NONCE_OVERFLOW, EXISTENTIAL_DEPOSIT, EthereumAccountId,
-    MAX_OUTGOING_MESSAGES, SLOT_DURATION, TargetBlockFullness, block_weights, maximum_block_length,
+    ERR_CONTRACT_CREATION_NOT_ALLOWED, ERR_EVM_NONCE_OVERFLOW, EXISTENTIAL_DEPOSIT,
+    EthereumAccountId, MAX_OUTGOING_MESSAGES, SLOT_DURATION, TargetBlockFullness, block_weights,
+    maximum_block_length,
 };
 pub use domain_runtime_primitives::{
     Balance, BlockNumber, CheckExtrinsicsValidityError, DecodeExtrinsicError,
@@ -1125,7 +1126,7 @@ fn pre_dispatch_evm_transaction(
 
                 let next_nonce = account_nonce
                     .checked_add(U256::one())
-                    .ok_or(InvalidTransaction::Custom(ERR_NONCE_OVERFLOW))?;
+                    .ok_or(InvalidTransaction::Custom(ERR_EVM_NONCE_OVERFLOW))?;
 
                 EVMNoncetracker::set_account_nonce(AccountId::from(account_id), next_nonce);
             }


### PR DESCRIPTION
Currently we use unchecked overflowing arithmetic in our `CheckNonce` implementation.

This could cause:
- rejection of the initial EVM transaction, if the substrate account has a zero nonce, but the extension nonce is non-zero
- silent wrapping of the nonce, rather than returning an error

This is different from the upstream substrate implementation, which wraps:
https://github.com/paritytech/polkadot-sdk/blob/6b5a1284e83ed52dfc61f7deb920af41ae1efd31/substrate/frame/system/src/extensions/check_nonce.rs#L87
https://github.com/paritytech/polkadot-sdk/blob/6b5a1284e83ed52dfc61f7deb920af41ae1efd31/substrate/frame/system/src/extensions/check_nonce.rs#L104

This PR also adds comments (and a TODO) justifying temporarily using the benchmarked `frame_system::CheckNonce` extension weight for the `evm_tracker::CheckNonce` extension.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
