### PR TITLE
Run benchmark check in CI, allow devs to run CI scripts locally

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -354,20 +354,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-
 
-      # Pruning the target directory is only required if we're using a build cache or running locally
       - name: check all crates individually
         run: |
-          for crate in $(find . -name Cargo.toml -o -path ./target -prune | xargs -n 1 dirname | grep -v '^[.]$' | sort); do
-              echo "$crate";
-              pushd "$crate";
-              if ! cargo -Zgitoxide -Zgit clippy --locked --all-targets -- -D warnings; then
-                  pwd;
-                  popd;
-                  exit 1;
-              fi;
-              pwd;
-              popd;
-          done
+          scripts/check-crates-individually.sh
 
   # This job checks for incorrectly added dependencies, or dependencies that were made unused by code changes.
   cargo-unused-deps:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -364,14 +364,6 @@ jobs:
     runs-on: ${{ fromJson(github.repository_owner == 'autonomys' &&
       '"runs-on=${{ github.run_id }}/runner=self-hosted-ubuntu-22.04-x86-64"' || '"ubuntu-22.04"') }}
 
-    # This feature list is `--all-features` except `rocm`, which is incompatible with `cuda`
-    # When cargo supports excluding features (or mutually exclusive features), we can use
-    # `--all-features --exclude-feature rocm`
-    # <https://github.com/rust-lang/cargo/issues/11467>
-    # <https://internals.rust-lang.org/t/pre-rfc-mutually-excusive-global-features/19618>
-    env:
-      MOST_FEATURES: _gpu,async-trait,binary,cluster,cuda,default-library,domain-block-builder,domain-block-preprocessor,frame-benchmarking-cli,frame-system-benchmarking,hex-literal,kzg,numa,pallet-subspace,pallet-timestamp,pallet-utility,parallel,parking_lot,rand,runtime-benchmarks,sc-client-api,sc-executor,schnorrkel,serde,sp-blockchain,sp-core,sp-io,sp-state-machine,sp-std,sp-storage,sppark,static_assertions,std,subspace-proof-of-space-gpu,substrate-wasm-builder,testing,wasm-builder,with-tracing,x509-parser
-
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -387,7 +379,18 @@ jobs:
           cuda: '12.4.1'
           method: network
           sub-packages: '["nvcc", "cudart"]'
-        if: runner.os == 'Linux' || runner.os == 'Windows'
+
+      - name: ROCm toolchain
+        run: |
+          ROCM_VERSION=6.2.2
+          sudo mkdir -p --mode=0755 /etc/apt/keyrings
+          curl -L https://repo.radeon.com/rocm/rocm.gpg.key | gpg --dearmor | sudo tee /etc/apt/keyrings/rocm.gpg > /dev/null
+          echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/rocm/apt/$ROCM_VERSION jammy main" | sudo tee /etc/apt/sources.list.d/rocm.list > /dev/null
+          echo -e "Package: *\nPin: release o=repo.radeon.com\nPin-Priority: 600" | sudo tee /etc/apt/preferences.d/rocm-pin-600 > /dev/null
+          sudo apt-get update
+          DEBIAN_FRONTEND=noninteractive sudo apt-get install -y --no-install-recommends rocm-hip-runtime-dev
+          echo "/opt/rocm/lib" | sudo tee /etc/ld.so.conf.d/rocm.conf > /dev/null
+          sudo ldconfig
 
       - name: Configure cache
         uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
@@ -399,11 +402,15 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-
 
+      - name: Install cargo-udeps
+        uses: taiki-e/install-action@21517c4e721ab8b872d9b8e90828e584dcabe8e2 # 2.56.3
+        with:
+          tool: cargo-udeps
+
       # If this check fails, check the new dependency is actually needed. If it is, try adding any
-      # new features to MOST_FEATURES. If that doesn't work, add an exception to the crate:
+      # new features to MOST_FEATURES in the script. If that doesn't work, add an exception to the
+      # crate:
       # <https://github.com/est31/cargo-udeps?tab=readme-ov-file#ignoring-some-of-the-dependencies>
       - name: check for unused dependencies
-        uses: aig787/cargo-udeps-action@v1
-        with:
-          version: latest
-          args: --workspace --all-targets --locked --features ${{ env.MOST_FEATURES }}
+        run: |
+          ./scripts/find-unused-deps.sh

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -179,33 +179,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
-      # On macOS, we need a proper Clang version, not Apple's custom version without wasm32 support
-      - name: Install LLVM and Clang for macOS
-        uses: KyleMayes/install-llvm-action@dec985c8d7b46a2f363ea1a78f660c946a3349ea # v2.0.1
-        with:
-          env: true
-          version: 17
-        if: runner.os == 'macOS'
-
-      # Because macOS, see https://andreasfertig.blog/2021/02/clang-and-gcc-on-macos-catalina-finding-the-include-paths/
-      - name: Configure C compiler macOS
-        run: |
-          echo "SDKROOT=$(xcrun --show-sdk-path)" >> $GITHUB_ENV
-        if: runner.os == 'macOS'
-
-      - name: Install glibtoolize (macOS)
-        run: brew install libtool
-        if: runner.os == 'macOS'
-
       - name: Install Protoc
         uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-
-      # Needed for hwloc
-      - name: Install automake (macOS)
-        run: brew install automake
-        if: runner.os == 'macOS'
 
       - name: Configure cache
         uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -146,6 +146,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-
 
+      # Checks benchmark code style and syntax (but clippy does not do code generation checks)
       - name: cargo clippy
         run: |
           cargo -Zgitoxide -Zgit clippy --locked --all-targets --features runtime-benchmarks -- -D warnings
@@ -292,6 +293,39 @@ jobs:
       - name: cargo nextest run --locked
         run: |
           cargo -Zgitoxide -Zgit nextest run --locked
+
+  # Checks benchmark code generation, and runs each benchmark once.
+  # Fails if code generation fails, benchmarks panic, or generated weights are not valid Rust.
+  check-runtime-benchmarks:
+    # We always run benchmarks on our Linux reference machine
+    runs-on: ${{ fromJson(github.repository_owner == 'autonomys' &&
+      '"runs-on=${{ github.run_id }}/runner=self-hosted-ubuntu-22.04-x86-64"' || '"ubuntu-22.04"') }}
+
+    # Don't use the full 6 hours if a benchmark hangs
+    timeout-minutes: 120
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Install Protoc
+        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure cache
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: runtime-benchmark.sh check
+        run: |
+          scripts/runtime-benchmark.sh check
 
   # This job checks all crates individually, including no_std and other featureless builds.
   # We need to check crates individually for missing features, because cargo does feature

--- a/crates/subspace-farmer/Cargo.toml
+++ b/crates/subspace-farmer/Cargo.toml
@@ -60,7 +60,6 @@ subspace-logging = { workspace = true, optional = true }
 subspace-metrics = { workspace = true, optional = true }
 subspace-networking.workspace = true
 subspace-proof-of-space.workspace = true
-subspace-proof-of-space-gpu = { workspace = true, optional = true }
 subspace-rpc-primitives.workspace = true
 subspace-verification = { workspace = true, features = ["kzg"] }
 substrate-bip39.workspace = true
@@ -72,6 +71,10 @@ tokio-stream = { workspace = true, features = ["sync"] }
 tracing.workspace = true
 ulid = { workspace = true, features = ["serde"] }
 zeroize.workspace = true
+
+# Avoid an unused dependency on macOS, GPU is not supported there
+[target.'cfg(any(target_os = "linux", windows))'.dependencies]
+subspace-proof-of-space-gpu = { workspace = true, optional = true }
 
 [features]
 default = ["default-library", "binary"]

--- a/crates/subspace-runtime-primitives/src/extension.rs
+++ b/crates/subspace-runtime-primitives/src/extension.rs
@@ -72,10 +72,18 @@ where
 
         // Disable normal balance transfers.
         let (contains_balance_call, calls) = Self::contains_balance_transfer(call);
-        if contains_balance_call {
+
+        let res = if contains_balance_call {
             Err(InvalidTransaction::Call.into())
         } else {
             Ok((ValidTransaction::default(), calls))
+        };
+
+        // For benchmarks, always return success, so benchmarks run transfers.
+        if cfg!(feature = "runtime-benchmarks") {
+            Ok((ValidTransaction::default(), calls))
+        } else {
+            res
         }
     }
 

--- a/crates/subspace-runtime-primitives/src/extension/benchmarking.rs
+++ b/crates/subspace-runtime-primitives/src/extension/benchmarking.rs
@@ -22,6 +22,11 @@ pub struct Pallet<T: BalancesConfig + UtilityConfig + MultisigConfig>(PhantomDat
 
 const SEED: u32 = 0;
 
+/// Some machines have smaller stack sizes, so we need to limit the depth of the call stack.
+/// This is particularly important when dropping a deeply nested call stack, because each call
+/// results in two stack frames: a Call drop, and a Vec drop.
+const MAXIMUM_CALL_DEPTH: usize = 1000;
+
 #[allow(clippy::multiple_bound_locations)]
 #[benchmarks(where
 	T: Send + Sync + scale_info::TypeInfo + fmt::Debug +
@@ -36,41 +41,80 @@ mod benchmarks {
     use super::*;
     use frame_system::pallet_prelude::RuntimeCallFor;
 
+    /// Construct a single-level list of non-balance calls, with a balance call at the end.
     #[benchmark]
     fn balance_transfer_check_multiple(c: Linear<0, MAXIMUM_NUMBER_OF_CALLS>) {
         let mut calls = Vec::with_capacity(c as usize + 1);
-        for _i in 0..=c {
+        for _i in 0..c {
             // Non-balance calls are more expensive to check, because we have to read them all.
             // (We can only exit the check loop early if we encounter a balance transfer call.)
             calls.push(construct_non_balance_call::<T>());
         }
 
+        calls.push(construct_balance_call::<T>());
+
         let call = construct_utility_call_list::<T>(calls);
 
         #[block]
         {
+            // In benchmarks, we force the extension to always run its checks, and always return
+            // success, so we can run transfer benchmarks as well.
             BalanceTransferCheckExtension::<T>::do_validate_signed(&call).unwrap();
         }
     }
 
+    /// Construct a multi-level utility call tree, containing non-balance calls at the tips, and a
+    /// balance call at the end.
     #[benchmark]
     fn balance_transfer_check_utility(c: Linear<0, MAXIMUM_NUMBER_OF_CALLS>) {
-        let mut call = construct_balance_call::<T>();
-        for _i in 0..=c {
+        let c = c as usize;
+
+        let mut outer_call = Vec::with_capacity(c.div_ceil(MAXIMUM_CALL_DEPTH));
+
+        let mut call = construct_non_balance_call::<T>();
+        for i in 0..c {
             call = construct_utility_call::<T>(call);
+
+            if i >= MAXIMUM_CALL_DEPTH {
+                outer_call.push(call);
+                call = construct_non_balance_call::<T>();
+            }
         }
+
+        outer_call.push(call);
+        outer_call.push(construct_balance_call::<T>());
+
+        let call = construct_utility_call_list::<T>(outer_call);
+
         #[block]
         {
             BalanceTransferCheckExtension::<T>::do_validate_signed(&call).unwrap();
         }
     }
 
+    /// Construct a multi-level multisig call tree, containing non-balance calls at the tips, and a
+    /// balance call at the end.
     #[benchmark]
     fn balance_transfer_check_multisig(c: Linear<0, MAXIMUM_NUMBER_OF_CALLS>) {
-        let mut call = construct_balance_call::<T>();
-        for _i in 0..=c {
+        let c = c as usize;
+
+        let mut outer_call = Vec::with_capacity(c.div_ceil(MAXIMUM_CALL_DEPTH));
+
+        let mut call = construct_non_balance_call::<T>();
+        for i in 0..c {
             call = construct_multisig_call::<T>(call);
+
+            if i >= MAXIMUM_CALL_DEPTH {
+                outer_call.push(call);
+                call = construct_non_balance_call::<T>();
+            }
         }
+
+        outer_call.push(call);
+        outer_call.push(construct_balance_call::<T>());
+
+        let call = construct_utility_call_list::<T>(outer_call);
+
         #[block]
         {
             BalanceTransferCheckExtension::<T>::do_validate_signed(&call).unwrap();
@@ -78,6 +122,10 @@ mod benchmarks {
     }
 }
 
+/// Construct a balance transfer call.
+///
+/// Balance calls short-circuit the extension checks, so we can only use them at the end of a call
+/// list.
 fn construct_balance_call<T: BalancesConfig>() -> RuntimeCallFor<T>
 where
     RuntimeCallFor<T>: From<BalancesCall<T>>,
@@ -91,6 +139,7 @@ where
     .into()
 }
 
+/// Construct a non-balance call.
 fn construct_non_balance_call<T: BalancesConfig>() -> RuntimeCallFor<T>
 where
     RuntimeCallFor<T>: From<BalancesCall<T>>,
@@ -102,6 +151,7 @@ where
     .into()
 }
 
+/// Construct a utility call containing a single `call`.
 fn construct_utility_call<T: UtilityConfig>(call: RuntimeCallFor<T>) -> RuntimeCallFor<T>
 where
     RuntimeCallFor<T>: From<UtilityCall<T>>,
@@ -112,6 +162,7 @@ where
     .into()
 }
 
+/// Construct a utility call containing a list of `calls`.
 fn construct_utility_call_list<T: UtilityConfig>(calls: Vec<RuntimeCallFor<T>>) -> RuntimeCallFor<T>
 where
     RuntimeCallFor<T>: From<UtilityCall<T>>,
@@ -122,6 +173,7 @@ where
     .into()
 }
 
+/// Construct a multisig call containing a single `call`.
 fn construct_multisig_call<T: MultisigConfig>(call: RuntimeCallFor<T>) -> RuntimeCallFor<T>
 where
     RuntimeCallFor<T>: From<MultisigCall<T>> + Into<<T as MultisigConfig>::RuntimeCall>,

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -428,9 +428,10 @@ impl MaybeBalancesCall<Runtime> for RuntimeCall {
 impl BalanceTransferChecks for Runtime {
     fn is_balance_transferable() -> bool {
         let enabled = RuntimeConfigs::enable_balance_transfers();
-        // for benchmarks, always return enabled.
+        // For benchmarks, always return disabled, so the extension runs its checks.
+        // But in the extension, we always return success, so benchmarks run transfers as well.
         if cfg!(feature = "runtime-benchmarks") {
-            true
+            false
         } else {
             enabled
         }

--- a/scripts/bump-versions.sh
+++ b/scripts/bump-versions.sh
@@ -3,13 +3,14 @@
 # http://redsymbol.net/articles/unofficial-bash-strict-mode/
 set -euo pipefail
 
-if [[ "$#" -ne 2 ]]; then
-    echo "Usage: $0 <old-version> <new-version>"
-    exit 1
+if [[ "$#" -ne 3 ]] || ([[ "$1" != "client" ]] && [[ "$1" != "consensus" ]] && [[ "$1" != "evm" ]] && [[ "$1" != "auto-id" ]]); then
+  echo "Usage: $0 client|consensus|evm|auto-id <old-version> <new-version>"
+  exit 1
 fi
 
-OLD_VERSION="$1"
-NEW_VERSION="$2"
+MODE="$1"
+OLD_VERSION="$2"
+NEW_VERSION="$3"
 
 # Users can set their own SED_IN_PLACE, for example, if their GNU sed is `gsed`
 if [[ -z "${SED_IN_PLACE[@]+"${SED_IN_PLACE[@]}"}" ]]; then
@@ -23,12 +24,12 @@ if [[ -z "${SED_IN_PLACE[@]+"${SED_IN_PLACE[@]}"}" ]]; then
 fi
 
 echo "Current directory: $(pwd)"
-if [[ ! -d "./crates/subspace-node" ]] || [[ ! -d "./crates/subspace-gateway" ]] || [[ ! -d "./crates/subspace-farmer" ]] || [[ ! -d "./crates/subspace-bootstrap-node" ]]; then
+if [[ ! -d "./crates/subspace-node" ]] || [[ ! -d "./crates/subspace-runtime" ]] || [[ ! -d "./domains/runtime/evm" ]] || [[ ! -d "./domains/runtime/auto-id" ]]; then
   echo "Changing to the root of the repository:"
   cd "$(dirname "$0")/.."
   echo "Current directory: $(pwd)"
-  if [[ ! -d "./crates/subspace-node" ]] || [[ ! -d "./crates/subspace-gateway" ]] || [[ ! -d "./crates/subspace-farmer" ]] || [[ ! -d "./crates/subspace-bootstrap-node" ]]; then
-    echo "Missing ./crates/subspace-node, ./crates/subspace-gateway, ./crates/subspace-farmer or ./crates/subspace-bootstrap-node"
+  if [[ ! -d "./crates/subspace-node" ]] || [[ ! -d "./crates/subspace-runtime" ]] || [[ ! -d "./domains/runtime/evm" ]] || [[ ! -d "./domains/runtime/auto-id" ]]; then
+    echo "Missing ./crates/subspace-node, ./crates/subspace-runtime, ./domains/runtime/evm or ./domains/runtime/auto-id"
     echo "This script must be run from the base of an autonomys/subspace repository checkout"
     exit 1
   fi
@@ -37,26 +38,39 @@ fi
 # show executed commands
 set -x
 
-echo "Replacing the old version ($OLD_VERSION) with the new version ($NEW_VERSION) in binary crates:"
-"${SED_IN_PLACE[@]}" -e "s/$OLD_VERSION/$NEW_VERSION/g" \
+echo "Replacing old '$MODE' version '$OLD_VERSION' with new version '$NEW_VERSION' in crates:"
+if [[ "$MODE" == "client" ]]; then
+  "${SED_IN_PLACE[@]}" -e "s/$OLD_VERSION/$NEW_VERSION/g" \
     ./crates/subspace-node/Cargo.toml \
     ./crates/subspace-gateway/Cargo.toml \
     ./crates/subspace-farmer/Cargo.toml \
-    ./crates/subspace-bootstrap-node/Cargo.toml || (echo "'$SED_IN_PLACE' failed, please set \$SED_IN_PLACE to a valid sed in-place replacement command" && exit 1)
+    ./crates/subspace-bootstrap-node/Cargo.toml \
+      || (echo "'$SED_IN_PLACE' failed, please set \$SED_IN_PLACE to a valid sed in-place replacement command" && exit 1)
+elif [[ "$MODE" == "consensus" ]]; then
+  "${SED_IN_PLACE[@]}" -e "s/spec_version: $OLD_VERSION,/spec_version: $NEW_VERSION,/g" \
+    ./crates/subspace-runtime/src/lib.rs \
+      || (echo "'$SED_IN_PLACE' failed, please set \$SED_IN_PLACE to a valid sed in-place replacement command" && exit 1)
+elif [[ "$MODE" == "evm" ]]; then
+  "${SED_IN_PLACE[@]}" -e "s/spec_version: $OLD_VERSION,/spec_version: $NEW_VERSION,/g" \
+    ./domains/runtime/evm/src/lib.rs \
+      || (echo "'$SED_IN_PLACE' failed, please set \$SED_IN_PLACE to a valid sed in-place replacement command" && exit 1)
+elif [[ "$MODE" == "auto-id" ]]; then
+  "${SED_IN_PLACE[@]}" -e "s/spec_version: $OLD_VERSION,/spec_version: $NEW_VERSION,/g" \
+    ./domains/runtime/auto-id/src/lib.rs \
+      || (echo "'$SED_IN_PLACE' failed, please set \$SED_IN_PLACE to a valid sed in-place replacement command" && exit 1)
+fi
 
 echo "Updating Cargo.lock..."
-cargo check
+cargo check --profile release
 
-echo "Making sure the old version is not used anywhere else:"
-if ! grep --recursive --exclude-dir=target --exclude-dir=.git --exclude=Cargo.lock --exclude=Cargo.toml --fixed-strings "$OLD_VERSION" .; then
+if [[ "$MODE" == "client" ]]; then
+  echo "Making sure the old version is not used anywhere else:"
+  if ! grep --recursive --exclude-dir=target --exclude-dir=.git --exclude=Cargo.lock --exclude=Cargo.toml --fixed-strings "$OLD_VERSION" .; then
+    # It worked, fall through to the success message
+    echo "All old versions replaced"
+  else
     # Stop showing executed commands
     set +x
-    echo
-    echo "==================================="
-    echo "Success: all old versions replaced."
-    echo "==================================="
-    echo
-else
     echo
     echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
     echo "Error: The old version ($OLD_VERSION) is still in use."
@@ -64,4 +78,14 @@ else
     echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
     echo
     exit 1
+  fi
 fi
+
+# Stop showing executed commands
+set +x
+
+echo
+echo "======================================"
+echo "Success: old '$MODE' versions replaced"
+echo "======================================"
+echo

--- a/scripts/check-crates-individually.sh
+++ b/scripts/check-crates-individually.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+# http://redsymbol.net/articles/unofficial-bash-strict-mode/
+set -euo pipefail
+
+echo "Current directory: $(pwd)"
+if [[ ! -d "./crates/pallet-domains" ]] || [[ ! -d "./domains/runtime/evm" ]]; then
+  echo "Changing to the root of the repository:"
+  cd "$(dirname "$0")/.."
+  echo "Current directory: $(pwd)"
+  if [[ ! -d "./crates/pallet-domains" ]] || [[ ! -d "./domains/runtime/evm" ]]; then
+    echo "Missing ./crates/pallet-domains or ./domains/runtime/evm directories"
+    echo "This script must be run from the base of an autonomys/subspace repository checkout"
+    exit 1
+  fi
+fi
+
+# Show commands before executing them
+set -x
+
+# Pruning the target directory is only required if we're using a build cache or running locally
+for crate in $(find . -name Cargo.toml -o -path ./target -prune | xargs -n 1 dirname | grep -v '^[.]$' | sort); do
+  echo "Checking '$crate' will compile individually:"
+  pushd "$crate"
+  if ! cargo -Zgitoxide -Zgit clippy --locked --all-targets -- -D warnings; then
+    echo "Crate '$crate' failed to compile individually"
+    popd
+    exit 1
+  fi
+  echo "Crate '$crate' successfully compiled individually"
+  popd
+done
+
+# Stop showing executed commands
+set +x
+
+echo
+echo "============================================="
+echo "Successfully compiled all crates individually"
+echo "============================================="
+echo

--- a/scripts/find-unused-deps.sh
+++ b/scripts/find-unused-deps.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+# http://redsymbol.net/articles/unofficial-bash-strict-mode/
+set -euo pipefail
+
+echo "Current directory: $(pwd)"
+if [[ ! -d "./crates/pallet-domains" ]] || [[ ! -d "./domains/runtime/evm" ]]; then
+  echo "Changing to the root of the repository:"
+  cd "$(dirname "$0")/.."
+  echo "Current directory: $(pwd)"
+  if [[ ! -d "./crates/pallet-domains" ]] || [[ ! -d "./domains/runtime/evm" ]]; then
+    echo "Missing ./crates/pallet-domains or ./domains/runtime/evm directories"
+    echo "This script must be run from the base of an autonomys/subspace repository checkout"
+    exit 1
+  fi
+fi
+
+# This feature list is `--all-features` except `rocm`, which is incompatible with `cuda`
+# When cargo supports excluding features (or mutually exclusive features), we can use
+# `--all-features --exclude-feature rocm`
+# <https://github.com/rust-lang/cargo/issues/11467>
+# <https://internals.rust-lang.org/t/pre-rfc-mutually-excusive-global-features/19618>
+BASE_FEATURES="async-trait,binary,cluster,default-library,domain-block-builder,domain-block-preprocessor,frame-benchmarking-cli,frame-system-benchmarking,hex-literal,kzg,numa,pallet-subspace,pallet-timestamp,pallet-utility,parallel,parking_lot,rand,runtime-benchmarks,sc-client-api,sc-executor,schnorrkel,serde,sp-blockchain,sp-core,sp-io,sp-state-machine,sp-std,sp-storage,static_assertions,std,subspace-proof-of-space-gpu,substrate-wasm-builder,testing,wasm-builder,with-tracing,x509-parser"
+if [[ "$(uname)" == "Darwin" ]]; then
+  echo "Skipping GPU features because we're on macOS"
+  EXTRA_FEATURES=("")
+else
+  # We skip non-GPU builds on Linux and Windows, because they have unused GPU deps
+  EXTRA_FEATURES=("cuda,sppark,_gpu" "rocm,sppark,_gpu")
+fi
+
+# Show commands before executing them
+set -x
+
+for EXTRA_FEATURE in "${EXTRA_FEATURES[@]}"; do
+  echo "Checking for unused dependencies with '$EXTRA_FEATURE' extra features..."
+  cargo -Zgitoxide -Zgit udeps --workspace --all-targets --locked --features "$BASE_FEATURES,$EXTRA_FEATURE"
+done
+
+# Stop showing executed commands
+set +x
+
+echo
+echo "============================================"
+echo "Successfully checked for unused dependencies"
+if [[ "$(uname)" == "Darwin" ]]; then
+  echo "GPU features were not checked, because we're on macOS"
+fi
+echo "============================================"
+echo

--- a/shared/subspace-proof-of-space-gpu/Cargo.toml
+++ b/shared/subspace-proof-of-space-gpu/Cargo.toml
@@ -21,7 +21,8 @@ sppark = { workspace = true, optional = true }
 subspace-core-primitives = { workspace = true, optional = true }
 subspace-kzg = { workspace = true, optional = true }
 
-[dev-dependencies]
+# Avoid unused dependencies on macOS, GPU is not supported there
+[target.'cfg(any(target_os = "linux", windows))'.dev-dependencies]
 subspace-erasure-coding.workspace = true
 subspace-farmer-components.workspace = true
 subspace-proof-of-space.workspace = true


### PR DESCRIPTION
This PR makes it easier for developers to check their code and do releases, by improving our developer scripts and CI.

#### Benchmark Fixes

- makes the balance transfer extension benchmark actually check calls
- reduces the stack depth in the balance transfer extension benchmark, to avoid runtime stack overflow
- adds extra iterations to an unreliable benchmark (see https://github.com/autonomys/subspace/pull/3629#issuecomment-3063566497)

#### CI Improvements

- adds a runtime benchmarks check to CI, which runs one quick iteration
- removes unused steps in CI, which never actually run in our CI environments

#### Script Improvements

- adds consensus and domain runtime spec versions to bump-versions.sh
- makes some scripts work in more environments (like macOS)
- adds rocm checks to unused deps script
- checks that scripted code modifications will compile (in multiple scripts)

#### Script Movement

- moves find-unused-deps.sh and check-crates-individually.sh into their own scripts, so devs can run them locally

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
