### PR TITLE
Give SSH access to GitHub runners

### DIFF
--- a/.github/runs-on.yml
+++ b/.github/runs-on.yml
@@ -6,3 +6,8 @@ runners:
     family: ["c7a", "c7i", "m7a", "m7i"]
     spot: capacity-optimized
     image: ubuntu22-full-x64
+# Give runner SSH access to the GitHub SSH keys of these accounts
+admins:
+  - jfrank-summit
+  - teor2345
+  - vedhavyas


### PR DESCRIPTION
Normally, runner SSH access is automatically given to GitHub accounts with repository push permission.

This adds some extra developer accounts to that list:
https://runs-on.com/networking/ssh/#ssh-users

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
