### PR TITLE
Stop accepting bundles from operator after they produced an invalid bundle allegedly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2927,6 +2927,7 @@ dependencies = [
  "sp-weights",
  "subspace-core-primitives",
  "subspace-runtime-primitives",
+ "subspace-test-client",
  "subspace-test-primitives",
  "subspace-test-runtime",
  "subspace-test-service",
@@ -13986,6 +13987,7 @@ dependencies = [
 name = "subspace-test-primitives"
 version = "0.1.0"
 dependencies = [
+ "pallet-domains",
  "parity-scale-codec",
  "sp-api",
  "sp-core",

--- a/crates/pallet-domains/src/block_tree.rs
+++ b/crates/pallet-domains/src/block_tree.rs
@@ -625,6 +625,26 @@ pub(crate) fn prune_receipt<T: Config>(
     Ok(Some(block_tree_node))
 }
 
+pub(crate) fn invalid_bundle_authors_for_receipt<T: Config>(
+    domain_id: DomainId,
+    er: &ExecutionReceiptOf<T>,
+) -> Vec<OperatorId> {
+    let bundle_digests =
+        ExecutionInbox::<T>::get((domain_id, er.domain_block_number, er.consensus_block_number));
+    bundle_digests
+        .into_iter()
+        .enumerate()
+        .filter_map(|(index, digest)| {
+            let bundle_author = InboxedBundleAuthor::<T>::get(digest.header_hash)?;
+            if er.inboxed_bundles[index].is_invalid() {
+                Some(bundle_author)
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -15,7 +15,7 @@ pub mod domain_registry;
 pub mod extensions;
 pub mod migrations;
 pub mod runtime_registry;
-mod staking;
+pub mod staking;
 mod staking_epoch;
 pub mod weights;
 

--- a/domains/client/domain-operator/Cargo.toml
+++ b/domains/client/domain-operator/Cargo.toml
@@ -75,6 +75,7 @@ sc-service.workspace = true
 sp-domains = { workspace = true }
 sp-state-machine.workspace = true
 subspace-core-primitives.workspace = true
+subspace-test-client.workspace = true
 subspace-test-runtime.workspace = true
 subspace-test-service.workspace = true
 subspace-test-primitives = { workspace = true, features = ["std"] }

--- a/domains/client/domain-operator/src/bundle_producer_election_solver.rs
+++ b/domains/client/domain-operator/src/bundle_producer_election_solver.rs
@@ -89,11 +89,13 @@ where
                 &vrf_sign_data,
             ) {
                 if let Some(vrf_signature) = maybe_vrf_signature {
-                    let threshold = calculate_threshold(
+                    let Some(threshold) = calculate_threshold(
                         operator_stake,
                         total_domain_stake,
                         bundle_slot_probability,
-                    );
+                    ) else {
+                        return Ok(None);
+                    };
 
                     if is_below_threshold(&vrf_signature.pre_output, threshold) {
                         let proof_of_election = ProofOfElection {

--- a/domains/client/domain-operator/src/tests.rs
+++ b/domains/client/domain-operator/src/tests.rs
@@ -8667,6 +8667,35 @@ async fn test_false_bundle_author() {
             .contains_key(&bob_operator_id)
     );
     assert!(staking_summary.next_operators.contains(&bob_operator_id));
+
+    let tx = subspace_test_service::construct_extrinsic_generic::<_>(
+        &ferdie.client,
+        pallet_sudo::Call::sudo {
+            call: Box::new(
+                pallet_domains::Call::force_staking_epoch_transition {
+                    domain_id: EVM_DOMAIN_ID,
+                }
+                .into(),
+            ),
+        },
+        Sr25519Keyring::Alice,
+        false,
+        1,
+        0u128,
+    );
+    ferdie.send_extrinsic(tx).await.unwrap();
+
+    ferdie.produce_blocks(1).await.unwrap();
+    let staking_summary = ferdie
+        .get_domain_staking_summary(EVM_DOMAIN_ID)
+        .unwrap()
+        .unwrap();
+    assert!(
+        staking_summary
+            .current_operators
+            .contains_key(&bob_operator_id)
+    );
+    assert!(staking_summary.next_operators.contains(&bob_operator_id));
 }
 
 fn bundle_to_tx(

--- a/domains/client/domain-operator/src/tests.rs
+++ b/domains/client/domain-operator/src/tests.rs
@@ -43,7 +43,7 @@ use sp_domains::core_api::DomainCoreApi;
 use sp_domains::merkle_tree::MerkleTree;
 use sp_domains::{
     BlockFees, Bundle, BundleValidity, ChainId, ChannelId, DomainsApi, HeaderHashingFor,
-    InboxedBundle, InvalidBundleType, PermissionedActionAllowedBy, Transfers,
+    InboxedBundle, InvalidBundleType, OperatorPublicKey, PermissionedActionAllowedBy, Transfers,
 };
 use sp_domains_fraud_proof::InvalidTransactionCode;
 use sp_domains_fraud_proof::fraud_proof::{
@@ -59,7 +59,7 @@ use sp_runtime::traits::{BlakeTwo256, Convert, Hash as HashT, Header as HeaderT,
 use sp_runtime::transaction_validity::{
     InvalidTransaction, TransactionSource, TransactionValidityError,
 };
-use sp_runtime::{Digest, MultiAddress, OpaqueExtrinsic, TransactionOutcome};
+use sp_runtime::{Digest, MultiAddress, OpaqueExtrinsic, Percent, TransactionOutcome};
 use sp_state_machine::backend::AsTrieBackend;
 use sp_subspace_mmr::ConsensusChainMmrLeafProof;
 use sp_transaction_pool::runtime_api::TaggedTransactionQueue;
@@ -72,6 +72,7 @@ use std::time::Duration;
 use subspace_core_primitives::pot::PotOutput;
 use subspace_runtime_primitives::opaque::Block as CBlock;
 use subspace_runtime_primitives::{AI3, Balance, BlockHashFor, HeaderFor};
+use subspace_test_client::chain_spec::get_from_seed;
 use subspace_test_primitives::{DOMAINS_BLOCK_PRUNING_DEPTH, OnchainStateApi as _};
 use subspace_test_runtime::Runtime;
 use subspace_test_service::{
@@ -6245,6 +6246,8 @@ async fn test_multiple_consensus_blocks_derive_similar_domain_block() {
     // Fork B
     let bundle = {
         opaque_bundle.extrinsics = vec![];
+        // zero bundle weight since there are not extrinsics
+        opaque_bundle.sealed_header.header.estimated_bundle_weight = Weight::zero();
         opaque_bundle.sealed_header.header.bundle_extrinsics_root =
             sp_domains::EMPTY_EXTRINSIC_ROOT;
         opaque_bundle.sealed_header.signature = Sr25519Keyring::Alice
@@ -8462,6 +8465,208 @@ async fn test_domain_total_issuance_match_consensus_chain_bookkeeping_with_xdm()
         alice.clear_tx_pool().await;
         produce_blocks!(ferdie, alice, 5).await.unwrap();
     }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_false_bundle_author() {
+    let directory = TempDir::new().expect("Must be able to create temporary directory");
+
+    let mut builder = sc_cli::LoggerBuilder::new("");
+    builder.with_colors(false);
+    let _ = builder.init();
+
+    let tokio_handle = tokio::runtime::Handle::current();
+
+    // Start Ferdie
+    let mut ferdie = MockConsensusNode::run(
+        tokio_handle.clone(),
+        Ferdie,
+        BasePath::new(directory.path().join("ferdie")),
+    );
+
+    // Run Alice (a evm domain authority node)
+    let alice = domain_test_service::DomainNodeBuilder::new(
+        tokio_handle.clone(),
+        BasePath::new(directory.path().join("alice")),
+    )
+    .build_evm_node(Role::Authority, Alice, &mut ferdie)
+    .await;
+
+    // Run Bob as another authority node
+    let bob_operator_id = 2;
+    let bob = domain_test_service::DomainNodeBuilder::new(
+        tokio_handle.clone(),
+        BasePath::new(directory.path().join("bob")),
+    )
+    .operator_id(bob_operator_id)
+    .build_evm_node(Role::Authority, Bob, &mut ferdie)
+    .await;
+
+    produce_blocks!(ferdie, alice, 1, bob).await.unwrap();
+
+    let tx = subspace_test_service::construct_extrinsic_generic::<_>(
+        &ferdie.client,
+        pallet_domains::Call::register_operator {
+            domain_id: EVM_DOMAIN_ID,
+            amount: 100 * AI3,
+            config: OperatorConfig {
+                signing_key: get_from_seed::<OperatorPublicKey>("Bob"),
+                minimum_nominator_stake: 100 * AI3,
+                nomination_tax: Percent::from_percent(5),
+            },
+        },
+        Sr25519Keyring::Bob,
+        false,
+        0,
+        0u128,
+    );
+    ferdie.send_extrinsic(tx).await.unwrap();
+    produce_blocks!(ferdie, alice, 1, bob).await.unwrap();
+
+    let staking_summary = ferdie
+        .get_domain_staking_summary(EVM_DOMAIN_ID)
+        .unwrap()
+        .unwrap();
+    assert!(staking_summary.next_operators.contains(&bob_operator_id));
+
+    let tx = subspace_test_service::construct_extrinsic_generic::<_>(
+        &ferdie.client,
+        pallet_sudo::Call::sudo {
+            call: Box::new(
+                pallet_domains::Call::force_staking_epoch_transition {
+                    domain_id: EVM_DOMAIN_ID,
+                }
+                .into(),
+            ),
+        },
+        Sr25519Keyring::Alice,
+        false,
+        0,
+        0u128,
+    );
+    ferdie.send_extrinsic(tx).await.unwrap();
+
+    produce_blocks!(ferdie, alice, 1, bob).await.unwrap();
+
+    let staking_summary = ferdie
+        .get_domain_staking_summary(EVM_DOMAIN_ID)
+        .unwrap()
+        .unwrap();
+    assert!(
+        staking_summary
+            .current_operators
+            .contains_key(&bob_operator_id)
+    );
+    assert!(staking_summary.next_operators.contains(&bob_operator_id));
+
+    // Produce a bundle that contains the previously sent extrinsic and record that bundle for later use
+    let (slot, target_bundle) = ferdie
+        .produce_slot_and_wait_for_bundle_submission_from_operator(bob_operator_id)
+        .await;
+    let extrinsics: Vec<Vec<u8>> = target_bundle
+        .extrinsics
+        .clone()
+        .into_iter()
+        .map(|ext| ext.encode())
+        .collect();
+    let bundle_extrinsic_root = BlakeTwo256::ordered_trie_root(extrinsics, StateVersion::V1);
+    produce_block_with!(
+        ferdie.produce_block_with_slot_at(
+            slot,
+            ferdie.client.info().best_hash,
+            Some(vec![bundle_to_tx(&ferdie, target_bundle)])
+        ),
+        alice,
+        bob
+    )
+    .await
+    .unwrap();
+
+    // produce bundle from alice who marks the bob's previous invalid
+    let alice_operator_id = 0;
+    let (slot, mut opaque_bundle) = ferdie
+        .produce_slot_and_wait_for_bundle_submission_from_operator(alice_operator_id)
+        .await;
+
+    let (bad_receipt_hash, bad_submit_bundle_tx) = {
+        let bad_receipt = &mut opaque_bundle.sealed_header.header.receipt;
+        // bad receipt marks this particular bundle as `InvalidBundleWeight`
+        bad_receipt.inboxed_bundles = vec![InboxedBundle::invalid(
+            InvalidBundleType::InvalidBundleWeight,
+            bundle_extrinsic_root,
+        )];
+
+        opaque_bundle.sealed_header.signature = Sr25519Keyring::Alice
+            .pair()
+            .sign(opaque_bundle.sealed_header.pre_hash().as_ref())
+            .into();
+        (
+            opaque_bundle.receipt().hash::<BlakeTwo256>(),
+            bundle_to_tx(&ferdie, opaque_bundle),
+        )
+    };
+
+    // Wait for the fraud proof that targets the bad ER
+    let wait_for_fraud_proof_fut = ferdie.wait_for_fraud_proof(move |fp| {
+        if let FraudProofVariant::InvalidBundles(proof) = &fp.proof
+            && InvalidBundleType::InvalidBundleWeight == proof.invalid_bundle_type
+        {
+            assert!(!proof.is_good_invalid_fraud_proof);
+            return true;
+        }
+        false
+    });
+
+    // Produce a consensus block that contains `bad_submit_bundle_tx` and the bad receipt should
+    // be added to the consensus chain block tree
+    produce_block_with!(
+        ferdie.produce_block_with_slot_at(
+            slot,
+            ferdie.client.info().best_hash,
+            Some(vec![bad_submit_bundle_tx])
+        ),
+        alice,
+        bob
+    )
+    .await
+    .unwrap();
+    assert!(ferdie.does_receipt_exist(bad_receipt_hash).unwrap());
+
+    // bob should not be in the current and next operator set
+    let staking_summary = ferdie
+        .get_domain_staking_summary(EVM_DOMAIN_ID)
+        .unwrap()
+        .unwrap();
+    assert!(
+        !staking_summary
+            .current_operators
+            .contains_key(&bob_operator_id)
+    );
+    assert!(!staking_summary.next_operators.contains(&bob_operator_id));
+
+    let timed_out = tokio::time::timeout(TIMEOUT, wait_for_fraud_proof_fut)
+        .await
+        .inspect_err(|_| error!("fraud proof was not created before the timeout"))
+        .is_err();
+
+    // Produce a consensus block that contains the fraud proof, the fraud proof wil be verified
+    // and executed, and prune the bad receipt from the block tree
+    ferdie.produce_blocks(1).await.unwrap();
+    assert!(!ferdie.does_receipt_exist(bad_receipt_hash).unwrap());
+    // We check for timeouts last, because they are the least useful test failure message.
+    assert!(!timed_out);
+
+    // since er is pruned through fraud proof, bob should be back in next operator set.
+    let staking_summary = ferdie
+        .get_domain_staking_summary(EVM_DOMAIN_ID)
+        .unwrap()
+        .unwrap();
+    assert!(
+        !staking_summary
+            .current_operators
+            .contains_key(&bob_operator_id)
+    );
+    assert!(staking_summary.next_operators.contains(&bob_operator_id));
 }
 
 fn bundle_to_tx(

--- a/test/subspace-test-primitives/Cargo.toml
+++ b/test/subspace-test-primitives/Cargo.toml
@@ -13,6 +13,7 @@ include = [
 
 [dependencies]
 parity-scale-codec = { workspace = true, features = ["derive"] }
+pallet-domains.workspace = true
 sp-api.workspace = true
 sp-domains.workspace = true
 sp-core.workspace = true
@@ -25,6 +26,7 @@ subspace-runtime-primitives.workspace = true
 default = ["std"]
 std = [
     "parity-scale-codec/std",
+    "pallet-domains/std",
     "sp-api/std",
     "sp-domains/std",
     "sp-core/std",

--- a/test/subspace-test-primitives/src/lib.rs
+++ b/test/subspace-test-primitives/src/lib.rs
@@ -1,9 +1,10 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 //! Test primitive crates that expose necessary extensions that are used in tests.
 
+use pallet_domains::staking::StakingSummary;
 use parity_scale_codec::{Decode, Encode};
 use sp_core::H256;
-use sp_domains::DomainId;
+use sp_domains::{DomainId, OperatorId};
 use sp_messenger::messages::{ChainId, ChannelId};
 use sp_runtime::traits::NumberFor;
 use sp_subspace_mmr::{ConsensusChainMmrLeafProof, MmrLeaf};
@@ -29,5 +30,8 @@ sp_api::decl_runtime_apis! {
 
         /// Return the domain balance in the consensus chain bookkeeping
         fn domain_balance(domain_id: DomainId) -> Balance;
+
+        /// Returns the domain stake summary
+        fn domain_stake_summary(domain_id: DomainId) -> Option<StakingSummary<OperatorId, Balance>>;
     }
 }

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -59,6 +59,7 @@ use frame_support::{PalletId, construct_runtime, parameter_types};
 use frame_system::limits::{BlockLength, BlockWeights};
 use frame_system::pallet_prelude::RuntimeCallFor;
 use pallet_balances::NegativeImbalance;
+use pallet_domains::staking::StakingSummary;
 pub use pallet_rewards::RewardPoint;
 pub use pallet_subspace::{AllowAuthoringBy, EnableRewardsAt};
 use pallet_transporter::EndpointHandler;
@@ -1873,6 +1874,10 @@ impl_runtime_apis! {
 
         fn domain_balance(domain_id: DomainId) -> Balance {
             Transporter::domain_balances(domain_id)
+        }
+
+        fn domain_stake_summary(domain_id: DomainId) -> Option<StakingSummary<OperatorId, Balance>>{
+            Domains::domain_staking_summary(domain_id)
         }
     }
 


### PR DESCRIPTION
Up until now, we continue to accept bundles from operators who produced an invalid bundle before until they are slashed. If they have a higher stake, they can continue to produce more invalid bundles. This PR changes following
- Mark operator as InvalidBundleAuthor at a specific ER and remove them from current and next operator set.
- If the ER turns out to be malicious, then once the ER is pruned add them back to the next operator set and they will produce bundles from next epoch.
- If the ER is valid, then once the ER is confirmed, they will be slashed.

New variant to operator status is introduced but does not require any migration either on taurus or mainnet.
Also had to fix a test that was incorrectly constructed.

Closes: #2316

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
