### PR TITLE
Log sudo and domain sudo calls in the runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7945,6 +7945,7 @@ version = "0.1.0"
 dependencies = [
  "frame-support",
  "frame-system",
+ "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8241,6 +8241,7 @@ dependencies = [
  "futures",
  "log",
  "pallet-balances",
+ "pallet-sudo",
  "parity-scale-codec",
  "rand 0.8.5",
  "scale-info",

--- a/crates/pallet-subspace/Cargo.toml
+++ b/crates/pallet-subspace/Cargo.toml
@@ -18,6 +18,7 @@ frame-benchmarking = { workspace = true, optional = true }
 frame-support.workspace = true
 frame-system.workspace = true
 log.workspace = true
+pallet-sudo.workspace = true
 scale-info = { workspace = true, features = ["derive"] }
 schnorrkel.workspace = true
 serde = { workspace = true, features = ["alloc", "derive"], optional = true }
@@ -54,6 +55,7 @@ std = [
     "frame-support/std",
     "frame-system/std",
     "log/std",
+    "pallet-sudo/std",
     "scale-info/std",
     "schnorrkel/std",
     "serde",
@@ -70,4 +72,5 @@ std = [
 runtime-benchmarks = [
     "frame-benchmarking",
     "frame-benchmarking/runtime-benchmarks",
+    "pallet-sudo/runtime-benchmarks",
 ]

--- a/crates/pallet-subspace/src/extensions.rs
+++ b/crates/pallet-subspace/src/extensions.rs
@@ -9,7 +9,10 @@ use crate::pallet::Call as SubspaceCall;
 use crate::{Config, Origin, Pallet as Subspace};
 use frame_support::RuntimeDebugNoBound;
 use frame_support::pallet_prelude::{PhantomData, TypeInfo, Weight};
+use frame_system::ensure_root;
 use frame_system::pallet_prelude::{BlockNumberFor, RuntimeCallFor};
+use log::info;
+use pallet_sudo::Call as SudoCall;
 use parity_scale_codec::{Decode, Encode};
 use scale_info::prelude::fmt;
 use sp_consensus_subspace::SignedVote;
@@ -30,6 +33,14 @@ where
     fn maybe_subspace_call(&self) -> Option<&SubspaceCall<Runtime>>;
 }
 
+/// Trait to convert Runtime call to possible Sudo call.
+pub trait MaybeSudoCall<Runtime>
+where
+    Runtime: pallet_sudo::Config,
+{
+    fn maybe_sudo_call(&self) -> Option<&SudoCall<Runtime>>;
+}
+
 /// Weight info used by this extension
 #[derive(RuntimeDebugNoBound)]
 pub enum ExtensionWeightData {
@@ -39,7 +50,7 @@ pub enum ExtensionWeightData {
     Skipped,
 }
 
-/// Extensions for pallet-subspace unsigned extrinsics.
+/// Extension for pallet-subspace unsigned extrinsics.
 #[derive(Encode, Decode, Clone, Eq, PartialEq, TypeInfo)]
 pub struct SubspaceExtension<Runtime>(PhantomData<Runtime>);
 
@@ -55,7 +66,7 @@ impl<Runtime> Default for SubspaceExtension<Runtime> {
     }
 }
 
-impl<T: Config> fmt::Debug for SubspaceExtension<T> {
+impl<Runtime> fmt::Debug for SubspaceExtension<Runtime> {
     #[cfg(feature = "std")]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "SubspaceExtension",)
@@ -69,7 +80,7 @@ impl<T: Config> fmt::Debug for SubspaceExtension<T> {
 
 impl<Runtime> SubspaceExtension<Runtime>
 where
-    Runtime: Config + scale_info::TypeInfo + fmt::Debug + Send + Sync,
+    Runtime: Config + scale_info::TypeInfo + Send + Sync,
 {
     fn do_check_vote(
         signed_vote: &SignedVote<BlockNumberFor<Runtime>, Runtime::Hash, Runtime::AccountId>,
@@ -92,7 +103,7 @@ where
 
 impl<Runtime> TransactionExtension<RuntimeCallFor<Runtime>> for SubspaceExtension<Runtime>
 where
-    Runtime: Config + scale_info::TypeInfo + fmt::Debug + Send + Sync,
+    Runtime: Config + scale_info::TypeInfo + Send + Sync,
     <RuntimeCallFor<Runtime> as Dispatchable>::RuntimeOrigin:
         AsSystemOriginSigner<<Runtime as frame_system::Config>::AccountId> + From<Origin> + Clone,
     RuntimeCallFor<Runtime>: MaybeSubspaceCall<Runtime>,
@@ -172,6 +183,138 @@ where
         match pre {
             // return the unused weight for a validated call.
             ExtensionWeightData::Validated(used_weight) => {
+                Ok(Self::max_weight().saturating_sub(used_weight))
+            }
+            // return no weight since this call is not validated and took no weight.
+            ExtensionWeightData::Skipped => Ok(Weight::zero()),
+        }
+    }
+}
+
+/// Extension for runtime call monitoring.
+#[derive(Encode, Decode, Clone, Eq, PartialEq, TypeInfo)]
+pub struct CallMonitorExtension<Runtime>(PhantomData<Runtime>);
+
+impl<Runtime> CallMonitorExtension<Runtime> {
+    pub fn new() -> Self {
+        Self(PhantomData)
+    }
+}
+
+impl<Runtime> Default for CallMonitorExtension<Runtime> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<Runtime> fmt::Debug for CallMonitorExtension<Runtime> {
+    #[cfg(feature = "std")]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "CallMonitorExtension",)
+    }
+
+    #[cfg(not(feature = "std"))]
+    fn fmt(&self, _: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Ok(())
+    }
+}
+
+impl<Runtime> CallMonitorExtension<Runtime>
+where
+    Runtime: pallet_sudo::Config + scale_info::TypeInfo + Send + Sync,
+{
+    /// Log a sudo call before it is called.
+    fn do_log_sudo_call(sudo_call: &SudoCall<Runtime>, source: TransactionSource, len: usize) {
+        info!(
+            "subspace sudo call: {:?} ({} bytes) from source: {:?}",
+            sudo_call, len, source,
+        );
+    }
+
+    /// Log the outcome of a sudo call.
+    fn do_log_sudo_call_result(result: &DispatchResult, len: usize) {
+        info!("subspace sudo call ({} bytes) result: {:?}", len, result);
+    }
+
+    fn max_weight() -> Weight {
+        // We assume this extension runs in less than 300 instructions (100 microseconds).
+        // TODO: benchmark this extension if it ever does significant work
+        Weight::from_parts(100_000, 0)
+    }
+}
+
+impl<Runtime> TransactionExtension<RuntimeCallFor<Runtime>> for CallMonitorExtension<Runtime>
+where
+    Runtime: pallet_sudo::Config + scale_info::TypeInfo + Send + Sync,
+    <RuntimeCallFor<Runtime> as Dispatchable>::RuntimeOrigin:
+        AsSystemOriginSigner<<Runtime as frame_system::Config>::AccountId> + From<Origin> + Clone,
+    RuntimeCallFor<Runtime>: MaybeSudoCall<Runtime>,
+{
+    const IDENTIFIER: &'static str = "CallMonitorExtension";
+    type Implicit = ();
+    type Val = ExtensionWeightData;
+    type Pre = ExtensionWeightData;
+
+    fn weight(&self, call: &RuntimeCallFor<Runtime>) -> Weight {
+        match call.maybe_sudo_call() {
+            Some(_sudo_call) => Self::max_weight(),
+            _ => Weight::zero(),
+        }
+    }
+
+    fn validate(
+        &self,
+        origin: DispatchOriginOf<RuntimeCallFor<Runtime>>,
+        call: &RuntimeCallFor<Runtime>,
+        _info: &DispatchInfoOf<RuntimeCallFor<Runtime>>,
+        len: usize,
+        _self_implicit: Self::Implicit,
+        _inherited_implication: &impl Implication,
+        source: TransactionSource,
+    ) -> ValidateResult<Self::Val, RuntimeCallFor<Runtime>> {
+        // we only care about successful sudo calls, from the root origin
+        if let Ok(()) = ensure_root(origin.clone())
+            && let Some(sudo_call) = call.maybe_sudo_call()
+        {
+            Self::do_log_sudo_call(sudo_call, source, len);
+
+            Ok((
+                ValidTransaction::default(),
+                ExtensionWeightData::Validated(Self::max_weight()),
+                origin,
+            ))
+        } else {
+            Ok((
+                ValidTransaction::default(),
+                ExtensionWeightData::Skipped,
+                origin,
+            ))
+        }
+    }
+
+    fn prepare(
+        self,
+        val: Self::Val,
+        _origin: &DispatchOriginOf<RuntimeCallFor<Runtime>>,
+        _call: &RuntimeCallFor<Runtime>,
+        _info: &DispatchInfoOf<RuntimeCallFor<Runtime>>,
+        _len: usize,
+    ) -> Result<Self::Pre, TransactionValidityError> {
+        Ok(val)
+    }
+
+    fn post_dispatch_details(
+        pre: Self::Pre,
+        _info: &DispatchInfoOf<RuntimeCallFor<Runtime>>,
+        _post_info: &PostDispatchInfoOf<RuntimeCallFor<Runtime>>,
+        len: usize,
+        result: &DispatchResult,
+    ) -> Result<Weight, TransactionValidityError> {
+        match pre {
+            // return the unused weight for a validated call.
+            ExtensionWeightData::Validated(used_weight) => {
+                // TODO: clone the call into `pre` and log it here as well if neeed
+                Self::do_log_sudo_call_result(result, len);
                 Ok(Self::max_weight().saturating_sub(used_weight))
             }
             // return no weight since this call is not validated and took no weight.

--- a/crates/sp-domains/src/lib.rs
+++ b/crates/sp-domains/src/lib.rs
@@ -379,7 +379,7 @@ pub enum EvmType {
     /// An EVM domain with a contract creation allow list.
     Private {
         /// Accounts initially allowed to create contracts on a private EVM domain.
-        /// The domain owner can update this list using a pallet-domains call (or there's a sudo call).
+        /// The domain owner or sudo can update this list using a pallet-domains call.
         initial_contract_creation_allow_list: PermissionedActionAllowedBy<EthereumAccountId>,
     },
 }

--- a/crates/subspace-malicious-operator/src/malicious_bundle_producer.rs
+++ b/crates/subspace-malicious-operator/src/malicious_bundle_producer.rs
@@ -403,20 +403,23 @@ fn get_singed_extra(best_number: u64, immortal: bool, nonce: Nonce) -> SignedExt
         .map(|c| c / 2)
         .unwrap_or(2);
     (
-        frame_system::CheckNonZeroSender::<Runtime>::new(),
-        frame_system::CheckSpecVersion::<Runtime>::new(),
-        frame_system::CheckTxVersion::<Runtime>::new(),
-        frame_system::CheckGenesis::<Runtime>::new(),
-        frame_system::CheckMortality::<Runtime>::from(if immortal {
-            generic::Era::Immortal
-        } else {
-            generic::Era::mortal(period, best_number)
-        }),
-        frame_system::CheckNonce::<Runtime>::from(nonce.into()),
-        frame_system::CheckWeight::<Runtime>::new(),
+        (
+            frame_system::CheckNonZeroSender::<Runtime>::new(),
+            frame_system::CheckSpecVersion::<Runtime>::new(),
+            frame_system::CheckTxVersion::<Runtime>::new(),
+            frame_system::CheckGenesis::<Runtime>::new(),
+            frame_system::CheckMortality::<Runtime>::from(if immortal {
+                generic::Era::Immortal
+            } else {
+                generic::Era::mortal(period, best_number)
+            }),
+            frame_system::CheckNonce::<Runtime>::from(nonce.into()),
+            frame_system::CheckWeight::<Runtime>::new(),
+        ),
         pallet_transaction_payment::ChargeTransactionPayment::<Runtime>::from(0u128),
         BalanceTransferCheckExtension::<Runtime>::default(),
         pallet_subspace::extensions::SubspaceExtension::<Runtime>::new(),
+        pallet_subspace::extensions::CallMonitorExtension::<Runtime>::new(),
         pallet_domains::extensions::DomainsExtension::<Runtime>::new(),
         pallet_messenger::extensions::MessengerExtension::<Runtime>::new(),
     )
@@ -434,12 +437,15 @@ pub fn construct_signed_extrinsic(
         call.clone(),
         extra.clone(),
         (
-            (),
-            subspace_runtime::VERSION.spec_version,
-            subspace_runtime::VERSION.transaction_version,
-            consensus_chain_info.genesis_hash,
-            consensus_chain_info.best_hash,
-            (),
+            (
+                (),
+                subspace_runtime::VERSION.spec_version,
+                subspace_runtime::VERSION.transaction_version,
+                consensus_chain_info.genesis_hash,
+                consensus_chain_info.best_hash,
+                (),
+                (),
+            ),
             (),
             (),
             (),

--- a/domains/pallets/domain-sudo/Cargo.toml
+++ b/domains/pallets/domain-sudo/Cargo.toml
@@ -16,6 +16,7 @@ include = [
 parity-scale-codec = { workspace = true, features = ["derive"] }
 frame-support.workspace = true
 frame-system.workspace = true
+log.workspace = true
 scale-info = { workspace = true, features = ["derive"] }
 sp-core.workspace = true
 sp-runtime.workspace = true
@@ -27,6 +28,7 @@ std = [
     "parity-scale-codec/std",
     "frame-support/std",
     "frame-system/std",
+    "log/std",
     "scale-info/std",
     "sp-core/std",
     "sp-runtime/std",

--- a/domains/pallets/domain-sudo/src/lib.rs
+++ b/domains/pallets/domain-sudo/src/lib.rs
@@ -31,6 +31,7 @@ mod pallet {
     use frame_support::traits::UnfilteredDispatchable;
     use frame_system::ensure_none;
     use frame_system::pallet_prelude::OriginFor;
+    use log::info;
     use sp_domain_sudo::{INHERENT_IDENTIFIER, InherentError, InherentType, IntoRuntimeCall};
 
     #[pallet::config]
@@ -68,7 +69,9 @@ mod pallet {
         pub fn sudo(origin: OriginFor<T>, call: Box<<T as Config>::RuntimeCall>) -> DispatchResult {
             ensure_none(origin)?;
 
+            info!("domain sudo call: {:?}", call);
             let res = call.dispatch_bypass_filter(RawOrigin::Root.into());
+            info!("domain sudo call result: {:?}", res);
             Self::deposit_event(Event::Sudid {
                 sudo_result: res.map(|_| ()).map_err(|e| e.error),
             });

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -61,6 +61,7 @@ use frame_system::pallet_prelude::RuntimeCallFor;
 use pallet_balances::NegativeImbalance;
 use pallet_domains::staking::StakingSummary;
 pub use pallet_rewards::RewardPoint;
+use pallet_subspace::extensions::MaybeSudoCall;
 pub use pallet_subspace::{AllowAuthoringBy, EnableRewardsAt};
 use pallet_transporter::EndpointHandler;
 use parity_scale_codec::{Compact, CompactLen, Decode, Encode, MaxEncodedLen};
@@ -633,6 +634,15 @@ impl pallet_sudo::Config for Runtime {
     type WeightInfo = pallet_sudo::weights::SubstrateWeight<Runtime>;
 }
 
+impl MaybeSudoCall<Runtime> for RuntimeCall {
+    fn maybe_sudo_call(&self) -> Option<&pallet_sudo::Call<Runtime>> {
+        match self {
+            RuntimeCall::Sudo(call) => Some(call),
+            _ => None,
+        }
+    }
+}
+
 parameter_types! {
     pub SelfChainId: ChainId = ChainId::Consensus;
 }
@@ -1058,16 +1068,19 @@ pub type Header = generic::Header<BlockNumber, BlakeTwo256>;
 pub type Block = generic::Block<Header, UncheckedExtrinsic>;
 /// The SignedExtension to the basic transaction logic.
 pub type SignedExtra = (
-    frame_system::CheckNonZeroSender<Runtime>,
-    frame_system::CheckSpecVersion<Runtime>,
-    frame_system::CheckTxVersion<Runtime>,
-    frame_system::CheckGenesis<Runtime>,
-    frame_system::CheckMortality<Runtime>,
-    frame_system::CheckNonce<Runtime>,
-    frame_system::CheckWeight<Runtime>,
+    (
+        frame_system::CheckNonZeroSender<Runtime>,
+        frame_system::CheckSpecVersion<Runtime>,
+        frame_system::CheckTxVersion<Runtime>,
+        frame_system::CheckGenesis<Runtime>,
+        frame_system::CheckMortality<Runtime>,
+        frame_system::CheckNonce<Runtime>,
+        frame_system::CheckWeight<Runtime>,
+    ),
     pallet_transaction_payment::ChargeTransactionPayment<Runtime>,
     BalanceTransferCheckExtension<Runtime>,
     pallet_subspace::extensions::SubspaceExtension<Runtime>,
+    pallet_subspace::extensions::CallMonitorExtension<Runtime>,
     pallet_domains::extensions::DomainsExtension<Runtime>,
     pallet_messenger::extensions::MessengerExtension<Runtime>,
 );
@@ -1292,20 +1305,23 @@ fn extract_successful_bundles(
 
 fn create_unsigned_general_extrinsic(call: RuntimeCall) -> UncheckedExtrinsic {
     let extra: SignedExtra = (
-        frame_system::CheckNonZeroSender::<Runtime>::new(),
-        frame_system::CheckSpecVersion::<Runtime>::new(),
-        frame_system::CheckTxVersion::<Runtime>::new(),
-        frame_system::CheckGenesis::<Runtime>::new(),
-        frame_system::CheckMortality::<Runtime>::from(generic::Era::Immortal),
-        // for unsigned extrinsic, nonce check will be skipped
-        // so set a default value
-        frame_system::CheckNonce::<Runtime>::from(0u32.into()),
-        frame_system::CheckWeight::<Runtime>::new(),
+        (
+            frame_system::CheckNonZeroSender::<Runtime>::new(),
+            frame_system::CheckSpecVersion::<Runtime>::new(),
+            frame_system::CheckTxVersion::<Runtime>::new(),
+            frame_system::CheckGenesis::<Runtime>::new(),
+            frame_system::CheckMortality::<Runtime>::from(generic::Era::Immortal),
+            // for unsigned extrinsic, nonce check will be skipped
+            // so set a default value
+            frame_system::CheckNonce::<Runtime>::from(0u32.into()),
+            frame_system::CheckWeight::<Runtime>::new(),
+        ),
         // for unsigned extrinsic, transaction fee check will be skipped
         // so set a default value
         pallet_transaction_payment::ChargeTransactionPayment::<Runtime>::from(0u128),
         BalanceTransferCheckExtension::<Runtime>::default(),
         pallet_subspace::extensions::SubspaceExtension::<Runtime>::new(),
+        pallet_subspace::extensions::CallMonitorExtension::<Runtime>::new(),
         pallet_domains::extensions::DomainsExtension::<Runtime>::new(),
         pallet_messenger::extensions::MessengerExtension::<Runtime>::new(),
     );

--- a/test/subspace-test-service/src/lib.rs
+++ b/test/subspace-test-service/src/lib.rs
@@ -1431,20 +1431,23 @@ fn get_signed_extra(
         .map(|c| c / 2)
         .unwrap_or(2);
     (
-        frame_system::CheckNonZeroSender::<Runtime>::new(),
-        frame_system::CheckSpecVersion::<Runtime>::new(),
-        frame_system::CheckTxVersion::<Runtime>::new(),
-        frame_system::CheckGenesis::<Runtime>::new(),
-        frame_system::CheckMortality::<Runtime>::from(if immortal {
-            generic::Era::Immortal
-        } else {
-            generic::Era::mortal(period, current_block)
-        }),
-        frame_system::CheckNonce::<Runtime>::from(nonce.into()),
-        frame_system::CheckWeight::<Runtime>::new(),
+        (
+            frame_system::CheckNonZeroSender::<Runtime>::new(),
+            frame_system::CheckSpecVersion::<Runtime>::new(),
+            frame_system::CheckTxVersion::<Runtime>::new(),
+            frame_system::CheckGenesis::<Runtime>::new(),
+            frame_system::CheckMortality::<Runtime>::from(if immortal {
+                generic::Era::Immortal
+            } else {
+                generic::Era::mortal(period, current_block)
+            }),
+            frame_system::CheckNonce::<Runtime>::from(nonce.into()),
+            frame_system::CheckWeight::<Runtime>::new(),
+        ),
         pallet_transaction_payment::ChargeTransactionPayment::<Runtime>::from(tip),
         BalanceTransferCheckExtension::<Runtime>::default(),
         pallet_subspace::extensions::SubspaceExtension::<Runtime>::new(),
+        pallet_subspace::extensions::CallMonitorExtension::<Runtime>::new(),
         pallet_domains::extensions::DomainsExtension::<Runtime>::new(),
         pallet_messenger::extensions::MessengerExtension::<Runtime>::new(),
     )
@@ -1476,7 +1479,7 @@ where
         >::from_raw(
             function,
             extra.clone(),
-            ((), 100, 1, genesis_block, current_block_hash, (), (), (), (), (), (),()),
+            (((), 100, 1, genesis_block, current_block_hash, (), ()),(), (), (), (), (),()),
         ),
         extra,
     )


### PR DESCRIPTION
This PR is an initial part of autonomys/subspace-chain-alerts#3, which logs:
- sudo calls using an extension
- domain sudo calls directly in our pallet

Other mechanisms to log sudo calls don't work, because:
- there's no logging in pallet-sudo
- call filters are skipped by sudo calls
- events only show the result of the call, not what the call actually was

#### Next Steps

- add operator slash logging
- add email/slack/grafana notifications for these logs

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
