### PR TITLE
Add migration for the SharePrice structure change on Taurus

### DIFF
--- a/crates/pallet-domains/src/migrations.rs
+++ b/crates/pallet-domains/src/migrations.rs
@@ -1,3 +1,68 @@
 mod v1_to_v5;
 
+pub(crate) use share_price_v0::OperatorEpochSharePrice as OperatorEpochSharePriceV0;
 pub use v1_to_v5::VersionCheckedMigrateDomainsV1ToV5;
+
+mod share_price_v0 {
+    use crate::staking::{DomainEpoch, SharePrice as SharePriceV1};
+    use crate::{Config, Pallet};
+    use frame_support::pallet_prelude::OptionQuery;
+    use frame_support::{Identity, storage_alias};
+    use parity_scale_codec::{Decode, Encode};
+    use scale_info::TypeInfo;
+    use sp_domains::OperatorId;
+    use sp_runtime::{Perbill, Perquintill};
+
+    #[derive(TypeInfo, Debug, Encode, Decode, Clone, PartialEq, Eq, Default)]
+    pub struct SharePrice(Perbill);
+
+    impl From<SharePrice> for SharePriceV1 {
+        fn from(val: SharePrice) -> Self {
+            SharePriceV1(Perquintill::from_parts(
+                (val.0.deconstruct() as u64).saturating_mul(1_000_000_000u64),
+            ))
+        }
+    }
+
+    #[storage_alias]
+    pub(crate) type OperatorEpochSharePrice<T: Config> = StorageDoubleMap<
+        Pallet<T>,
+        Identity,
+        OperatorId,
+        Identity,
+        DomainEpoch,
+        SharePrice,
+        OptionQuery,
+    >;
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use crate::staking::SharePrice as SharePriceV1;
+        use crate::tests::Test;
+
+        #[test]
+        fn test_share_price_structure_migration() {
+            let share_price_v0 = SharePrice(Perbill::from_rational(123456789u32, 987654321u32));
+            let share_price_v1: SharePriceV1 = share_price_v0.clone().into();
+
+            for n in [
+                1213u32,
+                940u32,
+                9678231u32,
+                2367u32,
+                834228u32,
+                298749827u32,
+            ] {
+                assert_eq!(
+                    share_price_v0.0.mul_floor(n) as u128,
+                    share_price_v1.stake_to_shares::<Test>(n.into())
+                );
+                assert_eq!(
+                    share_price_v0.0.saturating_reciprocal_mul_floor(n) as u128,
+                    share_price_v1.shares_to_stake::<Test>(n.into())
+                );
+            }
+        }
+    }
+}

--- a/crates/pallet-domains/src/migrations.rs
+++ b/crates/pallet-domains/src/migrations.rs
@@ -38,31 +38,67 @@ mod share_price_v0 {
     #[cfg(test)]
     mod tests {
         use super::*;
-        use crate::staking::SharePrice as SharePriceV1;
-        use crate::tests::Test;
+        use crate::staking::{SharePrice as SharePriceV1, get_share_price};
+        use crate::tests::{Test, new_test_ext};
 
         #[test]
         fn test_share_price_structure_migration() {
-            let share_price_v0 = SharePrice(Perbill::from_rational(123456789u32, 987654321u32));
-            let share_price_v1: SharePriceV1 = share_price_v0.clone().into();
-
-            for n in [
-                1213u32,
-                940u32,
-                9678231u32,
-                2367u32,
-                834228u32,
-                298749827u32,
+            for share_price_v0 in [
+                SharePrice(Perbill::from_parts(1)),
+                SharePrice(Perbill::one()),
+                SharePrice(Perbill::from_rational(123456789u32, 987654321u32)),
+                SharePrice(Perbill::from_rational(
+                    1_000_000_000u32,
+                    1_000_000_000u32 + 123456u32,
+                )),
             ] {
-                assert_eq!(
-                    share_price_v0.0.mul_floor(n) as u128,
-                    share_price_v1.stake_to_shares::<Test>(n.into())
-                );
-                assert_eq!(
-                    share_price_v0.0.saturating_reciprocal_mul_floor(n) as u128,
-                    share_price_v1.shares_to_stake::<Test>(n.into())
-                );
+                let share_price_v1: SharePriceV1 = share_price_v0.clone().into();
+
+                for n in [
+                    1213u128,
+                    940u128,
+                    9678231u128,
+                    2367u128,
+                    834228u128,
+                    298749827u128,
+                    1234567890987654321u128,
+                ] {
+                    assert_eq!(
+                        share_price_v0.0.mul_floor::<u128>(n),
+                        share_price_v1.stake_to_shares::<Test>(n)
+                    );
+
+                    // The v1 share price `shares_to_stake` will return a strict rounding down result
+                    // while the v0 may not, thus v0 share price may return more stake.
+                    assert!(
+                        share_price_v0.0.saturating_reciprocal_mul_floor::<u128>(n)
+                            >= share_price_v1.shares_to_stake::<Test>(n)
+                    );
+                }
             }
+        }
+
+        #[test]
+        fn test_share_price_getter_migration() {
+            new_test_ext().execute_with(|| {
+                let operator_id = 0;
+                let domain_epoch = (0u32.into(), 0u32).into();
+                let share_price_v0 = SharePrice(Perbill::from_rational(123456789u32, 987654321u32));
+                let share_price_v1: SharePriceV1 = share_price_v0.clone().into();
+
+                // Decode a v0 share price to v1 should result in an error
+                let decode_result =
+                    <SharePriceV1 as Decode>::decode(&mut share_price_v0.encode().as_slice());
+                assert!(decode_result.is_err());
+
+                // Insert an v0 share price
+                OperatorEpochSharePrice::<Test>::insert(operator_id, domain_epoch, &share_price_v0);
+
+                // `get_share_price` should internally convert the v0 share price to v1.
+                let share_price = get_share_price::<Test>(operator_id, domain_epoch);
+
+                assert_eq!(share_price, Some(share_price_v1));
+            })
         }
     }
 }

--- a/crates/pallet-domains/src/staking.rs
+++ b/crates/pallet-domains/src/staking.rs
@@ -5,6 +5,7 @@ extern crate alloc;
 
 use crate::block_tree::invalid_bundle_authors_for_receipt;
 use crate::bundle_storage_fund::{self, deposit_reserve_for_storage_fund};
+use crate::migrations::OperatorEpochSharePriceV0;
 use crate::pallet::{
     Deposits, DomainRegistry, DomainStakingSummary, HeadDomainNumber, NextOperatorId,
     OperatorIdOwner, Operators, PendingSlashes, PendingStakingOperationCount, Withdrawals,
@@ -40,7 +41,7 @@ pub(crate) struct Deposit<Share: Copy, Balance: Copy> {
 /// A share price is parts per billion of shares/ai3.
 /// Note: Shares must always be equal to or lower than ai3, and both shares and ai3 can't be zero.
 #[derive(TypeInfo, Debug, Encode, Decode, Clone, PartialEq, Eq, Default)]
-pub struct SharePrice(Perquintill);
+pub struct SharePrice(pub Perquintill);
 
 impl SharePrice {
     /// Creates a new instance of share price from shares and stake.
@@ -87,6 +88,16 @@ impl SharePrice {
     pub(crate) fn one() -> Self {
         Self(Perquintill::one())
     }
+}
+
+// TODO: this is only needed for migration of the share price structure change in Taurus
+// remove once Taurus is deprecated
+pub(crate) fn get_share_price<T: Config>(
+    operator_id: OperatorId,
+    domain_epoch: DomainEpoch,
+) -> Option<SharePrice> {
+    OperatorEpochSharePrice::<T>::get(operator_id, domain_epoch)
+        .or_else(|| OperatorEpochSharePriceV0::<T>::get(operator_id, domain_epoch).map(Into::into))
 }
 
 /// Unique epoch identifier across all domains. A combination of Domain and its epoch.
@@ -477,10 +488,7 @@ pub(crate) fn do_convert_previous_epoch_deposits<T: Config>(
     let epoch_share_price = match deposit.pending {
         None => return Ok(()),
         Some(pending_deposit) => {
-            match OperatorEpochSharePrice::<T>::get(
-                operator_id,
-                pending_deposit.effective_domain_epoch,
-            ) {
+            match get_share_price::<T>(operator_id, pending_deposit.effective_domain_epoch) {
                 Some(p) => p,
                 None => {
                     ensure!(
@@ -533,7 +541,7 @@ pub(crate) fn do_convert_previous_epoch_withdrawal<T: Config>(
                 return Ok(());
             }
 
-            match OperatorEpochSharePrice::<T>::get(operator_id, withdraw.domain_epoch) {
+            match get_share_price::<T>(operator_id, withdraw.domain_epoch) {
                 Some(p) => p,
                 None => return Err(Error::MissingOperatorEpochSharePrice),
             }


### PR DESCRIPTION
In the latest consensus runtime release of Taurus (spec version 16) the share price is defined as `SharePrice(Perbill)`, while in the main branch, the structure is changed to `SharePrice(Perquintill)`, `Perbill` and `Perquintill` internally use a different integer type, this PR adds necessary migration for this change on Taurus.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
