### PR TITLE
fix: now farmer piece cache sync percentage base on total cache size

### DIFF
--- a/crates/subspace-farmer/src/farmer_cache.rs
+++ b/crates/subspace-farmer/src/farmer_cache.rs
@@ -515,13 +515,15 @@ where
 
         // Store whatever correct pieces are immediately available after restart
         self.piece_caches.write().await.clone_from(&caches);
+        let stored_count = caches.stored_pieces().len();
 
         debug!(
+            %stored_count,
             count = %piece_indices_to_store.len(),
             "Identified piece indices that should be cached",
         );
 
-        let pieces_to_download_total = piece_indices_to_store.len();
+        let pieces_to_download_total = piece_indices_to_store.len() + stored_count;
         let piece_indices_to_store = piece_indices_to_store
             .into_values()
             .collect::<Vec<_>>()
@@ -532,7 +534,7 @@ where
             .map(|chunk| chunk.to_vec())
             .collect::<Vec<_>>();
 
-        let downloaded_pieces_count = AtomicUsize::new(0);
+        let downloaded_pieces_count = AtomicUsize::new(stored_count);
         let caches = Mutex::new(caches);
         self.handlers.progress.call_simple(&0.0);
         let piece_indices_to_store = piece_indices_to_store.into_iter().enumerate();

--- a/crates/subspace-farmer/src/farmer_cache.rs
+++ b/crates/subspace-farmer/src/farmer_cache.rs
@@ -515,7 +515,7 @@ where
 
         // Store whatever correct pieces are immediately available after restart
         self.piece_caches.write().await.clone_from(&caches);
-        let stored_count = caches.stored_pieces().len();
+        let stored_count = caches.stored_pieces_offsets().len();
 
         debug!(
             %stored_count,

--- a/crates/subspace-farmer/src/farmer_cache/piece_cache_state.rs
+++ b/crates/subspace-farmer/src/farmer_cache/piece_cache_state.rs
@@ -32,10 +32,6 @@ impl PieceCachesState {
             .fold(0usize, |acc, backend| acc + backend.total_capacity as usize)
     }
 
-    pub(super) fn stored_pieces(&self) -> impl ExactSizeIterator + '_ {
-        self.stored_pieces.iter()
-    }
-
     pub(super) fn pop_free_offset(&mut self) -> Option<FarmerCacheOffset> {
         match self.dangling_free_offsets.pop_front() {
             Some(free_offset) => {

--- a/crates/subspace-farmer/src/farmer_cache/piece_cache_state.rs
+++ b/crates/subspace-farmer/src/farmer_cache/piece_cache_state.rs
@@ -32,6 +32,10 @@ impl PieceCachesState {
             .fold(0usize, |acc, backend| acc + backend.total_capacity as usize)
     }
 
+    pub(super) fn stored_pieces(&self) -> impl ExactSizeIterator + '_ {
+        self.stored_pieces.iter()
+    }
+
     pub(super) fn pop_free_offset(&mut self) -> Option<FarmerCacheOffset> {
         match self.dangling_free_offsets.pop_front() {
             Some(free_offset) => {


### PR DESCRIPTION
close: #3614

Thanks to the previous refactoring, it's now easy to retrieve stored_pieces.
Added a helper function to retrieve stored_pieces.

```
// first start
2025-07-29T08:45:00.887876Z DEBUG subspace_farmer::farmer_cache: Identified piece indices that should be cached count=10134
2025-07-29T08:48:52.478604Z  INFO subspace_farmer::farmer_cache: Piece cache sync 0.00% complete (0 B / 9.9 GiB)
2025-07-29T09:03:02.331834Z  INFO subspace_farmer::farmer_cache: Piece cache sync 0.10% complete (100.0 MiB / 9.8 GiB)

// restart

// before
2025-07-29T09:05:40.406689Z DEBUG subspace_farmer::farmer_cache: Identified piece indices that should be cached count=10034
2025-07-29T09:06:54.225429Z  INFO subspace_farmer::farmer_cache: Piece cache sync 0.00% complete (0 B / 9.8 GiB)
2025-07-29T09:07:39.959417Z  INFO subspace_farmer::farmer_cache: Piece cache sync 0.10% complete (10.0 MiB / 9.8 GiB)

// now
2025-07-29T09:12:54.610036Z DEBUG subspace_farmer::farmer_cache: Identified piece indices that should be cached stored_count=102 count=10024
2025-07-29T09:13:36.207475Z  INFO subspace_farmer::farmer_cache: Piece cache sync 1.09% complete (110.0 MiB / 9.9 GiB)
2025-07-29T09:16:00.496766Z  INFO subspace_farmer::farmer_cache: Piece cache sync 1.19% complete (120.0 MiB / 9.9 GiB)

// again
2025-07-29T09:33:30.134762Z DEBUG subspace_farmer::farmer_cache: Identified piece indices that should be cached stored_count=122 count=10004
2025-07-29T09:36:39.527984Z  INFO subspace_farmer::farmer_cache: Piece cache sync 1.28% complete (130.0 MiB / 9.9 GiB)
```

As you can see from the log changes, a restart no longer resets the percentage calculation but instead continues from the previous count; additionally, stored_count is now printed in the Debug log.

(For testing purposes, I set INTERMEDIATE_CACHE_UPDATE_INTERVAL to 10 for convenience; under normal circumstances, the printing interval is much longer)

## Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
