### PR TITLE
Configurable domain pruning depth and staking withdrawal period for Runtime through Genesis

### DIFF
--- a/crates/pallet-runtime-configs/src/lib.rs
+++ b/crates/pallet-runtime-configs/src/lib.rs
@@ -128,6 +128,11 @@ mod pallet {
                 "ConfirmationDepthK can not be zero"
             );
 
+            assert!(
+                staking_withdrawal_period >= domain_block_pruning_depth,
+                "Stake Withdrawal locking period must be >= Block tree pruning depth"
+            );
+
             <EnableDomains<T>>::put(enable_domains);
             <EnableDynamicCostOfStorage<T>>::put(enable_dynamic_cost_of_storage);
             <EnableBalanceTransfers<T>>::put(enable_balance_transfers);

--- a/crates/pallet-runtime-configs/src/lib.rs
+++ b/crates/pallet-runtime-configs/src/lib.rs
@@ -10,26 +10,31 @@ use core::marker::PhantomData;
 use frame_system::pallet_prelude::BlockNumberFor;
 pub use pallet::*;
 use sp_runtime::traits::Get;
+use subspace_runtime_primitives::GenesisConfigParams;
 pub use weights::WeightInfo;
+
+const DEFAULT_GENESIS_PARAMS: GenesisConfigParams = GenesisConfigParams::production_params();
 
 pub struct DefaultDomainBlockPruning<T>(PhantomData<T>);
 impl<T: Config> Get<BlockNumberFor<T>> for DefaultDomainBlockPruning<T> {
     fn get() -> BlockNumberFor<T> {
-        BlockNumberFor::<T>::from(14_400u32)
+        BlockNumberFor::<T>::from(DEFAULT_GENESIS_PARAMS.domain_block_pruning_depth)
     }
 }
 
 pub struct DefaultDomainStakingWithdrawalPeriod<T>(PhantomData<T>);
 impl<T: Config> Get<BlockNumberFor<T>> for DefaultDomainStakingWithdrawalPeriod<T> {
     fn get() -> BlockNumberFor<T> {
-        BlockNumberFor::<T>::from(14_400u32)
+        BlockNumberFor::<T>::from(DEFAULT_GENESIS_PARAMS.staking_withdrawal_period)
     }
 }
 
 #[frame_support::pallet]
 mod pallet {
     use crate::weights::WeightInfo;
-    use crate::{DefaultDomainBlockPruning, DefaultDomainStakingWithdrawalPeriod};
+    use crate::{
+        DEFAULT_GENESIS_PARAMS, DefaultDomainBlockPruning, DefaultDomainStakingWithdrawalPeriod,
+    };
     use frame_support::pallet_prelude::*;
     use frame_system::pallet_prelude::*;
     use sp_runtime::traits::Zero;
@@ -101,11 +106,17 @@ mod pallet {
                 enable_domains: false,
                 enable_dynamic_cost_of_storage: false,
                 enable_balance_transfers: false,
-                confirmation_depth_k: BlockNumberFor::<T>::from(100u32),
+                confirmation_depth_k: BlockNumberFor::<T>::from(
+                    DEFAULT_GENESIS_PARAMS.confirmation_depth_k,
+                ),
                 council_democracy_config_params:
                     CouncilDemocracyConfigParams::<BlockNumberFor<T>>::default(),
-                domain_block_pruning_depth: BlockNumberFor::<T>::from(14_400u32),
-                staking_withdrawal_period: BlockNumberFor::<T>::from(14_400u32),
+                domain_block_pruning_depth: BlockNumberFor::<T>::from(
+                    DEFAULT_GENESIS_PARAMS.domain_block_pruning_depth,
+                ),
+                staking_withdrawal_period: BlockNumberFor::<T>::from(
+                    DEFAULT_GENESIS_PARAMS.staking_withdrawal_period,
+                ),
             }
         }
     }

--- a/crates/sp-domains/src/lib.rs
+++ b/crates/sp-domains/src/lib.rs
@@ -1004,7 +1004,7 @@ pub struct NominatorPosition<Balance, DomainBlockNumber, Share> {
 sp_api::decl_runtime_apis! {
     /// APIs used to access the domains pallet.
     // When updating this version, document new APIs with "Only present in API versions" comments.
-    #[api_version(5)]
+    #[api_version(6)]
     pub trait DomainsApi<DomainHeader: HeaderT> {
         /// Submits the transaction bundle via an unsigned extrinsic.
         fn submit_bundle_unsigned(opaque_bundle: OpaqueBundle<NumberFor<Block>, Block::Hash, DomainHeader, Balance>);
@@ -1109,6 +1109,10 @@ sp_api::decl_runtime_apis! {
             operator_id: OperatorId,
             nominator_account: sp_runtime::AccountId32,
         ) -> Option<NominatorPosition<Balance, HeaderNumberFor<DomainHeader>, Balance>>;
+
+        /// Returns the block pruning depth for domains
+        /// Available from Api version 6.
+        fn block_pruning_depth() -> NumberFor<Block>;
     }
 
     pub trait BundleProducerElectionApi<Balance: Encode + Decode> {

--- a/crates/subspace-fake-runtime-api/src/lib.rs
+++ b/crates/subspace-fake-runtime-api/src/lib.rs
@@ -298,6 +298,10 @@ sp_api::impl_runtime_apis! {
         ) -> Option<NominatorPosition<Balance, DomainNumber, Balance>> {
             unreachable!()
         }
+
+        fn block_pruning_depth() -> NumberFor<Block> {
+            unreachable!()
+        }
     }
 
     impl sp_domains::BundleProducerElectionApi<Block, Balance> for Runtime {

--- a/crates/subspace-malicious-operator/src/chain_spec.rs
+++ b/crates/subspace-malicious-operator/src/chain_spec.rs
@@ -20,7 +20,7 @@ use subspace_runtime::{
     RewardsConfig, RuntimeConfigsConfig, SubspaceConfig,
 };
 use subspace_runtime_primitives::{
-    AI3, AccountId, Balance, BlockNumber, CouncilDemocracyConfigParams,
+    AI3, AccountId, Balance, BlockNumber, CouncilDemocracyConfigParams, GenesisConfigParams,
 };
 
 fn endowed_accounts() -> Vec<(MultiAccountId, Balance)> {
@@ -130,6 +130,8 @@ struct GenesisParams {
     enable_balance_transfers: bool,
     confirmation_depth_k: u32,
     rewards_config: RewardsConfig,
+    domain_block_pruning_depth: u32,
+    staking_withdrawal_period: u32,
 }
 
 struct GenesisDomainParams {
@@ -155,6 +157,12 @@ pub fn dev_config() -> Result<GenericChainSpec, String> {
         raw_genesis.encode()
     };
 
+    let GenesisConfigParams {
+        confirmation_depth_k,
+        domain_block_pruning_depth,
+        staking_withdrawal_period,
+    } = GenesisConfigParams::dev_params();
+
     Ok(GenericChainSpec::builder(wasm_binary, None)
         .with_name("Subspace development")
         .with_id("subspace_dev")
@@ -177,12 +185,14 @@ pub fn dev_config() -> Result<GenericChainSpec, String> {
                     enable_domains: true,
                     enable_dynamic_cost_of_storage: false,
                     enable_balance_transfers: true,
-                    confirmation_depth_k: 5,
+                    confirmation_depth_k,
                     rewards_config: RewardsConfig {
                         remaining_issuance: 1_000_000 * AI3,
                         proposer_subsidy_points: Default::default(),
                         voter_subsidy_points: Default::default(),
                     },
+                    domain_block_pruning_depth,
+                    staking_withdrawal_period,
                 },
                 GenesisDomainParams {
                     domain_name: "evm-domain".to_owned(),
@@ -215,6 +225,8 @@ fn subspace_genesis_config(
         enable_balance_transfers,
         confirmation_depth_k,
         rewards_config,
+        domain_block_pruning_depth,
+        staking_withdrawal_period,
     } = genesis_params;
 
     subspace_runtime::RuntimeGenesisConfig {
@@ -241,8 +253,8 @@ fn subspace_genesis_config(
             confirmation_depth_k,
             council_democracy_config_params:
                 CouncilDemocracyConfigParams::<BlockNumber>::fast_params(),
-            domain_block_pruning_depth: 14_400u32,
-            staking_withdrawal_period: 14_400u32,
+            domain_block_pruning_depth,
+            staking_withdrawal_period,
         },
         domains: DomainsConfig {
             permissioned_action_allowed_by: Some(

--- a/crates/subspace-malicious-operator/src/chain_spec.rs
+++ b/crates/subspace-malicious-operator/src/chain_spec.rs
@@ -241,6 +241,8 @@ fn subspace_genesis_config(
             confirmation_depth_k,
             council_democracy_config_params:
                 CouncilDemocracyConfigParams::<BlockNumber>::fast_params(),
+            domain_block_pruning_depth: 14_400u32,
+            staking_withdrawal_period: 14_400u32,
         },
         domains: DomainsConfig {
             permissioned_action_allowed_by: Some(

--- a/crates/subspace-malicious-operator/src/malicious_domain_instance_starter.rs
+++ b/crates/subspace-malicious-operator/src/malicious_domain_instance_starter.rs
@@ -22,12 +22,12 @@ use sp_blockchain::HeaderBackend;
 use sp_consensus_subspace::SubspaceApi;
 use sp_core::crypto::AccountId32;
 use sp_core::traits::SpawnEssentialNamed;
-use sp_domains::{DomainInstanceData, RuntimeType};
+use sp_domains::{DomainInstanceData, DomainsApi, RuntimeType};
 use sp_keystore::KeystorePtr;
 use std::sync::Arc;
 use subspace_runtime::RuntimeApi as CRuntimeApi;
 use subspace_runtime_primitives::opaque::Block as CBlock;
-use subspace_runtime_primitives::{AccountId, DOMAINS_BLOCK_PRUNING_DEPTH, HeaderFor};
+use subspace_runtime_primitives::{AccountId, HeaderFor};
 use subspace_service::FullClient as CFullClient;
 
 /// `DomainInstanceStarter` used to start a domain instance node based on the given
@@ -117,10 +117,10 @@ impl DomainInstanceStarter {
         };
 
         let consensus_best_hash = consensus_client.info().best_hash;
-        let chain_constants = consensus_client
-            .runtime_api()
-            .chain_constants(consensus_best_hash)?;
+        let runtime_api = consensus_client.runtime_api();
+        let chain_constants = runtime_api.chain_constants(consensus_best_hash)?;
 
+        let domain_block_pruning_depth = runtime_api.block_pruning_depth(consensus_best_hash)?;
         match runtime_type {
             RuntimeType::Evm => {
                 let evm_base_path = domain_config
@@ -156,7 +156,7 @@ impl DomainInstanceStarter {
                     consensus_chain_sync_params: None::<
                         ConsensusChainSyncParams<_, HeaderFor<DomainBlock>>,
                     >,
-                    challenge_period: DOMAINS_BLOCK_PRUNING_DEPTH,
+                    challenge_period: domain_block_pruning_depth,
                     domain_backend,
                 };
 
@@ -219,7 +219,7 @@ impl DomainInstanceStarter {
                     consensus_chain_sync_params: None::<
                         ConsensusChainSyncParams<_, HeaderFor<DomainBlock>>,
                     >,
-                    challenge_period: DOMAINS_BLOCK_PRUNING_DEPTH,
+                    challenge_period: domain_block_pruning_depth,
                     domain_backend,
                 };
 

--- a/crates/subspace-node/src/chain_spec.rs
+++ b/crates/subspace-node/src/chain_spec.rs
@@ -36,6 +36,8 @@ struct GenesisParams {
     enable_balance_transfers: bool,
     confirmation_depth_k: u32,
     rewards_config: RewardsConfig,
+    domain_block_pruning_depth: u32,
+    staking_withdrawal_period: u32,
 }
 
 struct GenesisDomainParams {
@@ -221,6 +223,8 @@ pub fn mainnet_compiled() -> Result<GenericChainSpec, String> {
                     ])
                     .expect("Number of elements is below configured MaxRewardPoints; qed"),
                 },
+                domain_block_pruning_depth: 14_400u32,
+                staking_withdrawal_period: 14_400u32,
             },
             GenesisDomainParams {
                 permissioned_action_allowed_by: PermissionedActionAllowedBy::Accounts(vec![
@@ -283,14 +287,14 @@ pub fn devnet_config_compiled() -> Result<GenericChainSpec, String> {
                 enable_domains: true,
                 enable_dynamic_cost_of_storage: false,
                 enable_balance_transfers: true,
-                // TODO: Proper value here
-                confirmation_depth_k: 100,
-                // TODO: Proper value here
+                confirmation_depth_k: 5,
                 rewards_config: RewardsConfig {
                     remaining_issuance: 1_000_000_000 * AI3,
                     proposer_subsidy_points: Default::default(),
                     voter_subsidy_points: Default::default(),
                 },
+                domain_block_pruning_depth: 5,
+                staking_withdrawal_period: 5,
             },
             GenesisDomainParams {
                 permissioned_action_allowed_by: PermissionedActionAllowedBy::Accounts(vec![
@@ -350,6 +354,8 @@ pub fn dev_config() -> Result<GenericChainSpec, String> {
                         proposer_subsidy_points: Default::default(),
                         voter_subsidy_points: Default::default(),
                     },
+                    domain_block_pruning_depth: 5,
+                    staking_withdrawal_period: 5,
                 },
                 GenesisDomainParams {
                     permissioned_action_allowed_by: PermissionedActionAllowedBy::Accounts(vec![
@@ -391,6 +397,8 @@ fn subspace_genesis_config(
         enable_balance_transfers,
         confirmation_depth_k,
         rewards_config,
+        domain_block_pruning_depth,
+        staking_withdrawal_period,
     } = genesis_params;
 
     let genesis_domains = if enable_domains {
@@ -444,6 +452,8 @@ fn subspace_genesis_config(
             enable_balance_transfers,
             confirmation_depth_k,
             council_democracy_config_params,
+            domain_block_pruning_depth,
+            staking_withdrawal_period,
         },
         domains: DomainsConfig {
             permissioned_action_allowed_by: enable_domains

--- a/crates/subspace-node/src/chain_spec.rs
+++ b/crates/subspace-node/src/chain_spec.rs
@@ -21,7 +21,7 @@ use subspace_runtime::{
     SubspaceConfig, SudoConfig, SystemConfig, WASM_BINARY,
 };
 use subspace_runtime_primitives::{
-    AI3, AccountId, Balance, BlockNumber, CouncilDemocracyConfigParams,
+    AI3, AccountId, Balance, BlockNumber, CouncilDemocracyConfigParams, GenesisConfigParams,
 };
 
 const SUBSPACE_TELEMETRY_URL: &str = "wss://telemetry.subspace.foundation/submit/";
@@ -109,6 +109,12 @@ pub fn mainnet_compiled() -> Result<GenericChainSpec, String> {
         };
         let balances = get_genesis_allocations(GENESIS_ALLOCATIONS);
 
+        let GenesisConfigParams {
+            confirmation_depth_k,
+            domain_block_pruning_depth,
+            staking_withdrawal_period,
+        } = GenesisConfigParams::production_params();
+
         serde_json::to_value(subspace_genesis_config(
             sudo_account.clone(),
             balances,
@@ -125,7 +131,7 @@ pub fn mainnet_compiled() -> Result<GenericChainSpec, String> {
                 enable_domains: false,
                 enable_dynamic_cost_of_storage: false,
                 enable_balance_transfers: false,
-                confirmation_depth_k: 100,
+                confirmation_depth_k,
                 rewards_config: RewardsConfig {
                     remaining_issuance: 350_000_000 * AI3,
                     proposer_subsidy_points: BoundedVec::try_from(vec![
@@ -223,8 +229,8 @@ pub fn mainnet_compiled() -> Result<GenericChainSpec, String> {
                     ])
                     .expect("Number of elements is below configured MaxRewardPoints; qed"),
                 },
-                domain_block_pruning_depth: 14_400u32,
-                staking_withdrawal_period: 14_400u32,
+                domain_block_pruning_depth,
+                staking_withdrawal_period,
             },
             GenesisDomainParams {
                 permissioned_action_allowed_by: PermissionedActionAllowedBy::Accounts(vec![
@@ -277,6 +283,11 @@ pub fn devnet_config_compiled() -> Result<GenericChainSpec, String> {
         let sudo_account = get_account_id_from_seed("Alice");
 
         let balances = vec![(sudo_account.clone(), Balance::MAX / 2)];
+        let GenesisConfigParams {
+            confirmation_depth_k,
+            domain_block_pruning_depth,
+            staking_withdrawal_period,
+        } = GenesisConfigParams::dev_params();
         serde_json::to_value(subspace_genesis_config(
             sudo_account.clone(),
             balances,
@@ -287,14 +298,14 @@ pub fn devnet_config_compiled() -> Result<GenericChainSpec, String> {
                 enable_domains: true,
                 enable_dynamic_cost_of_storage: false,
                 enable_balance_transfers: true,
-                confirmation_depth_k: 5,
+                confirmation_depth_k,
                 rewards_config: RewardsConfig {
                     remaining_issuance: 1_000_000_000 * AI3,
                     proposer_subsidy_points: Default::default(),
                     voter_subsidy_points: Default::default(),
                 },
-                domain_block_pruning_depth: 5,
-                staking_withdrawal_period: 5,
+                domain_block_pruning_depth,
+                staking_withdrawal_period,
             },
             GenesisDomainParams {
                 permissioned_action_allowed_by: PermissionedActionAllowedBy::Accounts(vec![
@@ -317,6 +328,11 @@ pub fn devnet_config_compiled() -> Result<GenericChainSpec, String> {
 pub fn dev_config() -> Result<GenericChainSpec, String> {
     let wasm_binary = WASM_BINARY.ok_or_else(|| "Development wasm not available".to_string())?;
     let sudo_account = get_account_id_from_seed("Alice");
+    let GenesisConfigParams {
+        confirmation_depth_k,
+        domain_block_pruning_depth,
+        staking_withdrawal_period,
+    } = GenesisConfigParams::dev_params();
 
     Ok(GenericChainSpec::builder(wasm_binary, None)
         .with_name("Subspace development")
@@ -348,14 +364,14 @@ pub fn dev_config() -> Result<GenericChainSpec, String> {
                     enable_domains: true,
                     enable_dynamic_cost_of_storage: false,
                     enable_balance_transfers: true,
-                    confirmation_depth_k: 5,
+                    confirmation_depth_k,
                     rewards_config: RewardsConfig {
                         remaining_issuance: 1_000_000 * AI3,
                         proposer_subsidy_points: Default::default(),
                         voter_subsidy_points: Default::default(),
                     },
-                    domain_block_pruning_depth: 5,
-                    staking_withdrawal_period: 5,
+                    domain_block_pruning_depth,
+                    staking_withdrawal_period,
                 },
                 GenesisDomainParams {
                     permissioned_action_allowed_by: PermissionedActionAllowedBy::Accounts(vec![

--- a/crates/subspace-node/src/commands/run/domain.rs
+++ b/crates/subspace-node/src/commands/run/domain.rs
@@ -39,7 +39,9 @@ use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::sync::Arc;
 use subspace_runtime::RuntimeApi as CRuntimeApi;
 use subspace_runtime_primitives::opaque::Block as CBlock;
-use subspace_runtime_primitives::{DOMAINS_PRUNING_DEPTH_MULTIPLIER, HeaderFor};
+use subspace_runtime_primitives::{
+    DOMAINS_PRUNING_DEPTH_MULTIPLIER, GenesisConfigParams, HeaderFor,
+};
 use subspace_service::FullClient as CFullClient;
 use tokio::sync::broadcast::Receiver;
 use tokio_stream::wrappers::errors::BroadcastStreamRecvError;
@@ -47,9 +49,8 @@ use tracing::log::info;
 use tracing::warn;
 
 /// Domains Block pruning depth.
-/// This value is here because we this to set default state pruning and block pruning for clap arguments.
-/// Unfortunately clap does not support dynamic defaults.
-const DOMAINS_BLOCK_PRUNING_DEPTH: u32 = 14_400;
+const DOMAINS_BLOCK_PRUNING_DEPTH: u32 =
+    GenesisConfigParams::production_params().domain_block_pruning_depth;
 
 /// Minimum Block and State pruning required for Domain
 pub(crate) const MIN_PRUNING: u32 = DOMAINS_BLOCK_PRUNING_DEPTH * DOMAINS_PRUNING_DEPTH_MULTIPLIER;

--- a/crates/subspace-node/src/commands/run/domain.rs
+++ b/crates/subspace-node/src/commands/run/domain.rs
@@ -28,24 +28,28 @@ use sc_service::Configuration;
 use sc_service::config::{ExecutorConfiguration, KeystoreConfig};
 use sc_transaction_pool_api::OffchainTransactionPoolFactory;
 use sc_utils::mpsc::{TracingUnboundedReceiver, TracingUnboundedSender};
-use sp_api::ProvideRuntimeApi;
+use sp_api::{ApiExt, ProvideRuntimeApi};
 use sp_blockchain::HeaderBackend;
 use sp_consensus_subspace::SubspaceApi;
 use sp_core::crypto::{AccountId32, SecretString};
-use sp_domains::{DomainId, DomainInstanceData, OperatorId, RuntimeType};
+use sp_domains::{DomainId, DomainInstanceData, DomainsApi, OperatorId, RuntimeType};
+use sp_runtime::traits::Block as BlockT;
 use std::collections::HashMap;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::sync::Arc;
 use subspace_runtime::RuntimeApi as CRuntimeApi;
 use subspace_runtime_primitives::opaque::Block as CBlock;
-use subspace_runtime_primitives::{
-    DOMAINS_BLOCK_PRUNING_DEPTH, DOMAINS_PRUNING_DEPTH_MULTIPLIER, HeaderFor,
-};
+use subspace_runtime_primitives::{DOMAINS_PRUNING_DEPTH_MULTIPLIER, HeaderFor};
 use subspace_service::FullClient as CFullClient;
 use tokio::sync::broadcast::Receiver;
 use tokio_stream::wrappers::errors::BroadcastStreamRecvError;
 use tracing::log::info;
 use tracing::warn;
+
+/// Domains Block pruning depth.
+/// This value is here because we this to set default state pruning and block pruning for clap arguments.
+/// Unfortunately clap does not support dynamic defaults.
+const DOMAINS_BLOCK_PRUNING_DEPTH: u32 = 14_400;
 
 /// Minimum Block and State pruning required for Domain
 pub(crate) const MIN_PRUNING: u32 = DOMAINS_BLOCK_PRUNING_DEPTH * DOMAINS_PRUNING_DEPTH_MULTIPLIER;
@@ -523,13 +527,34 @@ pub(super) async fn run_domain(
         },
     );
 
+    let consensus_best_hash = consensus_client.info().best_hash;
+    let runtime_api = consensus_client.runtime_api();
+    let chain_constants = runtime_api
+        .chain_constants(consensus_best_hash)
+        .map_err(|err| Error::Other(err.to_string()))?;
+
+    let domains_api_version = runtime_api
+        .api_version::<dyn DomainsApi<CBlock, <CBlock as BlockT>::Header>>(consensus_best_hash)
+        .ok()
+        .flatten()
+        // It is safe to return a default version of 1, since there will always be version 1.
+        .unwrap_or(1);
+    // if api version is 6 or above, use api else instead fallback to default value
+    let domains_block_pruning_depth = if domains_api_version >= 6 {
+        runtime_api
+            .block_pruning_depth(consensus_best_hash)
+            .map_err(|err| Error::Other(err.to_string()))?
+    } else {
+        DOMAINS_BLOCK_PRUNING_DEPTH
+    };
+
     let operator_streams = OperatorStreams {
         // Ensure Consensus does not import blocks faster than Domains
         // Since when running domains, consensus blocks and state pruning are set to
-        // 2 * DOMAINS_BLOCK_PRUNING_DEPTH by default and if cli is overridden, the
-        // minimum of 2 * DOMAINS_BLOCK_PRUNING_DEPTH is always guaranteed.
+        // 2 * domains_block_pruning_depth by default and if cli is overridden, the
+        // minimum of 2 * domains_block_pruning_depth is always guaranteed.
         // Hence, we do not need to throttle the consensus block imports at least until it reaches
-        // DOMAINS_BLOCK_PRUNING_DEPTH number of blocks.
+        // domains_block_pruning_depth number of blocks.
         consensus_block_import_throttling_buffer_size: MIN_PRUNING / 2,
         block_importing_notification_stream,
         imported_block_notification_stream,
@@ -537,12 +562,6 @@ pub(super) async fn run_domain(
         acknowledgement_sender_stream: futures::stream::empty(),
         _phantom: Default::default(),
     };
-
-    let consensus_best_hash = consensus_client.info().best_hash;
-    let chain_constants = consensus_client
-        .runtime_api()
-        .chain_constants(consensus_best_hash)
-        .map_err(|err| Error::Other(err.to_string()))?;
 
     let domain_sync_oracle = Arc::new(DomainChainSyncOracle::new(
         consensus_network_sync_oracle,
@@ -581,7 +600,7 @@ pub(super) async fn run_domain(
                 maybe_operator_id: operator_id,
                 confirmation_depth_k: chain_constants.confirmation_depth_k(),
                 consensus_chain_sync_params,
-                challenge_period: DOMAINS_BLOCK_PRUNING_DEPTH,
+                challenge_period: domains_block_pruning_depth,
                 domain_backend,
             };
 
@@ -622,7 +641,7 @@ pub(super) async fn run_domain(
                 maybe_operator_id: operator_id,
                 confirmation_depth_k: chain_constants.confirmation_depth_k(),
                 consensus_chain_sync_params,
-                challenge_period: DOMAINS_BLOCK_PRUNING_DEPTH,
+                challenge_period: domains_block_pruning_depth,
                 domain_backend,
             };
 

--- a/crates/subspace-runtime-primitives/src/lib.rs
+++ b/crates/subspace-runtime-primitives/src/lib.rs
@@ -205,6 +205,35 @@ impl<BlockNumber: From<u32>> CouncilDemocracyConfigParams<BlockNumber> {
         }
     }
 }
+/// Config parameters for genesis.
+pub struct GenesisConfigParams {
+    /// Confirmation depth K
+    pub confirmation_depth_k: BlockNumber,
+    /// Domain pruning depth.
+    pub domain_block_pruning_depth: BlockNumber,
+    /// Staking withdrawal period.
+    pub staking_withdrawal_period: BlockNumber,
+}
+
+impl GenesisConfigParams {
+    /// Production specific domain parameters.
+    pub const fn production_params() -> Self {
+        Self {
+            confirmation_depth_k: 100u32,
+            domain_block_pruning_depth: 14_400u32,
+            staking_withdrawal_period: 14_400u32,
+        }
+    }
+
+    /// Development specific domain parameters.
+    pub const fn dev_params() -> Self {
+        Self {
+            confirmation_depth_k: 5u32,
+            domain_block_pruning_depth: 5u32,
+            staking_withdrawal_period: 5u32,
+        }
+    }
+}
 
 /// A trait for determining whether rewards are enabled or not
 pub trait RewardsEnabled {

--- a/crates/subspace-runtime-primitives/src/lib.rs
+++ b/crates/subspace-runtime-primitives/src/lib.rs
@@ -57,9 +57,6 @@ pub const MAX_BLOCK_LENGTH: u32 = 5 * 1024 * 1024;
 /// Pruning depth multiplier for state and blocks pruning.
 pub const DOMAINS_PRUNING_DEPTH_MULTIPLIER: u32 = 2;
 
-/// Domains Block pruning depth.
-pub const DOMAINS_BLOCK_PRUNING_DEPTH: u32 = 14_400;
-
 /// We allow for 3.75 MiB for `Normal` extrinsic with 5 MiB maximum block length.
 pub fn maximum_normal_block_length() -> BlockLength {
     BlockLength::max_with_normal_ratio(MAX_BLOCK_LENGTH, NORMAL_DISPATCH_RATIO)

--- a/test/subspace-test-client/src/chain_spec.rs
+++ b/test/subspace-test-client/src/chain_spec.rs
@@ -138,6 +138,8 @@ fn create_genesis_config(
             enable_balance_transfers: false,
             confirmation_depth_k: 100u32,
             council_democracy_config_params: CouncilDemocracyConfigParams::default(),
+            domain_block_pruning_depth: 14_400u32,
+            staking_withdrawal_period: 14_400u32,
         },
     })
 }

--- a/test/subspace-test-client/src/chain_spec.rs
+++ b/test/subspace-test-client/src/chain_spec.rs
@@ -138,8 +138,8 @@ fn create_genesis_config(
             enable_balance_transfers: false,
             confirmation_depth_k: 100u32,
             council_democracy_config_params: CouncilDemocracyConfigParams::default(),
-            domain_block_pruning_depth: 14_400u32,
-            staking_withdrawal_period: 14_400u32,
+            domain_block_pruning_depth: 10u32,
+            staking_withdrawal_period: 20u32,
         },
     })
 }

--- a/test/subspace-test-primitives/src/lib.rs
+++ b/test/subspace-test-primitives/src/lib.rs
@@ -9,9 +9,6 @@ use sp_messenger::messages::{ChainId, ChannelId};
 use sp_runtime::traits::NumberFor;
 use sp_subspace_mmr::{ConsensusChainMmrLeafProof, MmrLeaf};
 
-/// Domains Block pruning depth.
-pub const DOMAINS_BLOCK_PRUNING_DEPTH: u32 = 10;
-
 sp_api::decl_runtime_apis! {
     /// Api for querying onchain state in the test
     pub trait OnchainStateApi<AccountId, Balance>

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -125,7 +125,6 @@ use subspace_runtime_primitives::{
     MAX_CALL_RECURSION_DEPTH, MIN_REPLICATION_FACTOR, Moment, Nonce, SHANNON, Signature,
     SlowAdjustingFeeUpdate, TargetBlockFullness, XdmAdjustedWeightToFee, XdmFeeMultipler,
 };
-use subspace_test_primitives::DOMAINS_BLOCK_PRUNING_DEPTH;
 
 sp_runtime::impl_opaque_keys! {
     pub struct SessionKeys {
@@ -797,6 +796,20 @@ impl pallet_transporter::Config for Runtime {
     type MinimumTransfer = MinimumTransfer;
 }
 
+pub struct BlockTreePruningDepth;
+impl Get<BlockNumber> for BlockTreePruningDepth {
+    fn get() -> BlockNumber {
+        pallet_runtime_configs::DomainBlockPruningDepth::<Runtime>::get()
+    }
+}
+
+pub struct StakeWithdrawalLockingPeriod;
+impl Get<BlockNumber> for StakeWithdrawalLockingPeriod {
+    fn get() -> BlockNumber {
+        pallet_runtime_configs::StakingWithdrawalPeriod::<Runtime>::get()
+    }
+}
+
 parameter_types! {
     pub const MaximumReceiptDrift: BlockNumber = 2;
     pub const InitialDomainTxRange: u64 = INITIAL_DOMAIN_TX_RANGE;
@@ -809,8 +822,6 @@ parameter_types! {
     pub MaxDomainBlockWeight: Weight = NORMAL_DISPATCH_RATIO * BLOCK_WEIGHT_FOR_2_SEC;
     pub const DomainInstantiationDeposit: Balance = 100 * AI3;
     pub const MaxDomainNameLength: u32 = 32;
-    pub const BlockTreePruningDepth: u32 = DOMAINS_BLOCK_PRUNING_DEPTH;
-    pub const StakeWithdrawalLockingPeriod: BlockNumber = 20;
     pub const StakeEpochDuration: DomainNumber = 5;
     pub TreasuryAccount: AccountId = PalletId(*b"treasury").into_account_truncating();
     pub const MaxPendingStakingOperation: u32 = 512;
@@ -1652,6 +1663,10 @@ impl_runtime_apis! {
             nominator_account: sp_runtime::AccountId32,
         ) -> Option<sp_domains::NominatorPosition<Balance, DomainNumber, Balance>> {
             Domains::nominator_position(operator_id, nominator_account)
+        }
+
+        fn block_pruning_depth() -> NumberFor<Block> {
+            BlockTreePruningDepth::get()
         }
     }
 

--- a/test/subspace-test-service/src/lib.rs
+++ b/test/subspace-test-service/src/lib.rs
@@ -887,6 +887,14 @@ impl MockConsensusNode {
             .domain_stake_summary(self.client.info().best_hash, domain_id)?)
     }
 
+    /// Returns the domain block pruning depth.
+    pub fn get_domain_block_pruning_depth(&self) -> Result<BlockNumber, Box<dyn Error>> {
+        Ok(self
+            .client
+            .runtime_api()
+            .block_pruning_depth(self.client.info().best_hash)?)
+    }
+
     /// Return a future that only resolve if a fraud proof that the given `fraud_proof_predicate`
     /// return true is submitted to the consensus tx pool
     pub fn wait_for_fraud_proof<FP>(


### PR DESCRIPTION
## Summary

This PR makes domain block pruning depth and staking withdrawal period configurable through Genesis configuration instead of using hardcoded constants.

## What Changed

- **Replaced hardcoded constants** with configurable Genesis parameters
- **Added new storage items** in `pallet-runtime-configs`:
  - `DomainBlockPruningDepth<T>`
  - `StakingWithdrawalPeriod<T>`
- **Updated DomainsApi** from version 5 to 6 with new `block_pruning_depth()` method
- **Added client-side fallback logic** for backward compatibility
- **Implemented genesis validation** ensuring `staking_withdrawal_period >= domain_block_pruning_depth`

## Why This Change

Previously, domain pruning depth and withdrawal periods were hardcoded to 14,400 blocks across all networks. This created inflexibility for different deployment scenarios:

- **Production networks** need conservative values for security
- **Development/test networks** need faster values for development
- **Custom deployments** may require other specific values

## How It Works

### Genesis Configuration

```rust
pub struct GenesisConfig<T: Config> {
    // ... existing fields ...
    pub domain_block_pruning_depth: BlockNumberFor<T>,
    pub staking_withdrawal_period: BlockNumberFor<T>,
}
```

### Network-Specific Values

- **Mainnet**: 14,400 blocks (unchanged for security)
- **Development**: 5 blocks (faster for development)

### API Compatibility

- **API v6+**: Dynamic values from runtime configuration
- **API v5 and below**: Fallback to hardcoded 14,400 blocks

### Validation

Genesis build includes validation to ensure system integrity:

```rust
assert!(
    staking_withdrawal_period >= domain_block_pruning_depth,
    "Stake Withdrawal locking period must be >= Block tree pruning depth"
);
```

## Files Changed

- `crates/pallet-runtime-configs/src/lib.rs` - New storage and genesis config
- `crates/sp-domains/src/lib.rs` - API version bump and new method
- `crates/subspace-runtime/src/lib.rs` - Dynamic parameter integration
- `crates/subspace-node/src/commands/run/domain.rs` - Client-side API handling
- Chain specification files - Network-specific default values

## Testing

Existing integration tests validate the functionality through runtime APIs. The main change replaces hardcoded constants with genesis-configured values while maintaining the same API surface.

## Breaking Changes

**None.** This change is fully backward compatible:

- Older clients fall back to previous hardcoded values
- API versioning ensures smooth upgrades
- Default values remain unchanged for production networks

## Migration Path

For existing chains upgrading to this runtime:

- Default values (14,400 blocks) are applied automatically
- No manual intervention required
- Behavior remains identical to previous versions


### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
