### PR TITLE
Reduce "actively using dsn peers" log frequency

### DIFF
--- a/crates/subspace-networking/src/node_runner.rs
+++ b/crates/subspace-networking/src/node_runner.rs
@@ -54,7 +54,7 @@ const MAX_RANDOM_QUERY_INTERVAL: Duration = Duration::from_secs(60);
 const PERIODICAL_TASKS_INTERVAL: Duration = Duration::from_secs(5);
 
 /// The time between each peer stats info log.
-const PEER_INFO_LOG_INTERVAL: Duration = Duration::from_secs(30);
+const PEER_INFO_LOG_INTERVAL: Duration = Duration::from_secs(300);
 
 /// The maximum number of OS-reported listener addresses we will use.
 const MAX_LISTEN_ADDRESSES: usize = 30;


### PR DESCRIPTION
Currently, this log has a useful frequency on the node (1/10 log lines), but it is 149/150 log lines on the farmer, gateway, and DSN bootstrap nodes. This makes it hard to see other status lines.

Reducing the frequency to 5 minutes will reduce the frequency to 1/100 log lines on the node, and 14/15 on the farmer, gateway, and DSN bootstrap nodes. This will still give us important context in bug reports, but it won't be as spammy.

If we want to see frequent DSN status logs, we can use `RUST_LOG="[{connected_peers}]=debug,info"` to activate this 5 second log:
https://github.com/autonomys/subspace/blob/58c3df1515d11c0c0ca2333af32cd1c8ea078ecc/crates/subspace-networking/src/node_runner.rs#L1604-L1613

Here is the full `RUST_LOG` syntax:
https://docs.rs/tracing-subscriber/0.3.19/tracing_subscriber/filter/struct.EnvFilter.html#directives

cc @vedhavyas  because we talked about this log recently

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
