### PR TITLE
Make share overflow errors and missing share prices explicit

### DIFF
--- a/crates/pallet-domains/src/staking_epoch.rs
+++ b/crates/pallet-domains/src/staking_epoch.rs
@@ -278,7 +278,7 @@ pub(crate) fn do_finalize_operator_epoch_staking<T: Config>(
 
     let mut total_stake = operator.current_total_stake;
     let mut total_shares = operator.current_total_shares;
-    let share_price = SharePrice::new::<T>(total_shares, total_stake);
+    let share_price = SharePrice::new::<T>(total_shares, total_stake)?;
 
     // calculate and subtract total withdrew shares from previous epoch
     if !operator.withdrawals_in_epoch.is_zero() {
@@ -390,7 +390,7 @@ pub(crate) fn do_slash_operator<T: Config>(
 
         let mut total_stake = operator.current_total_stake;
         let mut total_shares = operator.current_total_shares;
-        let share_price = SharePrice::new::<T>(total_shares, total_stake);
+        let share_price = SharePrice::new::<T>(total_shares, total_stake)?;
 
         let mut total_storage_fee_deposit = operator.total_storage_fee_deposit;
 


### PR DESCRIPTION
This PR refactors the share price calculation code to explicitly error on invalid prices, and store `None` on missing prices.

Previously, we were ignoring errors and using 1 part per billion as a marker for a missing share price. This could lead to confusion or exploits if the actual share price ended up being that marker value.

#### Future Work

There is more work to do here for the review, including checking for zero shares and zero stake. But that belongs in another PR, because it seems to need extensive test changes:
https://www.notion.so/subspacelabs/Staking-Review-2150bae47e958091b3ffe512f1c40872?source=copy_link#21e0bae47e95803aaea6c5f8e8ed304b

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
