### PR TITLE
Make all node version git hashes the same length

### DIFF
--- a/.github/workflows/snapshot-build.yml
+++ b/.github/workflows/snapshot-build.yml
@@ -90,6 +90,12 @@ jobs:
             latest=false
             suffix=
 
+      # This length should be kept in sync with our fork of the substrate build script:
+      # https://github.com/autonomys/polkadot-sdk/blob/e831132867930ca90a7088c7246301ab29f015ba/substrate/utils/build-script-utils/src/version.rs#L28
+      - name: Get short SHA
+        run: |
+          echo SUBSTRATE_CLI_GIT_COMMIT_HASH=$(echo ${{github.sha}} | cut -c 1-11) >> "$GITHUB_ENV"
+
       - name: Build and push ${{ matrix.build.image }} image
         uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75 # v6.9.0
         with:
@@ -103,7 +109,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            SUBSTRATE_CLI_GIT_COMMIT_HASH=${{ github.sha }}
+            SUBSTRATE_CLI_GIT_COMMIT_HASH=${{ env.SUBSTRATE_CLI_GIT_COMMIT_HASH }}
 
       - name: Trigger snyk-container-scan Workflow
         uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # @v3.0.0
@@ -167,11 +173,13 @@ jobs:
     env:
       PRODUCTION_TARGET: target/${{ matrix.build.target }}/production
       RUSTFLAGS: ${{ matrix.build.rustflags }}
-      SUBSTRATE_CLI_GIT_COMMIT_HASH: ${{ github.sha }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      # The substrate build script automatically sets SUBSTRATE_CLI_GIT_COMMIT_HASH from the git repository:
+      # https://github.com/autonomys/polkadot-sdk/blob/e831132867930ca90a7088c7246301ab29f015ba/substrate/utils/build-script-utils/src/version.rs#L28
 
       # On macOS, we need a proper Clang version, not Apple's custom version without wasm32 support
       - name: Install LLVM and Clang for macOS

--- a/.github/workflows/snapshot-build.yml
+++ b/.github/workflows/snapshot-build.yml
@@ -167,6 +167,7 @@ jobs:
     env:
       PRODUCTION_TARGET: target/${{ matrix.build.target }}/production
       RUSTFLAGS: ${{ matrix.build.rustflags }}
+      SUBSTRATE_CLI_GIT_COMMIT_HASH: ${{ github.sha }}
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Currently, node versions on telemetry.subspace.network (and in node logs) show two different git hash lengths:
- full hash length for Linux, from `github.sha` in the Docker build arguments
- 11 character hash for Windows and macOS, from the [substrate build script fallback git command](https://github.com/autonomys/polkadot-sdk/blob/master/substrate/utils/build-script-utils/src/version.rs#L28)

This makes it difficult to track the percentage of nodes on each version, because we have to add 3 totals for each one (space acres, and subspace-node with short and long hashes).

We can get the same commit hash length for all builds by:
- passing the commit hash environmental variable to the Windows and macOS builds
- using the short commit hash for all builds (optional, but helps readability)

A snapshot build with this change is at:
https://github.com/autonomys/subspace/actions/runs/15813294850

I've tested it on macOS and Linux, and both show the short sha.

#### Background

Using an 11 character hash is enough to avoid ambiguity, according to `git log --oneline`:
https://stackoverflow.com/questions/18134627/how-much-of-a-git-sha-is-generally-considered-necessary-to-uniquely-identify-a/40220556#40220556

Currently, with 10,000 commits, we need 9 characters, so 11 characters should last us until around 100,000 commits. (Substrate is also likely to reach 100,000 commits and change their length before we do.)

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
