### PR TITLE
Avoid Fn generics in bundle versions

### DIFF
--- a/crates/pallet-domains/src/tests.rs
+++ b/crates/pallet-domains/src/tests.rs
@@ -1440,11 +1440,12 @@ fn test_version_store_and_get() {
     let upgrades = get_mock_upgrades();
     ext.execute_with(|| {
         for (upgraded_at, current_version, _) in upgrades.clone() {
-            Domains::set_previous_bundle_and_execution_receipt_version(
-                upgraded_at,
-                MockPreviousBundleAndExecutionReceiptVersions::<Test>::set,
-                MockPreviousBundleAndExecutionReceiptVersions::<Test>::get,
-                current_version,
+            MockPreviousBundleAndExecutionReceiptVersions::<Test>::set(
+                Domains::calculate_previous_bundle_and_execution_receipt_versions(
+                    upgraded_at,
+                    MockPreviousBundleAndExecutionReceiptVersions::<Test>::get(),
+                    current_version,
+                ),
             );
         }
 
@@ -1476,7 +1477,7 @@ fn test_version_store_and_get() {
         for (number, expected_version) in get_mock_version_queries() {
             let got_version = Domains::bundle_and_execution_receipt_version_for_consensus_number(
                 number,
-                MockPreviousBundleAndExecutionReceiptVersions::<Test>::get,
+                MockPreviousBundleAndExecutionReceiptVersions::<Test>::get(),
                 current_version,
             )
             .unwrap();

--- a/crates/subspace-node/src/chain_spec.rs
+++ b/crates/subspace-node/src/chain_spec.rs
@@ -67,6 +67,8 @@ pub fn mainnet_compiled() -> Result<GenericChainSpec, String> {
     .with_name("Autonomys Mainnet")
     // ID
     .with_id("autonomys_mainnet")
+    // This is a Live chain, but we use Custom here to display the correct chain name across a
+    // range of clients.
     .with_chain_type(ChainType::Custom("Autonomys Mainnet".to_string()))
     .with_telemetry_endpoints(
         TelemetryEndpoints::new(vec![(SUBSPACE_TELEMETRY_URL.into(), 1)])

--- a/crates/subspace-node/src/commands/run/domain.rs
+++ b/crates/subspace-node/src/commands/run/domain.rs
@@ -266,6 +266,8 @@ pub(super) fn create_domain_configuration(
             consensus_chain_configuration.chain_spec.id(),
             domain_id
         ))
+        // Some domains are Live chains, but we use Custom here to display the "domain" chain type
+        // across a range of clients.
         .with_chain_type(ChainType::Custom("SubspaceDomain".to_string()))
         .with_boot_nodes(
             consensus_chain_configuration

--- a/crates/subspace-node/src/domain/auto_id_chain_spec.rs
+++ b/crates/subspace-node/src/domain/auto_id_chain_spec.rs
@@ -174,7 +174,7 @@ fn get_operator_params(
 
 /// Returns AutoId genesis domain.
 /// Note: Currently unused since dev or devnet uses EVM domain and not AutoId
-#[allow(dead_code)]
+#[expect(dead_code)]
 pub fn get_genesis_domain(
     spec_id: SpecId,
     sudo_account: subspace_runtime_primitives::AccountId,


### PR DESCRIPTION
This PR removes Fn generics in bundle versions, instead just calling those functions in the caller.

It also expands some of the bundle version comments.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
