### PR TITLE
Catch solution from the future

### DIFF
--- a/crates/sc-consensus-subspace/src/block_import.rs
+++ b/crates/sc-consensus-subspace/src/block_import.rs
@@ -134,6 +134,14 @@ pub enum Error<Header: HeaderT> {
         /// How many pieces one sector is supposed to contain (max)
         max_pieces_in_sector: u16,
     },
+    /// History size is in the future
+    #[error("History size {solution} is in the future, current is {current}")]
+    FutureHistorySize {
+        /// Current history size
+        current: HistorySize,
+        /// History size solution was created for
+        solution: HistorySize,
+    },
     /// Piece verification failed
     #[error("Piece verification failed for slot {0}")]
     InvalidPiece(Slot),
@@ -218,6 +226,9 @@ where
                     piece_offset,
                     max_pieces_in_sector,
                 },
+                VerificationPrimitiveError::FutureHistorySize { current, solution } => {
+                    Error::FutureHistorySize { current, solution }
+                }
                 VerificationPrimitiveError::InvalidPiece => Error::InvalidPiece(slot),
                 VerificationPrimitiveError::OutsideSolutionRange {
                     half_solution_range,


### PR DESCRIPTION
This catches solution that is technically valid, but is in fact created for history size that has not happened yet.

The implication is that it was possible to create sectors that expire much later than expected.

The workflow is the following:
* modified farmer that only plots old history
  * sector is split into two halfs: one half with old and another with recent pieces
* picks history size in the future
* end up lucky with piece selection (or intentionally brute force various history sizes to become "lucky" since the process is probabilistic), such that all pieces already exist as of substantially older history size (at least within recent history size range is already a guaranteed success, possibly much later)
* while the history size is in the future, all pieces in the sector already exist, are value and will successfully verify

This PR extends consensus rules to ensure history size of the sector is not in the future.

This needs to be checked against mainnet history by doing full sync even though the benefit of such a hack is fairly limited, especially at current blockchain size.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
