### PR TITLE
Automatically check for unused dependencies in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -327,3 +327,53 @@ jobs:
               pwd;
               popd;
           done
+
+  # This job checks for incorrectly added dependencies, or dependencies that were made unused by code changes.
+  cargo-unused-deps:
+    # We need to use Linux to check GPU dependencies (or Windows, but it's slow)
+    runs-on: ${{ fromJson(github.repository_owner == 'autonomys' &&
+      '"runs-on=${{ github.run_id }}/runner=self-hosted-ubuntu-22.04-x86-64"' || '"ubuntu-22.04"') }}
+
+    # This feature list is `--all-features` except `rocm`, which is incompatible with `cuda`
+    # When cargo supports excluding features (or mutually exclusive features), we can use
+    # `--all-features --exclude-feature rocm`
+    # <https://github.com/rust-lang/cargo/issues/11467>
+    # <https://internals.rust-lang.org/t/pre-rfc-mutually-excusive-global-features/19618>
+    env:
+      MOST_FEATURES: _gpu,async-trait,binary,cluster,cuda,default-library,domain-block-builder,domain-block-preprocessor,frame-benchmarking-cli,frame-system-benchmarking,hex-literal,kzg,numa,pallet-subspace,pallet-timestamp,pallet-utility,parallel,parking_lot,rand,runtime-benchmarks,sc-client-api,sc-executor,schnorrkel,serde,sp-blockchain,sp-core,sp-io,sp-state-machine,sp-std,sp-storage,sppark,static_assertions,std,subspace-proof-of-space-gpu,substrate-wasm-builder,testing,wasm-builder,with-tracing,x509-parser
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Install Protoc
+        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: CUDA toolchain
+        uses: Jimver/cuda-toolkit@4bd727d5619dc6fa323b1e76c3aa5dca94f5ec6d # v0.2.19
+        with:
+          cuda: '12.4.1'
+          method: network
+          sub-packages: '["nvcc", "cudart"]'
+        if: runner.os == 'Linux' || runner.os == 'Windows'
+
+      - name: Configure cache
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      # If this check fails, check the new dependency is actually needed. If it is, try adding any
+      # new features to MOST_FEATURES. If that doesn't work, add an exception to the crate:
+      # <https://github.com/est31/cargo-udeps?tab=readme-ov-file#ignoring-some-of-the-dependencies>
+      - name: check for unused dependencies
+        uses: aig787/cargo-udeps-action@v1
+        with:
+          version: latest
+          args: --workspace --all-targets --locked --features ${{ env.MOST_FEATURES }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8066,7 +8066,6 @@ dependencies = [
  "pallet-block-fees",
  "pallet-ethereum",
  "pallet-evm",
- "pallet-timestamp",
  "pallet-transaction-payment",
  "pallet-utility",
  "parity-scale-codec",
@@ -12787,7 +12786,6 @@ version = "0.1.0"
 dependencies = [
  "sp-api",
  "subspace-core-primitives",
- "subspace-runtime-primitives",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -171,7 +171,6 @@ sc-consensus-subspace = { version = "0.1.0", path = "crates/sc-consensus-subspac
 sc-consensus-subspace-rpc = { version = "0.1.0", path = "crates/sc-consensus-subspace-rpc" }
 sc-domains = { version = "0.1.0", path = "crates/sc-domains" }
 sc-executor = { git = "https://github.com/subspace/polkadot-sdk", rev = "e831132867930ca90a7088c7246301ab29f015ba", default-features = false }
-sc-executor-common = { git = "https://github.com/subspace/polkadot-sdk", rev = "e831132867930ca90a7088c7246301ab29f015ba" }
 sc-informant = { git = "https://github.com/subspace/polkadot-sdk", rev = "e831132867930ca90a7088c7246301ab29f015ba" }
 sc-keystore = { git = "https://github.com/subspace/polkadot-sdk", rev = "e831132867930ca90a7088c7246301ab29f015ba" }
 sc-network = { git = "https://github.com/subspace/polkadot-sdk", rev = "e831132867930ca90a7088c7246301ab29f015ba" }

--- a/crates/sp-objects/Cargo.toml
+++ b/crates/sp-objects/Cargo.toml
@@ -15,12 +15,10 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 sp-api.workspace = true
 subspace-core-primitives.workspace = true
-subspace-runtime-primitives.workspace = true
 
 [features]
 default = ["std"]
 std = [
     "sp-api/std",
     "subspace-core-primitives/std",
-    "subspace-runtime-primitives/std",
 ]

--- a/crates/subspace-proof-of-space/Cargo.toml
+++ b/crates/subspace-proof-of-space/Cargo.toml
@@ -50,3 +50,8 @@ std = [
 parallel = [
     "dep:rayon",
 ]
+
+# The std and no_std features are mutually exclusive, so when checking for unused dependencies,
+# ignore the `spin` dependency, which is only used in no_std.
+[package.metadata.cargo-udeps.ignore]
+normal = ["spin"]

--- a/domains/pallets/evm-tracker/Cargo.toml
+++ b/domains/pallets/evm-tracker/Cargo.toml
@@ -35,7 +35,6 @@ subspace-runtime-primitives.workspace = true
 [dev-dependencies]
 frame-benchmarking.workspace = true
 pallet-balances.workspace = true
-pallet-timestamp.workspace = true
 pallet-utility.workspace = true
 sp-io.workspace = true
 
@@ -50,7 +49,6 @@ std = [
     "pallet-ethereum/std",
     "pallet-evm/std",
     "pallet-block-fees/std",
-    "pallet-timestamp/std",
     "pallet-transaction-payment/std",
     "pallet-utility?/std",
     "parity-scale-codec/std",

--- a/shared/subspace-kzg/Cargo.toml
+++ b/shared/subspace-kzg/Cargo.toml
@@ -51,3 +51,8 @@ std = [
     "subspace-core-primitives/std",
     "tracing/std",
 ]
+
+# The std and no_std features are mutually exclusive, so when checking for unused dependencies,
+# ignore the `spin` dependency, which is only used in no_std.
+[package.metadata.cargo-udeps.ignore]
+normal = ["spin"]

--- a/shared/subspace-proof-of-space-gpu/Cargo.toml
+++ b/shared/subspace-proof-of-space-gpu/Cargo.toml
@@ -13,6 +13,7 @@ include = [
 ]
 
 [dependencies]
+# Only used from C code
 blst = { workspace = true, optional = true }
 rust-kzg-blst = { workspace = true, optional = true }
 # TODO: Fork with ROCm support, switch to upstream once `rocm` branch from `https://github.com/dot-asm/sppark` + https://github.com/dot-asm/sppark/pull/2 are upstreamed
@@ -41,3 +42,7 @@ _gpu = [
     "dep:subspace-core-primitives",
     "dep:subspace-kzg",
 ]
+
+# `cargo-udeps` can't detect C code-only usage
+[package.metadata.cargo-udeps.ignore]
+normal = ["blst"]


### PR DESCRIPTION
Subspace builds are already quite large and long, so it's important that we limit our dependencies.

This PR:
- checks for unused dependencies in CI
- removes existing unused dependencies (including some that are totally unused in the workspace from PR #3580)
- ignores any dependencies that are actually used, but can't be checked by `cargo-udeps`

You can see a successful run here, it takes about 5 minutes:
https://github.com/autonomys/subspace/actions/runs/15724815151/job/44312482540#step:7:1540

The feature list was generated by this script. We don't need to strictly keep it up to date, new features only need to be added when they are the only use of a dependency in that crate.
```sh
echo "" > cargo-info.txt
# list from Cargo.toml members field:
for crate in crates/* domains/client/* domains/pallets/* domains/primitives/* domains/runtime/* domains/service domains/test/runti\
me/* domains/test/pallets/* domains/test/service domains/test/utils shared/* test/subspace-test-client test/subspace-test-runtime \
test/subspace-test-service; do
  cargo info --frozen `cargo -Z unstable-options -C "$crate" pkgid --frozen` >> cargo-info.txt;
done

cat cargo-info.txt | grep " = " | cut -d= -f1 | cut -d" " -f3 | sort --unique

# remove rocm feature because it is incompatible with cuda
# remove frame-benchmarking and subspace-kzg due to "not a feature" errors
```

Close #3586

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
