### PR TITLE
Add `rust-all` CI job to aggregate results

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -391,3 +391,28 @@ jobs:
       - name: check for unused dependencies
         run: |
           ./scripts/find-unused-deps.sh
+
+  rust-all:
+    # Hack for buggy GitHub Actions behavior with skipped checks: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks#handling-skipped-but-required-checks
+    if: ${{ always() }}
+    runs-on: ubuntu-24.04
+    needs:
+      - cargo-fmt
+      - cargo-clippy
+      - cargo-runtime-build
+      - cargo-test
+      - check-runtime-benchmarks
+      - cargo-check-individually
+      - cargo-unused-deps
+    steps:
+      - name: Check job statuses
+        # Another hack is to actually check the status of the dependencies or else it'll fall through
+        run: |
+          echo "Checking statuses..."
+          [[ "${{ needs.cargo-fmt.result }}" == "success" ]] || exit 1
+          [[ "${{ needs.cargo-clippy.result }}" == "success" ]] || exit 1
+          [[ "${{ needs.cargo-runtime-build.result }}" == "success" ]] || exit 1
+          [[ "${{ needs.cargo-test.result }}" == "success" ]] || exit 1
+          [[ "${{ needs.check-runtime-benchmarks.result }}" == "success" ]] || exit 1
+          [[ "${{ needs.cargo-check-individually.result }}" == "success" ]] || exit 1
+          [[ "${{ needs.cargo-unused-deps.result }}" == "success" ]] || exit 1


### PR DESCRIPTION
This will aggregate status of all jobs in `rust-yml` workflow, simplifying branch protection rules. It also no longer depends on the final name of individual jobs that are generated from job matrix.

Helpful for https://github.com/autonomys/subspace/pull/3647

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
