### PR TITLE
Use higher default weight for pallet_transaction_fees init

### DIFF
--- a/crates/pallet-transaction-fees/src/weights.rs
+++ b/crates/pallet-transaction-fees/src/weights.rs
@@ -14,8 +14,9 @@ where
     T: frame_system::Config,
 {
     fn on_initialize() -> Weight {
-        Weight::from_parts(0, 0)
-            .saturating_add(T::DbWeight::get().reads(1_u64))
+        // TODO: benchmark this properly on reference hardware
+        Weight::from_parts(10_000, 10_000)
+            .saturating_add(T::DbWeight::get().reads(4_u64))
             .saturating_add(T::DbWeight::get().writes(4_u64))
     }
 }


### PR DESCRIPTION
The weight of pallet_transaction_fees::on_initialize is too low. It is missing 3 reads (from inside a function call), and CPU and proof size weights.

https://github.com/autonomys/subspace/blob/24d036cc6efd3f6372db275f1dfd4fc590ba6849/crates/pallet-transaction-fees/src/lib.rs#L157

This is only called once per block, so we can take the same approach as `set_next_consensus_chain_byte_fee`: use a known over-estimate, and benchmark properly when we have developer time.

There are roughly 12 instructions here, so 10,000 picoseconds of CPU is at least a 3x over-estimate.

We'll write a full benchmark when we prioritise developer time to work on ticket #3579.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
