### PR TITLE
disable spot instances

### DIFF
--- a/.github/runs-on.yml
+++ b/.github/runs-on.yml
@@ -4,7 +4,7 @@ runners:
     ram: [64, 128, 192]
     disk: default
     family: ["c7a", "c7i", "m7a", "m7i"]
-    spot: capacity-optimized
+    spot: false
     image: ubuntu22-full-x64
 # Give runner SSH access to the GitHub SSH keys of these accounts
 admins:


### PR DESCRIPTION
Due to our GH runners experiencing spot interruption events, i'm [disabling](https://runs-on.com/guides/troubleshoot/#spot-interruption-events) spot instances temporarily to see if that resolves the CI "Operation was cancelled" error we intermittently experience.

### Code contributor checklist:
* [X] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
