### PR TITLE
Add byte sizes to piece cache sync progress

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10548,6 +10548,7 @@ name = "sc-consensus-subspace"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "bytesize",
  "futures",
  "parity-scale-codec",
  "parking_lot 0.12.3",

--- a/crates/sc-consensus-subspace/Cargo.toml
+++ b/crates/sc-consensus-subspace/Cargo.toml
@@ -14,6 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 async-trait.workspace = true
+bytesize.workspace = true
 parity-scale-codec = { workspace = true, features = ["derive"] }
 futures.workspace = true
 parking_lot.workspace = true

--- a/crates/sc-consensus-subspace/src/archiver.rs
+++ b/crates/sc-consensus-subspace/src/archiver.rs
@@ -788,9 +788,9 @@ where
                 let encoded_block = encode_block(signed_block);
 
                 debug!(
-                    "Encoded block {} has size of {:.2} kiB",
+                    "Encoded block {} has size of {}",
                     block_number_to_archive,
-                    encoded_block.len() as f32 / 1024.0
+                    bytesize::to_string(encoded_block.len() as u64, true),
                 );
 
                 let block_outcome = archiver.add_block(encoded_block, block_object_mappings, false);
@@ -1190,9 +1190,9 @@ where
 
     let encoded_block = encode_block(block);
     debug!(
-        "Encoded block {} has size of {:.2} kiB",
+        "Encoded block {} has size of {}",
         block_number_to_archive,
-        encoded_block.len() as f32 / 1024.0
+        bytesize::to_string(encoded_block.len() as u64, true),
     );
 
     let block_outcome = archiver.add_block(

--- a/crates/subspace-farmer/src/farmer_cache.rs
+++ b/crates/subspace-farmer/src/farmer_cache.rs
@@ -654,7 +654,17 @@ where
                                 let mut piece_caches = self.piece_caches.write().await;
                                 piece_caches.clone_from(&caches.lock());
 
-                                info!("Piece cache sync {progress:.2}% complete");
+                                info!(
+                                    "Piece cache sync {progress:.2}% complete ({} / {})",
+                                    bytesize::to_string(
+                                        (prev_downloaded_pieces_count * Piece::SIZE) as u64,
+                                        true,
+                                    ),
+                                    bytesize::to_string(
+                                        (pieces_to_download_total * Piece::SIZE) as u64,
+                                        true,
+                                    ),
+                                );
                             }
 
                             self.handlers.progress.call_simple(&progress);

--- a/crates/subspace-networking/src/utils/piece_provider.rs
+++ b/crates/subspace-networking/src/utils/piece_provider.rs
@@ -101,7 +101,7 @@ where
         let (tx, mut rx) = mpsc::unbounded();
         let fut = async move {
             let not_downloaded_pieces = download_cached_pieces(
-                piece_indices.into_iter(),
+                piece_indices,
                 &self.node,
                 &self.piece_validator,
                 &tx,
@@ -428,7 +428,7 @@ async fn download_cached_pieces<PV, PieceIndices>(
 ) -> impl ExactSizeIterator<Item = PieceIndex>
 where
     PV: PieceValidator,
-    PieceIndices: Iterator<Item = PieceIndex>,
+    PieceIndices: IntoIterator<Item = PieceIndex>,
 {
     // Make sure every piece index has an entry since this will be the primary container for
     // tracking pieces to download going forward.
@@ -436,6 +436,7 @@ where
     // At the end pieces that were not downloaded will remain with a collection of known closest
     // peers for them.
     let mut pieces_to_download = piece_indices
+        .into_iter()
         .map(|piece_index| async move {
             let mut kademlia = KademliaWrapper::new(node.id());
             let key = piece_index.to_multihash();

--- a/shared/subspace-data-retrieval/src/segment_downloading.rs
+++ b/shared/subspace-data-retrieval/src/segment_downloading.rs
@@ -171,8 +171,7 @@ where
 
     let mut pieces_iter = segment_index
         .segment_piece_indexes_source_first()
-        .into_iter()
-        .peekable();
+        .into_iter();
 
     // Download in batches until we get enough or exhaust available pieces
     while !pieces_iter.is_empty() && downloaded_pieces != required_pieces_number {


### PR DESCRIPTION
This PR adds byte sizes to farmer piece cache syncing.

It also removes an unnecessary `peekable()` from segment downloading code, and makes a piece downloading function slightly more generic.

#### Background

Some users are confused by piece cache progress resetting after a farmer restart (#3614). This PR adds the size of the remaining cache to the log, which should make it clearer the remaining amount is decreasing.

Before:
> 2025-07-23T23:32:04.364152Z  INFO subspace_farmer::farmer_cache: Piece cache sync 4.20% complete

After:
> 2025-07-23T23:32:04.364152Z  INFO subspace_farmer::farmer_cache: Piece cache sync 4.20% complete (2.5 / 60.5 GiB)

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
