### PR TITLE
Bump binary crate versions to 0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13445,7 +13445,7 @@ dependencies = [
 
 [[package]]
 name = "subspace-farmer"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "async-lock 3.4.0",
@@ -13540,7 +13540,7 @@ dependencies = [
 
 [[package]]
 name = "subspace-gateway"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -13721,7 +13721,7 @@ dependencies = [
 
 [[package]]
 name = "subspace-node"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "auto-id-domain-runtime",
  "bip39",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13364,6 +13364,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "subspace-bootstrap-node"
+version = "0.1.1"
+dependencies = [
+ "clap",
+ "futures",
+ "hex",
+ "libp2p",
+ "prometheus-client",
+ "serde",
+ "serde_json",
+ "subspace-logging",
+ "subspace-metrics",
+ "subspace-networking",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "subspace-core-primitives"
 version = "0.1.0"
 dependencies = [
@@ -13706,8 +13724,6 @@ dependencies = [
  "prometheus-client",
  "rand 0.8.5",
  "schnellru",
- "serde",
- "serde_json",
  "subspace-core-primitives",
  "subspace-logging",
  "subspace-metrics",

--- a/crates/subspace-bootstrap-node/Cargo.toml
+++ b/crates/subspace-bootstrap-node/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "subspace-bootstrap-node"
+version = "0.1.1"
+authors = [
+    "Nazar Mokrynskyi <nazar@mokrynskyi.com>",
+    "Shamil Gadelshin <shamilgadelshin@gmail.com>"
+]
+description = "A Bootstrap node for the Subspace Network Blockchain"
+edition.workspace = true
+license = "0BSD"
+homepage = "https://subspace.network"
+repository = "https://github.com/autonomys/subspace"
+include = [
+    "/src",
+    "/Cargo.toml",
+]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[dependencies]
+clap = { workspace = true, features = ["color", "derive"] }
+futures.workspace = true
+hex.workspace = true
+libp2p = { workspace = true, features = ["kad"] }
+prometheus-client.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+subspace-logging.workspace = true
+subspace-metrics.workspace = true
+subspace-networking.workspace = true
+tokio = { workspace = true, features = ["macros", "parking_lot", "rt-multi-thread"] }
+tracing.workspace = true

--- a/crates/subspace-bootstrap-node/src/main.rs
+++ b/crates/subspace-bootstrap-node/src/main.rs
@@ -25,7 +25,7 @@ use tracing::{debug, info};
 pub const KNOWN_PEERS_CACHE_SIZE: u32 = 10000;
 
 #[derive(Debug, Parser)]
-#[clap(about, version = "0.1.1")]
+#[clap(about, version)]
 enum Command {
     /// Start bootstrap node
     Start {

--- a/crates/subspace-farmer/Cargo.toml
+++ b/crates/subspace-farmer/Cargo.toml
@@ -2,7 +2,7 @@
 name = "subspace-farmer"
 description = "Farmer for the Subspace Network Blockchain"
 license = "0BSD"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Nazar Mokrynskyi <nazar@mokrynskyi.com>"]
 edition.workspace = true
 include = [

--- a/crates/subspace-gateway/Cargo.toml
+++ b/crates/subspace-gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subspace-gateway"
-version = "0.1.0"
+version = "0.1.1"
 authors = [
     "Teor <teor@riseup.net>",
     "Shamil Gadelshin <shamilgadelshin@gmail.com>"

--- a/crates/subspace-networking/Cargo.toml
+++ b/crates/subspace-networking/Cargo.toml
@@ -27,6 +27,7 @@ fs2.workspace = true
 futures.workspace = true
 futures-timer.workspace = true
 hex.workspace = true
+libp2p = { workspace = true, features = ["autonat", "dns", "gossipsub", "identify", "kad", "macros", "metrics", "noise", "ping", "plaintext", "request-response", "serde", "tcp", "tokio", "yamux"] }
 memmap2.workspace = true
 multihash = { workspace = true, features = ["scale-codec"] }
 nohash-hasher.workspace = true
@@ -36,8 +37,6 @@ pin-project.workspace = true
 prometheus-client.workspace = true
 rand.workspace = true
 schnellru.workspace = true
-serde = { workspace = true, features = ["derive"] }
-serde_json.workspace = true
 subspace-core-primitives.workspace = true
 subspace-logging.workspace = true
 subspace-metrics.workspace = true
@@ -47,7 +46,6 @@ tokio-stream.workspace = true
 tracing.workspace = true
 unsigned-varint = { workspace = true, features = ["futures", "asynchronous_codec"] }
 void.workspace = true
-libp2p = { workspace = true, features = ["autonat", "dns", "gossipsub", "identify", "kad", "macros", "metrics", "noise", "ping", "plaintext", "request-response", "serde", "tcp", "tokio", "yamux"] }
 
 [dev-dependencies]
 rand.workspace = true

--- a/crates/subspace-networking/src/bin/subspace-bootstrap-node/main.rs
+++ b/crates/subspace-networking/src/bin/subspace-bootstrap-node/main.rs
@@ -25,7 +25,7 @@ use tracing::{debug, info};
 pub const KNOWN_PEERS_CACHE_SIZE: u32 = 10000;
 
 #[derive(Debug, Parser)]
-#[clap(about, version)]
+#[clap(about, version = "0.1.1")]
 enum Command {
     /// Start bootstrap node
     Start {

--- a/crates/subspace-node/Cargo.toml
+++ b/crates/subspace-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subspace-node"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Subspace Labs <https://subspace.network>"]
 description = "A Subspace Network Blockchain node."
 edition.workspace = true

--- a/docker/.dockerignore
+++ b/docker/.dockerignore
@@ -1,4 +1,6 @@
+# Exclude everything
 *
+# Then just include only the files required for builds
 !/crates
 !/domains
 !/shared

--- a/scripts/bump-versions.sh
+++ b/scripts/bump-versions.sh
@@ -23,12 +23,12 @@ if [[ -z "${SED_IN_PLACE[@]+"${SED_IN_PLACE[@]}"}" ]]; then
 fi
 
 echo "Current directory: $(pwd)"
-if [[ ! -d "./crates/subspace-node" ]] || [[ ! -d "./crates/subspace-gateway" ]] || [[ ! -d "./crates/subspace-farmer" ]] || [[ ! -d "./crates/subspace-networking/src/bin/subspace-bootstrap-node" ]]; then
+if [[ ! -d "./crates/subspace-node" ]] || [[ ! -d "./crates/subspace-gateway" ]] || [[ ! -d "./crates/subspace-farmer" ]] || [[ ! -d "./crates/subspace-bootstrap-node" ]]; then
   echo "Changing to the root of the repository:"
   cd "$(dirname "$0")/.."
   echo "Current directory: $(pwd)"
-  if [[ ! -d "./crates/subspace-node" ]] || [[ ! -d "./crates/subspace-gateway" ]] || [[ ! -d "./crates/subspace-farmer" ]] || [[ ! -d "./crates/subspace-networking/src/bin/subspace-bootstrap-node" ]]; then
-    echo "Missing ./crates/subspace-node, ./crates/subspace-gateway, ./crates/subspace-farmer or ./crates/subspace-networking/src/bin/subspace-bootstrap-node"
+  if [[ ! -d "./crates/subspace-node" ]] || [[ ! -d "./crates/subspace-gateway" ]] || [[ ! -d "./crates/subspace-farmer" ]] || [[ ! -d "./crates/subspace-bootstrap-node" ]]; then
+    echo "Missing ./crates/subspace-node, ./crates/subspace-gateway, ./crates/subspace-farmer or ./crates/subspace-bootstrap-node"
     echo "This script must be run from the base of an autonomys/subspace repository checkout"
     exit 1
   fi
@@ -42,7 +42,7 @@ echo "Replacing the old version ($OLD_VERSION) with the new version ($NEW_VERSIO
     ./crates/subspace-node/Cargo.toml \
     ./crates/subspace-gateway/Cargo.toml \
     ./crates/subspace-farmer/Cargo.toml \
-    ./crates/subspace-networking/src/bin/subspace-bootstrap-node/main.rs || (echo "'$SED_IN_PLACE' failed, please set \$SED_IN_PLACE to a valid sed in-place replacement command" && exit 1)
+    ./crates/subspace-bootstrap-node/Cargo.toml || (echo "'$SED_IN_PLACE' failed, please set \$SED_IN_PLACE to a valid sed in-place replacement command" && exit 1)
 
 echo "Updating Cargo.lock..."
 cargo check

--- a/scripts/bump-versions.sh
+++ b/scripts/bump-versions.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+# http://redsymbol.net/articles/unofficial-bash-strict-mode/
+set -euo pipefail
+
+if [[ "$#" -ne 2 ]]; then
+    echo "Usage: $0 <old-version> <new-version>"
+    exit 1
+fi
+
+OLD_VERSION="$1"
+NEW_VERSION="$2"
+
+# Users can set their own SED_IN_PLACE, for example, if their GNU sed is `gsed`
+if [[ -z "${SED_IN_PLACE[@]+"${SED_IN_PLACE[@]}"}" ]]; then
+  if [[ "$(uname)" == "Darwin" ]]; then
+    # BSD sed requires a space between -i and the backup extension
+    SED_IN_PLACE=(sed -i "")
+  else
+    # Assume everything else has GNU sed, where the backup extension is optional
+    SED_IN_PLACE=(sed --in-place)
+  fi
+fi
+
+echo "Current directory: $(pwd)"
+if [[ ! -d "./crates/subspace-node" ]] || [[ ! -d "./crates/subspace-gateway" ]] || [[ ! -d "./crates/subspace-farmer" ]] || [[ ! -d "./crates/subspace-networking/src/bin/subspace-bootstrap-node" ]]; then
+  echo "Changing to the root of the repository:"
+  cd "$(dirname "$0")/.."
+  echo "Current directory: $(pwd)"
+  if [[ ! -d "./crates/subspace-node" ]] || [[ ! -d "./crates/subspace-gateway" ]] || [[ ! -d "./crates/subspace-farmer" ]] || [[ ! -d "./crates/subspace-networking/src/bin/subspace-bootstrap-node" ]]; then
+    echo "Missing ./crates/subspace-node, ./crates/subspace-gateway, ./crates/subspace-farmer or ./crates/subspace-networking/src/bin/subspace-bootstrap-node"
+    echo "This script must be run from the base of an autonomys/subspace repository checkout"
+    exit 1
+  fi
+fi
+
+# show executed commands
+set -x
+
+echo "Replacing the old version ($OLD_VERSION) with the new version ($NEW_VERSION) in binary crates:"
+"${SED_IN_PLACE[@]}" -e "s/$OLD_VERSION/$NEW_VERSION/g" \
+    ./crates/subspace-node/Cargo.toml \
+    ./crates/subspace-gateway/Cargo.toml \
+    ./crates/subspace-farmer/Cargo.toml \
+    ./crates/subspace-networking/src/bin/subspace-bootstrap-node/main.rs || (echo "'$SED_IN_PLACE' failed, please set \$SED_IN_PLACE to a valid sed in-place replacement command" && exit 1)
+
+echo "Updating Cargo.lock..."
+cargo check
+
+echo "Making sure the old version is not used anywhere else:"
+if ! grep --recursive --exclude-dir=target --exclude-dir=.git --exclude=Cargo.lock --exclude=Cargo.toml --fixed-strings "$OLD_VERSION" .; then
+    # Stop showing executed commands
+    set +x
+    echo
+    echo "==================================="
+    echo "Success: all old versions replaced."
+    echo "==================================="
+    echo
+else
+    echo
+    echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+    echo "Error: The old version ($OLD_VERSION) is still in use."
+    echo "Please update this script ($0) to automatically replace it."
+    echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+    echo
+    exit 1
+fi


### PR DESCRIPTION
This PR bumps the farmer, node, gateway, and boostrap node versions to 0.1.1, and adds a `bump-versions.sh` script to make version bumps easier in future.

~~The bootstrap node doesn't have its own dedicated package, so we just bump its version in the `clap` macro.~~

I also moved the bootstrap node to its own crate, to simplify version management going forward.

#### Timing

We don't have to merge this right now, we just need it in before we tag the mainnet binary release.

As an alternative, we could bump to 0.1.1 for taurus testing, and 0.1.2 (or 0.2.0) for mainnet.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
