### PR TITLE
Add or document missing weights for frequent calls

### DIFF
--- a/domains/pallets/block-fees/src/lib.rs
+++ b/domains/pallets/block-fees/src/lib.rs
@@ -107,8 +107,14 @@ mod pallet {
     impl<T: Config> Pallet<T> {
         #[pallet::call_index(0)]
         #[pallet::weight((
-        // TODO: proper weight
-        Weight::from_all(10_000),
+        // For now, it is safe to treat this call as lightweight, because ensure_none() only
+        // performs a few enum variant checks (which may optimise to a single instruction).
+        // Each instruction typically weighs under 300 picoseconds. Similarly, a Balance is at most
+        // 16 bytes.
+        // TODO: eventually we should benchmark this weight
+        Weight::from_all(10_000).saturating_add(
+            T::DbWeight::get().writes(1)
+        ),
         DispatchClass::Mandatory
         ))]
         pub fn set_next_consensus_chain_byte_fee(

--- a/domains/pallets/domain-check-weight/src/lib.rs
+++ b/domains/pallets/domain-check-weight/src/lib.rs
@@ -51,8 +51,8 @@ where
 
     /// Check the block length and the max extrinsic weight and notes the new weight and length value.
     ///
-    /// It is same as the [`frame_system::CheckWeight::do_prepare`] except the `max_total/max_block`
-    /// weight limit check is removed.
+    /// It is same as the [`frame_system::CheckWeight::do_prepare`] except the `limit_per_class` and
+    /// `max_total/max_block` weight limit checks are removed.
     pub fn do_prepare(
         info: &DispatchInfoOf<T::RuntimeCall>,
         len: usize,
@@ -82,8 +82,7 @@ where
 {
     // Also Consider extrinsic length as proof weight.
     let extrinsic_weight = info
-        .call_weight
-        .saturating_add(info.extension_weight)
+        .total_weight()
         .saturating_add(maximum_weight.get(info.class).base_extrinsic)
         .saturating_add(Weight::from_parts(0, len as u64));
 
@@ -103,6 +102,8 @@ where
     const IDENTIFIER: &'static str = "CheckWeight";
 
     fn weight(&self, _: &T::RuntimeCall) -> Weight {
+        // It is ok to use the upstream weight here, because this extension does fewer checks
+        // than the upstream `CheckWeight`. See the comment on `struct CheckWeight` for details.
         <T::ExtensionsWeightInfo as frame_system::ExtensionsWeightInfo>::check_weight()
     }
 

--- a/domains/runtime/auto-id/src/lib.rs
+++ b/domains/runtime/auto-id/src/lib.rs
@@ -1045,7 +1045,7 @@ impl_runtime_apis! {
 
         fn construct_consensus_chain_byte_fee_extrinsic(transaction_byte_fee: Balance) -> ExtrinsicFor<Block> {
             UncheckedExtrinsic::new_bare(
-                pallet_block_fees::Call::set_next_consensus_chain_byte_fee{ transaction_byte_fee }.into()
+                pallet_block_fees::Call::set_next_consensus_chain_byte_fee { transaction_byte_fee }.into()
             )
         }
 

--- a/domains/runtime/evm/src/lib.rs
+++ b/domains/runtime/evm/src/lib.rs
@@ -1507,7 +1507,7 @@ impl_runtime_apis! {
 
         fn construct_consensus_chain_byte_fee_extrinsic(transaction_byte_fee: Balance) -> ExtrinsicFor<Block> {
             UncheckedExtrinsic::new_bare(
-                pallet_block_fees::Call::set_next_consensus_chain_byte_fee{ transaction_byte_fee }.into()
+                pallet_block_fees::Call::set_next_consensus_chain_byte_fee { transaction_byte_fee }.into()
             )
         }
 

--- a/domains/test/runtime/auto-id/src/lib.rs
+++ b/domains/test/runtime/auto-id/src/lib.rs
@@ -1026,7 +1026,7 @@ impl_runtime_apis! {
 
         fn construct_consensus_chain_byte_fee_extrinsic(transaction_byte_fee: Balance) -> ExtrinsicFor<Block> {
             UncheckedExtrinsic::new_bare(
-                pallet_block_fees::Call::set_next_consensus_chain_byte_fee{ transaction_byte_fee }.into()
+                pallet_block_fees::Call::set_next_consensus_chain_byte_fee { transaction_byte_fee }.into()
             )
         }
 

--- a/domains/test/runtime/evm/src/lib.rs
+++ b/domains/test/runtime/evm/src/lib.rs
@@ -1520,7 +1520,7 @@ impl_runtime_apis! {
 
         fn construct_consensus_chain_byte_fee_extrinsic(transaction_byte_fee: Balance) -> ExtrinsicFor<Block> {
             UncheckedExtrinsic::new_bare(
-                pallet_block_fees::Call::set_next_consensus_chain_byte_fee{ transaction_byte_fee }.into()
+                pallet_block_fees::Call::set_next_consensus_chain_byte_fee { transaction_byte_fee }.into()
             )
         }
 


### PR DESCRIPTION
This PR fixes or documents the frequently used extension / call weights from ticket #3579:
- domain CheckWeight extension
- set_next_consensus_chain_byte_fee

These weights are the highest priority remaining weights for phase 2. They don't need to be exact, but we need to be sure they are accurate or over-estimates.

The remaining calls are infrequent, and the remaining extensions are much harder to benchmark. I'm waiting on some advice from @NingLin-P on that ticket before I prioritise those.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
