### PR TITLE
Improve CI reliability and add S3 cache for speed

### DIFF
--- a/.github/runs-on.yml
+++ b/.github/runs-on.yml
@@ -1,10 +1,16 @@
 runners:
   self-hosted-ubuntu-22.04-x86-64:
-    cpu: [16, 32, 64]
-    ram: [64, 128, 192]
+    # A range from lowest to highest
+    cpu: [16, 64]
+    ram: [64, 192]
     disk: default
-    family: ["c7a", "c7i", "m7a", "m7i"]
+    # Don't allow ARM machines, because they are slower (and switching architectures randomly could be confusing)
+    # Also don't use older processor generations, because they are slower
+    family: ["c7a", "c7i", "m7a", "m7i", "r7a", "r7i"]
+    # Don't allow runner interruption
     spot: false
+    # Prefer instances with high capacity (low interruption risk), then low cost
+    #spot: capacity-optimized
     image: ubuntu22-full-x64
 # Give runner SSH access to the GitHub SSH keys of these accounts
 admins:

--- a/.github/workflows/chain-spec-snapshot-build.yml
+++ b/.github/workflows/chain-spec-snapshot-build.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   chains-spec:
     runs-on: ${{ fromJson(github.repository_owner == 'autonomys' &&
-      '"runs-on=${{ github.run_id }}/runner=self-hosted-ubuntu-22.04-x86-64/spot=false"' || '"ubuntu-22.04"') }}
+      '"runs-on=${{ github.run_id }}-${{ github.run_attempt }}/runner=self-hosted-ubuntu-22.04-x86-64/spot=false"' || '"ubuntu-22.04"') }}
     permissions:
       contents: write
       packages: write

--- a/.github/workflows/chain-spec-snapshot-build.yml
+++ b/.github/workflows/chain-spec-snapshot-build.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   chains-spec:
     runs-on: ${{ fromJson(github.repository_owner == 'autonomys' &&
-      '"runs-on=${{ github.run_id }}/runner=self-hosted-ubuntu-22.04-x86-64"' || '"ubuntu-22.04"') }}
+      '"runs-on=${{ github.run_id }}/runner=self-hosted-ubuntu-22.04-x86-64/spot=false"' || '"ubuntu-22.04"') }}
     permissions:
       contents: write
       packages: write

--- a/.github/workflows/domain-genesis-storage-snapshot-build.yml
+++ b/.github/workflows/domain-genesis-storage-snapshot-build.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   domain-genesis-storage:
     runs-on: ${{ fromJson(github.repository_owner == 'autonomys' &&
-      '"runs-on=${{ github.run_id }}/runner=self-hosted-ubuntu-22.04-x86-64/spot=false"' || '"ubuntu-22.04"') }}
+      '"runs-on=${{ github.run_id }}-${{ github.run_attempt }}/runner=self-hosted-ubuntu-22.04-x86-64/spot=false"' || '"ubuntu-22.04"') }}
     permissions:
       contents: write
       packages: write

--- a/.github/workflows/domain-genesis-storage-snapshot-build.yml
+++ b/.github/workflows/domain-genesis-storage-snapshot-build.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   domain-genesis-storage:
     runs-on: ${{ fromJson(github.repository_owner == 'autonomys' &&
-      '"runs-on=${{ github.run_id }}/runner=self-hosted-ubuntu-22.04-x86-64"' || '"ubuntu-22.04"') }}
+      '"runs-on=${{ github.run_id }}/runner=self-hosted-ubuntu-22.04-x86-64/spot=false"' || '"ubuntu-22.04"') }}
     permissions:
       contents: write
       packages: write

--- a/.github/workflows/runtime-snapshot-build.yml
+++ b/.github/workflows/runtime-snapshot-build.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   runtime:
     runs-on: ${{ fromJson(github.repository_owner == 'autonomys' &&
-      '"runs-on=${{ github.run_id }}/runner=self-hosted-ubuntu-22.04-x86-64/spot=false"' || '"ubuntu-22.04"') }}
+      '"runs-on=${{ github.run_id }}-${{ github.run_attempt }}/runner=self-hosted-ubuntu-22.04-x86-64/spot=false"' || '"ubuntu-22.04"') }}
     permissions:
       contents: write
       packages: write

--- a/.github/workflows/runtime-snapshot-build.yml
+++ b/.github/workflows/runtime-snapshot-build.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   runtime:
     runs-on: ${{ fromJson(github.repository_owner == 'autonomys' &&
-      '"runs-on=${{ github.run_id }}/runner=self-hosted-ubuntu-22.04-x86-64"' || '"ubuntu-22.04"') }}
+      '"runs-on=${{ github.run_id }}/runner=self-hosted-ubuntu-22.04-x86-64/spot=false"' || '"ubuntu-22.04"') }}
     permissions:
       contents: write
       packages: write

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -46,6 +46,7 @@ jobs:
   cargo-clippy:
     strategy:
       matrix:
+        # Disable spot instances in the GitHub merge queue, and disable runs-on entirely for forks
         os: ${{ fromJson(github.repository_owner == 'autonomys' &&
           '[
             "runs-on=${{ github.run_id }}/runner=self-hosted-ubuntu-22.04-x86-64/extras=s3-cache${{ env.SPOT }}",

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -40,21 +40,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
-      - name: Install Protoc
-        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Configure cache
-        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
-
       - name: cargo fmt
         run: cargo fmt --all -- --check
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -49,7 +49,7 @@ jobs:
         # Disable spot instances in the GitHub merge queue, and disable runs-on entirely for forks
         os: ${{ fromJson(github.repository_owner == 'autonomys' &&
           '[
-            "runs-on=${{ github.run_id }}/runner=self-hosted-ubuntu-22.04-x86-64/extras=s3-cache${{ env.SPOT }}",
+            "runs-on=${{ github.run_id }}-${{ github.run_attempt }}/runner=self-hosted-ubuntu-22.04-x86-64/extras=s3-cache${{ env.SPOT }}",
             ["self-hosted", "windows-server-2022-x86-64"],
             ["self-hosted", "macos-14-arm64"]
           ]' ||
@@ -87,6 +87,17 @@ jobs:
         run: brew install libtool
         if: runner.os == 'macOS'
 
+      # We cache protoc because it sometimes fails to download, but cache is too slow on Windows.
+      - name: Configure tool cache
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+        id: tool-cache
+        with:
+          path: '~/**/_tool'
+          # We don't have an easy way to clear old tool versions, but there aren't many tools
+          # (or versions), so just reset when we upgrade the compiler.
+          key: ${{ runner.os }}-tool-${{ hashFiles('./rust-toolchain.toml') }}
+        if: runner.os != 'Windows'
+
       - name: Install Protoc
         uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
         with:
@@ -97,6 +108,7 @@ jobs:
         run: brew install automake
         if: runner.os == 'macOS'
 
+      # TODO: cache CUDA from Program Files on Windows, because it takes 6+ minutes to install.
       - name: CUDA toolchain
         uses: Jimver/cuda-toolkit@4bd727d5619dc6fa323b1e76c3aa5dca94f5ec6d # v0.2.19
         with:
@@ -134,15 +146,31 @@ jobs:
           Remove-Item "${env:RUNNER_TEMP}\HIP-SDK-Installer.exe"
         if: runner.os == 'Windows' && steps.rocm-cache.outputs.cache-hit != 'true'
 
-      - name: Configure cache
+      - name: Configure source deps cache
         uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
+          # We don't need to cache anything more than the crate packages and bare git clones.
+          # <https://doc.rust-lang.org/cargo/guide/cargo-home.html#caching-the-cargo-home-in-ci>
           path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+          # Reset stored crates when any direct dependency versions change, so we aren't storing
+          # outdated versions. Currently this happens every 1-3 weeks.
+          key: ${{ runner.os }}-cargo-${{ hashFiles('./Cargo.toml') }}
+
+      - name: Configure compiled deps cache
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+        with:
+          # Clippy has no build artifacts, so we can save the whole target directory
+          path: './target'
+          # There's no point in restoring deps from older compiler versions, because they won't be
+          # used. To stop the cache from growing too large, we also reset it whenever any direct
+          # dependency version changes.
+          # TODO: we might be able to share clippy and check-individually caches
+          key: ${{ runner.os }}-${{ github.job }}-target-${{ hashFiles('./Cargo.toml') }}-${{ hashFiles('./rust-toolchain.toml') }}
+        # Windows caching is very slow, and we already have sccache on Linux
+        if: runner.os == 'macOS'
 
       # Checks benchmark code style and syntax (but clippy does not do code generation checks)
       - name: cargo clippy
@@ -171,7 +199,7 @@ jobs:
   cargo-runtime-build:
     # If clippy and tests pass on all OSes, it is unlikely that a runtime build will pass on Linux, but fail on other OSes.
     runs-on: ${{ fromJson(github.repository_owner == 'autonomys' &&
-      '"runs-on=${{ github.run_id }}/runner=self-hosted-ubuntu-22.04-x86-64${{ env.SPOT }}"' || '"ubuntu-22.04"') }}
+      '"runs-on=${{ github.run_id }}-${{ github.run_attempt }}/runner=self-hosted-ubuntu-22.04-x86-64/extras=s3-cache${{ env.SPOT }}"' || '"ubuntu-22.04"') }}
 
     steps:
       - uses: runs-on/action@cd2b598b0515d39d78c38a02d529db87d2196d1e # v2.0.3
@@ -183,20 +211,26 @@ jobs:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
+      - name: Configure tool cache
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+        id: tool-cache
+        with:
+          path: '~/**/_tool'
+          key: ${{ runner.os }}-tool-${{ hashFiles('./rust-toolchain.toml') }}
+
       - name: Install Protoc
         uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Configure cache
+      - name: Configure source deps cache
         uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+          key: ${{ runner.os }}-cargo-${{ hashFiles('./Cargo.toml') }}
 
       - name: build subspace-runtime
         run: |
@@ -215,7 +249,7 @@ jobs:
       matrix:
         os: ${{ fromJson(github.repository_owner == 'autonomys' &&
           '[
-            "runs-on=${{ github.run_id }}/runner=self-hosted-ubuntu-22.04-x86-64${{ env.SPOT }}",
+            "runs-on=${{ github.run_id }}-${{ github.run_attempt }}/runner=self-hosted-ubuntu-22.04-x86-64/extras=s3-cache${{ env.SPOT }}",
             ["self-hosted", "windows-server-2022-x86-64"],
             ["self-hosted", "macos-14-arm64"]
           ]' ||
@@ -252,6 +286,14 @@ jobs:
         run: brew install libtool
         if: runner.os == 'macOS'
 
+      - name: Configure tool cache
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+        id: tool-cache
+        with:
+          path: '~/**/_tool'
+          key: ${{ runner.os }}-tool-${{ hashFiles('./rust-toolchain.toml') }}
+        if: runner.os != 'Windows'
+
       - name: Install Protoc
         uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
         with:
@@ -262,20 +304,19 @@ jobs:
         run: brew install automake
         if: runner.os == 'macOS'
 
-      - name: Configure cache
-        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
-
       - name: Install cargo-nextest
         uses: taiki-e/install-action@21517c4e721ab8b872d9b8e90828e584dcabe8e2 # 2.56.3
         with:
           tool: cargo-nextest
+
+      - name: Configure source deps cache
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+        with:
+          path: |
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+          key: ${{ runner.os }}-cargo-${{ hashFiles('./Cargo.toml') }}
 
       - name: cargo nextest run --locked
         run: |
@@ -286,7 +327,7 @@ jobs:
   check-runtime-benchmarks:
     # We always run benchmarks on our Linux reference machine
     runs-on: ${{ fromJson(github.repository_owner == 'autonomys' &&
-      '"runs-on=${{ github.run_id }}/runner=self-hosted-ubuntu-22.04-x86-64${{ env.SPOT }}"' || '"ubuntu-22.04"') }}
+      '"runs-on=${{ github.run_id }}-${{ github.run_attempt }}/runner=self-hosted-ubuntu-22.04-x86-64/extras=s3-cache${{ env.SPOT }}"' || '"ubuntu-22.04"') }}
 
     # Don't use the full 6 hours if a benchmark hangs
     timeout-minutes: 120
@@ -301,20 +342,26 @@ jobs:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
+      - name: Configure tool cache
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+        id: tool-cache
+        with:
+          path: '~/**/_tool'
+          key: ${{ runner.os }}-tool-${{ hashFiles('./rust-toolchain.toml') }}
+
       - name: Install Protoc
         uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Configure cache
+      - name: Configure source deps cache
         uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+          key: ${{ runner.os }}-cargo-${{ hashFiles('./Cargo.toml') }}
 
       - name: runtime-benchmark.sh check
         run: |
@@ -326,7 +373,7 @@ jobs:
   cargo-check-individually:
     # If clippy and tests pass on all OSes, it is unlikely that a crate build will pass on Linux but fail on other OSes.
     runs-on: ${{ fromJson(github.repository_owner == 'autonomys' &&
-      '"runs-on=${{ github.run_id }}/runner=self-hosted-ubuntu-22.04-x86-64${{ env.SPOT }}"' || '"ubuntu-22.04"') }}
+      '"runs-on=${{ github.run_id }}-${{ github.run_attempt }}/runner=self-hosted-ubuntu-22.04-x86-64/extras=s3-cache${{ env.SPOT }}"' || '"ubuntu-22.04"') }}
 
     steps:
       - uses: runs-on/action@cd2b598b0515d39d78c38a02d529db87d2196d1e # v2.0.3
@@ -338,20 +385,27 @@ jobs:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
+      - name: Configure tool cache
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+        id: tool-cache
+        with:
+          path: '~/**/_tool'
+          key: ${{ runner.os }}-tool-${{ hashFiles('./rust-toolchain.toml') }}
+
       - name: Install Protoc
         uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Configure cache
+
+      - name: Configure source deps cache
         uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+          key: ${{ runner.os }}-cargo-${{ hashFiles('./Cargo.toml') }}
 
       - name: check all crates individually
         run: |
@@ -361,7 +415,7 @@ jobs:
   cargo-unused-deps:
     # We need to use Linux to check GPU dependencies (or Windows, but it's slow)
     runs-on: ${{ fromJson(github.repository_owner == 'autonomys' &&
-      '"runs-on=${{ github.run_id }}/runner=self-hosted-ubuntu-22.04-x86-64${{ env.SPOT }}"' || '"ubuntu-22.04"') }}
+      '"runs-on=${{ github.run_id }}-${{ github.run_attempt }}/runner=self-hosted-ubuntu-22.04-x86-64/extras=s3-cache${{ env.SPOT }}"' || '"ubuntu-22.04"') }}
 
     steps:
       - uses: runs-on/action@cd2b598b0515d39d78c38a02d529db87d2196d1e # v2.0.3
@@ -372,6 +426,13 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Configure tool cache
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+        id: tool-cache
+        with:
+          path: '~/**/_tool'
+          key: ${{ runner.os }}-tool-${{ hashFiles('./rust-toolchain.toml') }}
 
       - name: Install Protoc
         uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
@@ -397,20 +458,19 @@ jobs:
           echo "/opt/rocm/lib" | sudo tee /etc/ld.so.conf.d/rocm.conf > /dev/null
           sudo ldconfig
 
-      - name: Configure cache
-        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
-
       - name: Install cargo-udeps
         uses: taiki-e/install-action@21517c4e721ab8b872d9b8e90828e584dcabe8e2 # 2.56.3
         with:
           tool: cargo-udeps
+
+      - name: Configure source deps cache
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+        with:
+          path: |
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+          key: ${{ runner.os }}-cargo-${{ hashFiles('./Cargo.toml') }}
 
       # If this check fails, check the new dependency is actually needed. If it is, try adding any
       # new features to MOST_FEATURES in the script. If that doesn't work, add an exception to the

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,6 +26,10 @@ env:
   # For slow tests, this can be reduced using `#[property_test(config = "ProptestConfig { .. }")]`.
   PROPTEST_CASES: 10000
   PROPTEST_MAX_GLOBAL_REJECTS: 100000
+  # Disable spot instances in the GitHub merge queue. Otherwise, inherit the spot setting from the
+  # runner config. This environment variable helps us avoid nested strings inside complex actions
+  # expressions.
+  SPOT: ${{ contains(github.ref, 'gh-readonly-queue') && '/spot=false' || '' }}
 
 jobs:
   cargo-fmt:
@@ -59,7 +63,7 @@ jobs:
       matrix:
         os: ${{ fromJson(github.repository_owner == 'autonomys' &&
           '[
-            "runs-on=${{ github.run_id }}/runner=self-hosted-ubuntu-22.04-x86-64",
+            "runs-on=${{ github.run_id }}/runner=self-hosted-ubuntu-22.04-x86-64/extras=s3-cache${{ env.SPOT }}",
             ["self-hosted", "windows-server-2022-x86-64"],
             ["self-hosted", "macos-14-arm64"]
           ]' ||
@@ -173,7 +177,7 @@ jobs:
   cargo-runtime-build:
     # If clippy and tests pass on all OSes, it is unlikely that a runtime build will pass on Linux, but fail on other OSes.
     runs-on: ${{ fromJson(github.repository_owner == 'autonomys' &&
-      '"runs-on=${{ github.run_id }}/runner=self-hosted-ubuntu-22.04-x86-64"' || '"ubuntu-22.04"') }}
+      '"runs-on=${{ github.run_id }}/runner=self-hosted-ubuntu-22.04-x86-64${{ env.SPOT }}"' || '"ubuntu-22.04"') }}
 
     steps:
       - name: Checkout
@@ -211,7 +215,7 @@ jobs:
       matrix:
         os: ${{ fromJson(github.repository_owner == 'autonomys' &&
           '[
-            "runs-on=${{ github.run_id }}/runner=self-hosted-ubuntu-22.04-x86-64",
+            "runs-on=${{ github.run_id }}/runner=self-hosted-ubuntu-22.04-x86-64${{ env.SPOT }}",
             ["self-hosted", "windows-server-2022-x86-64"],
             ["self-hosted", "macos-14-arm64"]
           ]' ||
@@ -276,7 +280,7 @@ jobs:
   check-runtime-benchmarks:
     # We always run benchmarks on our Linux reference machine
     runs-on: ${{ fromJson(github.repository_owner == 'autonomys' &&
-      '"runs-on=${{ github.run_id }}/runner=self-hosted-ubuntu-22.04-x86-64"' || '"ubuntu-22.04"') }}
+      '"runs-on=${{ github.run_id }}/runner=self-hosted-ubuntu-22.04-x86-64${{ env.SPOT }}"' || '"ubuntu-22.04"') }}
 
     # Don't use the full 6 hours if a benchmark hangs
     timeout-minutes: 120
@@ -310,7 +314,7 @@ jobs:
   cargo-check-individually:
     # If clippy and tests pass on all OSes, it is unlikely that a crate build will pass on Linux but fail on other OSes.
     runs-on: ${{ fromJson(github.repository_owner == 'autonomys' &&
-      '"runs-on=${{ github.run_id }}/runner=self-hosted-ubuntu-22.04-x86-64"' || '"ubuntu-22.04"') }}
+      '"runs-on=${{ github.run_id }}/runner=self-hosted-ubuntu-22.04-x86-64${{ env.SPOT }}"' || '"ubuntu-22.04"') }}
 
     steps:
       - name: Checkout
@@ -339,7 +343,7 @@ jobs:
   cargo-unused-deps:
     # We need to use Linux to check GPU dependencies (or Windows, but it's slow)
     runs-on: ${{ fromJson(github.repository_owner == 'autonomys' &&
-      '"runs-on=${{ github.run_id }}/runner=self-hosted-ubuntu-22.04-x86-64"' || '"ubuntu-22.04"') }}
+      '"runs-on=${{ github.run_id }}/runner=self-hosted-ubuntu-22.04-x86-64${{ env.SPOT }}"' || '"ubuntu-22.04"') }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -33,8 +33,8 @@ env:
 
 jobs:
   cargo-fmt:
-    runs-on: ${{ fromJson(github.repository_owner == 'autonomys' &&
-      '"runs-on=${{ github.run_id }}/runner=self-hosted-ubuntu-22.04-x86-64"' || '"ubuntu-22.04"') }}
+    # Format checks do not require significant resources, so we use a free runner.
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -58,6 +58,14 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+      # Enable the sccache runs-on S3 backend for Linux runners, to cache C/C++/CUDA and Rust.
+      # On GitHub-hosted or fork runners, the runs-on action is ignored.
+      - uses: runs-on/action@cd2b598b0515d39d78c38a02d529db87d2196d1e # v2.0.3
+        with:
+          sccache: ${{ runner.os == 'Linux' && 's3' || '' }}
+      - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+        if: runner.os == 'Linux' && github.repository_owner == 'autonomys'
+
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
@@ -166,6 +174,12 @@ jobs:
       '"runs-on=${{ github.run_id }}/runner=self-hosted-ubuntu-22.04-x86-64${{ env.SPOT }}"' || '"ubuntu-22.04"') }}
 
     steps:
+      - uses: runs-on/action@cd2b598b0515d39d78c38a02d529db87d2196d1e # v2.0.3
+        with:
+          sccache: 's3'
+      - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+        if: github.repository_owner == 'autonomys'
+
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
@@ -211,6 +225,12 @@ jobs:
     timeout-minutes: 120
 
     steps:
+      - uses: runs-on/action@cd2b598b0515d39d78c38a02d529db87d2196d1e # v2.0.3
+        with:
+          sccache: ${{ runner.os == 'Linux' && 's3' || '' }}
+      - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+        if: runner.os == 'Linux' && github.repository_owner == 'autonomys'
+
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
@@ -272,6 +292,12 @@ jobs:
     timeout-minutes: 120
 
     steps:
+      - uses: runs-on/action@cd2b598b0515d39d78c38a02d529db87d2196d1e # v2.0.3
+        with:
+          sccache: 's3'
+      - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+        if: github.repository_owner == 'autonomys'
+
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
@@ -303,6 +329,12 @@ jobs:
       '"runs-on=${{ github.run_id }}/runner=self-hosted-ubuntu-22.04-x86-64${{ env.SPOT }}"' || '"ubuntu-22.04"') }}
 
     steps:
+      - uses: runs-on/action@cd2b598b0515d39d78c38a02d529db87d2196d1e # v2.0.3
+        with:
+          sccache: 's3'
+      - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+        if: github.repository_owner == 'autonomys'
+
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
@@ -332,6 +364,12 @@ jobs:
       '"runs-on=${{ github.run_id }}/runner=self-hosted-ubuntu-22.04-x86-64${{ env.SPOT }}"' || '"ubuntu-22.04"') }}
 
     steps:
+      - uses: runs-on/action@cd2b598b0515d39d78c38a02d529db87d2196d1e # v2.0.3
+        with:
+          sccache: 's3'
+      - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+        if: github.repository_owner == 'autonomys'
+
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -33,6 +33,7 @@ env:
 
 jobs:
   cargo-fmt:
+    name: cargo-fmt (Linux x86-64)
     # Format checks do not require significant resources, so we use a free runner.
     runs-on: ubuntu-22.04
 
@@ -44,6 +45,7 @@ jobs:
         run: cargo fmt --all -- --check
 
   cargo-clippy:
+    name: cargo-clippy (${{ strategy.job-index == 0 && 'Linux x86-64' || (strategy.job-index == 1 && 'Windows x86-64' || 'macOS arm64') }})
     strategy:
       matrix:
         # Disable spot instances in the GitHub merge queue, and disable runs-on entirely for forks
@@ -197,6 +199,7 @@ jobs:
         if: runner.os == 'Windows'
 
   cargo-runtime-build:
+    name: cargo-runtime-build (Linux x86-64)
     # If clippy and tests pass on all OSes, it is unlikely that a runtime build will pass on Linux, but fail on other OSes.
     runs-on: ${{ fromJson(github.repository_owner == 'autonomys' &&
       '"runs-on=${{ github.run_id }}-${{ github.run_attempt }}/runner=self-hosted-ubuntu-22.04-x86-64/extras=s3-cache${{ env.SPOT }}"' || '"ubuntu-22.04"') }}
@@ -245,6 +248,7 @@ jobs:
           cargo -Zgitoxide -Zgit build --locked --package auto-id-domain-runtime
 
   cargo-test:
+    name: cargo-test (${{ strategy.job-index == 0 && 'Linux x86-64' || (strategy.job-index == 1 && 'Windows x86-64' || 'macOS arm64') }})
     strategy:
       matrix:
         os: ${{ fromJson(github.repository_owner == 'autonomys' &&
@@ -325,6 +329,7 @@ jobs:
   # Checks benchmark code generation, and runs each benchmark once.
   # Fails if code generation fails, benchmarks panic, or generated weights are not valid Rust.
   check-runtime-benchmarks:
+    name: check-runtime-benchmarks (Linux x86-64)
     # We always run benchmarks on our Linux reference machine
     runs-on: ${{ fromJson(github.repository_owner == 'autonomys' &&
       '"runs-on=${{ github.run_id }}-${{ github.run_attempt }}/runner=self-hosted-ubuntu-22.04-x86-64/extras=s3-cache${{ env.SPOT }}"' || '"ubuntu-22.04"') }}
@@ -371,6 +376,7 @@ jobs:
   # We need to check crates individually for missing features, because cargo does feature
   # unification, which hides missing features when crates are built together.
   cargo-check-individually:
+    name: cargo-check-individually (Linux x86-64)
     # If clippy and tests pass on all OSes, it is unlikely that a crate build will pass on Linux but fail on other OSes.
     runs-on: ${{ fromJson(github.repository_owner == 'autonomys' &&
       '"runs-on=${{ github.run_id }}-${{ github.run_attempt }}/runner=self-hosted-ubuntu-22.04-x86-64/extras=s3-cache${{ env.SPOT }}"' || '"ubuntu-22.04"') }}
@@ -413,6 +419,7 @@ jobs:
 
   # This job checks for incorrectly added dependencies, or dependencies that were made unused by code changes.
   cargo-unused-deps:
+    name: cargo-unused-deps (Linux x86-64)
     # We need to use Linux to check GPU dependencies (or Windows, but it's slow)
     runs-on: ${{ fromJson(github.repository_owner == 'autonomys' &&
       '"runs-on=${{ github.run_id }}-${{ github.run_attempt }}/runner=self-hosted-ubuntu-22.04-x86-64/extras=s3-cache${{ env.SPOT }}"' || '"ubuntu-22.04"') }}

--- a/.github/workflows/snapshot-build.yml
+++ b/.github/workflows/snapshot-build.yml
@@ -21,7 +21,7 @@ jobs:
   # This will build container images and then extract executables out of them
   ubuntu:
     runs-on: ${{ fromJson(github.repository_owner == 'autonomys' &&
-      '"runs-on=${{ github.run_id }}/runner=self-hosted-ubuntu-22.04-x86-64/spot=false"' || '"ubuntu-22.04"') }}
+      '"runs-on=${{ github.run_id }}-${{ github.run_attempt }}/runner=self-hosted-ubuntu-22.04-x86-64/spot=false"' || '"ubuntu-22.04"') }}
     permissions:
       contents: write
       packages: write

--- a/.github/workflows/snapshot-build.yml
+++ b/.github/workflows/snapshot-build.yml
@@ -21,7 +21,7 @@ jobs:
   # This will build container images and then extract executables out of them
   ubuntu:
     runs-on: ${{ fromJson(github.repository_owner == 'autonomys' &&
-      '"runs-on=${{ github.run_id }}/runner=self-hosted-ubuntu-22.04-x86-64"' || '"ubuntu-22.04"') }}
+      '"runs-on=${{ github.run_id }}/runner=self-hosted-ubuntu-22.04-x86-64/spot=false"' || '"ubuntu-22.04"') }}
     permissions:
       contents: write
       packages: write


### PR DESCRIPTION
#### Caching Changes

This PR activates the [runs-on magic cache](https://runs-on.com/caching/magic-cache/), which caches for around 10 days on AWS S3.

As part of that change, it also adds extra caches for:
- S3 sccache on Linux: Rust, C, C++, and CUDA build products
  - this is a shared cache across jobs
  - saves 4-12+ minutes per Linux job (average 7 minutes)
- target on macOS: most Rust build products, maybe some C/C++/CUDA ones?
  - this is a per-job and per-platform cache, but S3 caching is free so we should be fine here
  - saves 7+ minutes per macOS clippy job, but is slower than a rebuild for tests
  - Windows caching is too slow, and Linux already has sccache
- tools like Protoc:
  - Protoc is sometimes unreliable, failing downloads
  - but caching is slower than downloads on Windows

And fixes the caches for:
- source deps: add required registry tracking files

#### Spot Instance Fixes

Spot instances are disabled in the merge queue and release-related workflows. This will only have an impact if we decide to re-enable them in `runs-on.yml`.

This is based on runs-on maintainer advice:
https://github.com/runs-on/runs-on/issues/338#issuecomment-3082994307
https://github.com/runs-on/runs-on/issues/337#issuecomment-3109618827

#### Instance changes

This PR expands the runs-on CI instances to include "r7" instances (memory optimised). Instances will be chosen based on lowest cost from the entire range provided. This is based on advice from the runs-on maintainer:
https://github.com/runs-on/runs-on/issues/338#issuecomment-3082994307

This is low risk, because our costs are already low. Because of our low costs, there's not much need to use spot instances, so I left them off in this PR.

It also removes some redundant CPU and RAM keys, because the provided numbers are already treated as a range:
https://runs-on.com/configuration/job-labels/#cpu

#### Workflow Cleanups

`cargo fmt` does not require much CPU or RAM, so its job is changed to a free GitHub runner. It also doesn't need any dependencies, so those are removed.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
