### PR TITLE
Retry segment downloads in node DSN sync and farmer piece reconstruction

### DIFF
--- a/crates/subspace-service/src/sync_from_dsn/import_blocks.rs
+++ b/crates/subspace-service/src/sync_from_dsn/import_blocks.rs
@@ -155,7 +155,9 @@ where
 
         let segment_pieces = download_segment_pieces(segment_index, piece_getter, 0, None)
             .await
-            .map_err(|error| format!("Failed to download segment pieces: {error}"))?;
+            .map_err(|error| {
+                format!("Failed to download segment pieces during block import: {error}")
+            })?;
         // CPU-intensive piece and segment reconstruction code can block the async executor.
         let segment_contents_fut = task::spawn_blocking({
             let reconstructor = reconstructor.clone();

--- a/crates/subspace-service/src/sync_from_dsn/snap_sync.rs
+++ b/crates/subspace-service/src/sync_from_dsn/snap_sync.rs
@@ -30,19 +30,15 @@ use std::time::Duration;
 use subspace_archiving::reconstructor::Reconstructor;
 use subspace_core_primitives::segments::SegmentIndex;
 use subspace_core_primitives::{BlockNumber, PublicKey};
-use subspace_data_retrieval::segment_downloading::download_segment_pieces;
+use subspace_data_retrieval::segment_downloading::{
+    SEGMENT_DOWNLOAD_RETRIES, SEGMENT_DOWNLOAD_RETRY_DELAY, download_segment_pieces,
+};
 use subspace_erasure_coding::ErasureCoding;
 use subspace_networking::Node;
 use tokio::sync::broadcast::Receiver;
 use tokio::task;
 use tokio::time::sleep;
 use tracing::{debug, error, trace, warn};
-
-/// The number of times we try to download a segment before giving up.
-const SEGMENT_DOWNLOAD_RETRIES: usize = 3;
-
-/// The amount of time we wait between segment download retries.
-const SEGMENT_DOWNLOAD_RETRY_DELAY: Duration = Duration::from_secs(10);
 
 /// Error type for snap sync.
 #[derive(thiserror::Error, Debug)]

--- a/crates/subspace-service/src/sync_from_dsn/snap_sync.rs
+++ b/crates/subspace-service/src/sync_from_dsn/snap_sync.rs
@@ -304,7 +304,9 @@ where
                 Some(SEGMENT_DOWNLOAD_RETRY_DELAY),
             )
             .await
-            .map_err(|error| format!("Failed to download segment pieces: {error}"))?;
+            .map_err(|error| {
+                format!("Failed to download segment pieces during snap sync: {error}")
+            })?;
 
             // CPU-intensive piece and segment reconstruction code can block the async executor.
             let segment_contents_fut = task::spawn_blocking({

--- a/shared/subspace-data-retrieval/src/segment_downloading.rs
+++ b/shared/subspace-data-retrieval/src/segment_downloading.rs
@@ -14,6 +14,14 @@ use tokio::task::spawn_blocking;
 use tokio::time::sleep;
 use tracing::debug;
 
+/// The number of times we try to download a segment before giving up.
+/// This is a suggested default, callers can supply their own value if needed.
+pub const SEGMENT_DOWNLOAD_RETRIES: usize = 3;
+
+/// The amount of time we wait between segment download retries.
+/// This is a suggested default, callers can supply their own value if needed.
+pub const SEGMENT_DOWNLOAD_RETRY_DELAY: Duration = Duration::from_secs(10);
+
 /// Segment getter errors.
 #[derive(Debug, thiserror::Error)]
 pub enum SegmentDownloadingError {


### PR DESCRIPTION
We've had one report of unreliable piece downloads on mainnet. This could be an unreliable or slow network, or it could be a rare networking bug.

As a precaution, I've made sure there are download retries wherever we download segments:
- during snap sync (already added in PR #3575)
- during DSN block sync on the node
- during piece reconstruction on the farmer

Without these retries, the node and farmer will try again later, after throwing away any pieces they have already downloaded. This is a waste, and could amplify network load issues, if this bug is triggered more often under network load.

#### Future Work

This is a mitigation for #3537 on mainnet, we should eventually diagnose and fix that bug (and review whether these retries are still needed).

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
