### PR TITLE
Deduplicate set_exit_on_panic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13668,6 +13668,7 @@ dependencies = [
  "sp-weights",
  "subspace-core-primitives",
  "subspace-networking",
+ "subspace-process",
  "subspace-proof-of-space",
  "subspace-runtime",
  "subspace-runtime-primitives",

--- a/crates/subspace-bootstrap-node/src/main.rs
+++ b/crates/subspace-bootstrap-node/src/main.rs
@@ -13,14 +13,13 @@ use serde::{Deserialize, Serialize};
 use std::error::Error;
 use std::fmt::{Display, Formatter};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
-use std::panic;
-use std::process::exit;
 use std::sync::Arc;
 use subspace_metrics::{RegistryAdapter, start_prometheus_metrics_server};
 use subspace_networking::libp2p::multiaddr::Protocol;
 use subspace_networking::{Config, KademliaMode, peer_id};
 use subspace_process::{
-    AsyncJoinOnDrop, init_logger, raise_fd_limit, run_future_in_dedicated_thread, shutdown_signal,
+    AsyncJoinOnDrop, init_logger, raise_fd_limit, run_future_in_dedicated_thread,
+    set_exit_on_panic, shutdown_signal,
 };
 use tokio::select;
 use tracing::{debug, info};
@@ -107,16 +106,6 @@ impl KeypairOutput {
             peer_id: peer_id_from_keypair(keypair).to_base58(),
         }
     }
-}
-
-/// Install a panic handler which exits on panics, rather than unwinding. Unwinding can hang the
-/// tokio runtime waiting for stuck tasks or threads.
-fn set_exit_on_panic() {
-    let default_panic_hook = panic::take_hook();
-    panic::set_hook(Box::new(move |panic_info| {
-        default_panic_hook(panic_info);
-        exit(1);
-    }));
 }
 
 #[tokio::main]

--- a/crates/subspace-farmer/Cargo.toml
+++ b/crates/subspace-farmer/Cargo.toml
@@ -57,7 +57,7 @@ subspace-farmer-components.workspace = true
 subspace-kzg.workspace = true
 subspace-metrics = { workspace = true, optional = true }
 subspace-networking.workspace = true
-subspace-process = { workspace = true, optional = true }
+subspace-process.workspace = true
 subspace-proof-of-space.workspace = true
 subspace-rpc-primitives.workspace = true
 subspace-verification = { workspace = true, features = ["kzg"] }
@@ -97,5 +97,4 @@ binary = [
     "dep:criterion",
     "dep:mimalloc",
     "dep:subspace-metrics",
-    "dep:subspace-process",
 ]

--- a/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
@@ -3,11 +3,10 @@
 mod commands;
 
 use clap::Parser;
+use std::fs;
 use std::path::PathBuf;
-use std::process::exit;
-use std::{fs, panic};
 use subspace_farmer::single_disk_farm::{ScrubTarget, SingleDiskFarm};
-use subspace_process::{init_logger, raise_fd_limit};
+use subspace_process::{init_logger, raise_fd_limit, set_exit_on_panic};
 use subspace_proof_of_space::chia::ChiaTable;
 use tracing::info;
 
@@ -66,14 +65,7 @@ enum Command {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    // Exit on panics, rather than unwinding. Unwinding can hang the tokio runtime waiting for
-    // stuck tasks or threads.
-    let default_panic_hook = panic::take_hook();
-    panic::set_hook(Box::new(move |panic_info| {
-        default_panic_hook(panic_info);
-        exit(1);
-    }));
-
+    set_exit_on_panic();
     init_logger();
     raise_fd_limit();
 

--- a/crates/subspace-gateway/src/commands.rs
+++ b/crates/subspace-gateway/src/commands.rs
@@ -12,8 +12,6 @@ use crate::piece_getter::DsnPieceGetter;
 use crate::piece_validator::SegmentCommitmentPieceValidator;
 use async_lock::Semaphore;
 use clap::Parser;
-use std::panic;
-use std::process::exit;
 use std::sync::Arc;
 use subspace_data_retrieval::object_fetcher::ObjectFetcher;
 use subspace_kzg::Kzg;
@@ -53,16 +51,6 @@ pub(crate) struct GatewayOptions {
 
     #[clap(flatten)]
     dsn_options: NetworkArgs,
-}
-
-/// Install a panic handler which exits on panics, rather than unwinding. Unwinding can hang the
-/// tokio runtime waiting for stuck tasks or threads.
-pub(crate) fn set_exit_on_panic() {
-    let default_panic_hook = panic::take_hook();
-    panic::set_hook(Box::new(move |panic_info| {
-        default_panic_hook(panic_info);
-        exit(1);
-    }));
 }
 
 /// Configures and returns object fetcher and DSN node runner.

--- a/crates/subspace-gateway/src/main.rs
+++ b/crates/subspace-gateway/src/main.rs
@@ -7,9 +7,9 @@ mod node_client;
 mod piece_getter;
 mod piece_validator;
 
-use crate::commands::{Command, set_exit_on_panic};
+use crate::commands::Command;
 use clap::Parser;
-use subspace_process::{init_logger, raise_fd_limit};
+use subspace_process::{init_logger, raise_fd_limit, set_exit_on_panic};
 use tracing::info;
 
 #[global_allocator]

--- a/crates/subspace-malicious-operator/Cargo.toml
+++ b/crates/subspace-malicious-operator/Cargo.toml
@@ -70,6 +70,7 @@ sp-keyring.workspace = true
 sp-weights.workspace = true
 subspace-core-primitives.workspace = true
 subspace-networking.workspace = true
+subspace-process.workspace = true
 subspace-proof-of-space.workspace = true
 subspace-runtime.workspace = true
 subspace-runtime-primitives.workspace = true

--- a/crates/subspace-malicious-operator/src/bin/subspace-malicious-operator.rs
+++ b/crates/subspace-malicious-operator/src/bin/subspace-malicious-operator.rs
@@ -18,6 +18,7 @@ use std::collections::HashMap;
 use subspace_malicious_operator::malicious_domain_instance_starter::DomainInstanceStarter;
 use subspace_malicious_operator::{Cli, DomainCli, create_malicious_operator_configuration};
 use subspace_networking::libp2p::Multiaddr;
+use subspace_process::{init_logger, raise_fd_limit, set_exit_on_panic};
 use subspace_proof_of_space::chia::ChiaTable;
 use subspace_runtime::{Block, RuntimeApi};
 use subspace_service::config::{SubspaceConfiguration, SubspaceNetworking};
@@ -77,6 +78,10 @@ fn set_default_ss58_version<C: AsRef<dyn ChainSpec>>(chain_spec: C) {
 
 #[expect(clippy::result_large_err, reason = "Comes from Substrate")]
 fn main() -> Result<(), Error> {
+    set_exit_on_panic();
+    init_logger();
+    raise_fd_limit();
+
     let cli = Cli::from_args();
 
     let sudo_account = cli.sudo_account();

--- a/crates/subspace-networking/examples/benchmark.rs
+++ b/crates/subspace-networking/examples/benchmark.rs
@@ -18,7 +18,7 @@ use subspace_core_primitives::pieces::{Piece, PieceIndex};
 use subspace_networking::protocols::request_response::handlers::piece_by_index::PieceByIndexRequestHandler;
 use subspace_networking::utils::piece_provider::{NoPieceValidator, PieceProvider, PieceValidator};
 use subspace_networking::{Config, Node};
-use subspace_process::init_logger;
+use subspace_process::{init_logger, set_exit_on_panic};
 use tracing::{debug, error, info, trace, warn};
 
 /// Defines initial duration between get_piece calls.
@@ -126,7 +126,9 @@ enum Command {
 
 #[tokio::main]
 async fn main() {
+    set_exit_on_panic();
     init_logger();
+
     let args: Args = Args::parse();
 
     info!(?args, "Benchmark started.");

--- a/crates/subspace-networking/examples/get-peers.rs
+++ b/crates/subspace-networking/examples/get-peers.rs
@@ -5,10 +5,11 @@ use parking_lot::Mutex;
 use std::sync::Arc;
 use std::time::Duration;
 use subspace_networking::Config;
-use subspace_process::init_logger;
+use subspace_process::{init_logger, set_exit_on_panic};
 
 #[tokio::main]
 async fn main() {
+    set_exit_on_panic();
     init_logger();
 
     let config_1 = Config {

--- a/crates/subspace-networking/examples/metrics.rs
+++ b/crates/subspace-networking/examples/metrics.rs
@@ -9,13 +9,15 @@ use std::sync::Arc;
 use std::time::Duration;
 use subspace_metrics::{RegistryAdapter, start_prometheus_metrics_server};
 use subspace_networking::{Config, Node};
-use subspace_process::{init_logger, shutdown_signal};
+use subspace_process::{init_logger, set_exit_on_panic, shutdown_signal};
 use tokio::time::sleep;
 use tracing::{error, info};
 
 #[tokio::main]
 async fn main() {
+    set_exit_on_panic();
     init_logger();
+
     let mut metric_registry = Registry::default();
     let metrics = Metrics::new(&mut metric_registry);
 

--- a/crates/subspace-networking/examples/networking.rs
+++ b/crates/subspace-networking/examples/networking.rs
@@ -8,12 +8,13 @@ use parking_lot::Mutex;
 use std::sync::Arc;
 use std::time::Duration;
 use subspace_networking::Config;
-use subspace_process::init_logger;
+use subspace_process::{init_logger, set_exit_on_panic};
 
 const TOPIC: &str = "Foo";
 
 #[tokio::main]
 async fn main() {
+    set_exit_on_panic();
     init_logger();
 
     let config_1 = Config {

--- a/crates/subspace-networking/examples/random-walker.rs
+++ b/crates/subspace-networking/examples/random-walker.rs
@@ -14,7 +14,7 @@ use subspace_networking::protocols::request_response::handlers::piece_by_index::
     PieceByIndexRequest, PieceByIndexRequestHandler, PieceByIndexResponse,
 };
 use subspace_networking::{Config, Multihash, Node, PeerDiscovered, SendRequestError};
-use subspace_process::init_logger;
+use subspace_process::{init_logger, set_exit_on_panic};
 use tracing::{debug, error, info, warn};
 
 #[derive(Debug, Parser)]
@@ -45,6 +45,7 @@ struct Args {
 
 #[tokio::main]
 async fn main() {
+    set_exit_on_panic();
     init_logger();
 
     let args: Args = Args::parse();

--- a/crates/subspace-networking/examples/requests.rs
+++ b/crates/subspace-networking/examples/requests.rs
@@ -8,7 +8,7 @@ use subspace_networking::Config;
 use subspace_networking::protocols::request_response::handlers::generic_request_handler::{
     GenericRequest, GenericRequestHandler,
 };
-use subspace_process::init_logger;
+use subspace_process::{init_logger, set_exit_on_panic};
 use tokio::time::sleep;
 
 #[derive(Encode, Decode)]
@@ -25,6 +25,7 @@ struct ExampleResponse;
 
 #[tokio::main]
 async fn main() {
+    set_exit_on_panic();
     init_logger();
 
     let config_1 = Config {

--- a/crates/subspace-node/src/commands.rs
+++ b/crates/subspace-node/src/commands.rs
@@ -7,5 +7,4 @@ pub use domain_key::{
     CreateDomainKeyOptions, InsertDomainKeyOptions, create_domain_key, insert_domain_key,
 };
 pub use run::{RunOptions, run};
-pub(crate) use shared::set_exit_on_panic;
 pub use wipe::{WipeOptions, wipe};

--- a/crates/subspace-node/src/commands/shared.rs
+++ b/crates/subspace-node/src/commands/shared.rs
@@ -6,9 +6,7 @@ use sp_core::crypto::{ExposeSecret, SecretString};
 use sp_core::sr25519::Pair;
 use sp_domains::KEY_TYPE;
 use sp_keystore::Keystore;
-use std::panic;
 use std::path::PathBuf;
-use std::process::exit;
 
 /// Options used for keystore
 #[derive(Debug, Parser)]
@@ -51,14 +49,4 @@ pub(super) fn store_key_in_keystore(
     LocalKeystore::open(keystore_path, password)?
         .insert(KEY_TYPE, suri.expose_secret(), &keypair.public())
         .map_err(|()| Error::Application("Failed to insert key into keystore".to_string().into()))
-}
-
-/// Install a panic handler which exits on panics, rather than unwinding. Unwinding can hang the
-/// tokio runtime waiting for stuck tasks or threads.
-pub(crate) fn set_exit_on_panic() {
-    let default_panic_hook = panic::take_hook();
-    panic::set_hook(Box::new(move |panic_info| {
-        default_panic_hook(panic_info);
-        exit(1);
-    }));
 }

--- a/crates/subspace-node/src/main.rs
+++ b/crates/subspace-node/src/main.rs
@@ -8,7 +8,6 @@ mod cli;
 mod domain;
 
 use crate::cli::{Cli, SubspaceCliPlaceholder};
-use crate::commands::set_exit_on_panic;
 use crate::domain::cli::DomainKey;
 use crate::domain::{DomainCli, DomainSubcommand};
 use clap::Parser;
@@ -23,6 +22,7 @@ use serde_json::Value;
 use sp_core::crypto::Ss58AddressFormat;
 #[cfg(feature = "runtime-benchmarks")]
 use sp_runtime::traits::HashingFor;
+use subspace_process::set_exit_on_panic;
 use subspace_proof_of_space::chia::ChiaTable;
 use subspace_runtime::{Block, RuntimeApi};
 #[cfg(feature = "runtime-benchmarks")]


### PR DESCRIPTION
We have this identical function across all our binaries, this code:
- moves it into subspace-process
- adds it to binaries that are missing it (the malicious operator and networking examples)

This PR also fixes a small dependency issue in subspace-farmer: subspace-process used to be optional, but now it's used all the time.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
