### PR TITLE
Make test CI more robust against network failures

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -278,7 +278,7 @@ jobs:
             ${{ runner.os }}-cargo-
 
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@07a34f8347b1eeb5f5469cdfa451b0a5db2ae4e8 # 2.38.4
+        uses: taiki-e/install-action@21517c4e721ab8b872d9b8e90828e584dcabe8e2 # 2.56.3
         with:
           tool: cargo-nextest
 


### PR DESCRIPTION
If crates.io is down, some CI actions can fail.

This is an upstream action issue, which is fixed by the latest action release:
https://github.com/taiki-e/install-action/issues/1005

It avoids errors like:
> Run taiki-e/install-action@07a34f8347b1eeb5f5469cdfa451b0a5db2ae4e8
> Run bash --noprofile --norc "${GITHUB_ACTION_PATH:?}/main.sh"
> info: host platform: x86_64_linux
> curl: (22) The requested URL returned error: 403

https://github.com/autonomys/space-acres/actions/runs/16038191770/job/45254425541#step:14:1

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
