### PR TITLE
Fix process exit checks and logs

### DIFF
--- a/crates/subspace-bootstrap-node/src/main.rs
+++ b/crates/subspace-bootstrap-node/src/main.rs
@@ -4,6 +4,7 @@
 
 use clap::Parser;
 use futures::FutureExt;
+use futures::channel::oneshot;
 use libp2p::identity::ed25519::Keypair;
 use libp2p::kad::Mode;
 use libp2p::{Multiaddr, PeerId, identity};
@@ -212,7 +213,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 () = signal.fuse() => {},
 
                 // Networking node runner future
-                _ = node_runner_fut.fuse() => {
+                Ok(()) | Err(oneshot::Canceled) = node_runner_fut.fuse() => {
                     info!("DSN network runner exited.");
                 },
             }

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -792,8 +792,8 @@ where
     // event handlers
     drop(plotted_pieces);
 
+    // The prometheus server is a non-essential service, so we don't exit if it stops.
     // TODO: spawn this in a dedicated thread
-    // TODO: stop if the prometheus server stops
     let _prometheus_worker = if should_start_prometheus_server {
         let prometheus_task = start_prometheus_metrics_server(
             prometheus_listen_on,

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -860,12 +860,11 @@ where
 
     select! {
         // Signal future
-        _ = signal.fuse() => {}
+        // Match the return type, so we change the code if we add errors in future.
+        () = signal.fuse() => {}
 
         // Networking future
-        _ = networking_fut.fuse() => {
-            info!("Node runner exited.")
-        },
+        Ok(()) | Err(oneshot::Canceled) = networking_fut.fuse() => {}
 
         // Farm future
         result = farm_fut.fuse() => {
@@ -873,9 +872,7 @@ where
         },
 
         // Piece cache worker future
-        _ = farmer_cache_worker_fut.fuse() => {
-            info!("Farmer cache worker exited.")
-        },
+        Ok(()) | Err(oneshot::Canceled) = farmer_cache_worker_fut.fuse() => {},
     }
 
     anyhow::Ok(())


### PR DESCRIPTION
This PR treats the bootstrap node prometheus task as non-essential, and explicitly ignores some exit errors.

#### Fixes

The boostrap node treats its prometheus task as non-essential: it doesn't exit if that task exits. This matches farmer behaviour. I added comments so we don't accidentally change this in future.

#### Type Checks

When we ignore a task cancellation, I added explicit types, so we don't accidentally ignore any other errors.

#### Refactors

I simplified the prometheus select code in the farmer and bootstrap node, so we don't have multiple `select!` statements. This requires the pattern matching feature of `tokio::select!`:
https://tokio.rs/tokio/tutorial/select#pattern-matching

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
