### PR TITLE
Release farmer cache piece permit after errors

### DIFF
--- a/crates/subspace-farmer/src/farmer_cache.rs
+++ b/crates/subspace-farmer/src/farmer_cache.rs
@@ -568,6 +568,8 @@ where
 
                     while let Some((index, (piece_index, result))) = pieces_stream.next().await {
                         debug!(%batch, %index, %piece_index, "Downloaded piece");
+                        // Release slot for future batches, by dropping it along with the piece.
+                        let _permit = permit.split(1);
 
                         let piece = match result {
                             Ok(Some(piece)) => {
@@ -588,8 +590,6 @@ where
                                 continue;
                             }
                         };
-                        // Release slot for future batches
-                        permit.split(1);
 
                         let (offset, maybe_backend) = {
                             let mut caches = caches.lock();


### PR DESCRIPTION
Currently the farmer will release the piece cache permit when a piece is successfully downloaded. But if there is an error, the slot isn't released until the end of the batch.

This PR releases the permit ~~as soon as the piece is yielded from the stream.~~ when the piece is dropped at the end of the scope, or when the loop is continued.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
