### PR TITLE
Fix confusing references to "testnet"

### DIFF
--- a/.github/workflows/chain-spec-snapshot-build.yml
+++ b/.github/workflows/chain-spec-snapshot-build.yml
@@ -28,7 +28,7 @@ jobs:
           pull: true
           push: false
 
-      - name: Generate testnet chain specifications
+      - name: Generate chain specifications
         run: |
           docker run --rm -u root ${{ steps.build.outputs.imageid }} build-spec --chain mainnet-compiled --disable-default-bootnode > chain-spec-mainnet.json
           docker run --rm -u root ${{ steps.build.outputs.imageid }} build-spec --chain mainnet-compiled --disable-default-bootnode --raw > chain-spec-raw-mainnet.json

--- a/.github/workflows/domain-genesis-storage-snapshot-build.yml
+++ b/.github/workflows/domain-genesis-storage-snapshot-build.yml
@@ -31,7 +31,7 @@ jobs:
           pull: true
           push: false
 
-      - name: Generate testnet domain genesis storages
+      - name: Generate domain genesis storages
         run: |
           EVM_SPEC_VERSION=$(sed -nr 's/.*spec_version: ([0-9]+),/\1/p' domains/runtime/evm/src/lib.rs)
           AUTO_ID_SPEC_VERSION=$(sed -nr 's/.*spec_version: ([0-9]+),/\1/p' domains/runtime/auto-id/src/lib.rs)

--- a/crates/subspace-node/src/domain/auto_id_chain_spec.rs
+++ b/crates/subspace-node/src/domain/auto_id_chain_spec.rs
@@ -104,20 +104,20 @@ pub fn devnet_config(
 
 pub fn load_chain_spec(spec_id: &str) -> Result<Box<dyn sc_cli::ChainSpec>, String> {
     let chain_spec = match spec_id {
-        "chronos" => chronos_config(get_testnet_genesis_by_spec_id(SpecId::Chronos))?,
-        "devnet" => devnet_config(get_testnet_genesis_by_spec_id(SpecId::DevNet))?,
-        "dev" => development_config(get_testnet_genesis_by_spec_id(SpecId::Dev))?,
-        "mainnet" => mainnet_config(get_testnet_genesis_by_spec_id(SpecId::Mainnet))?,
+        "chronos" => chronos_config(get_genesis_by_spec_id(SpecId::Chronos))?,
+        "devnet" => devnet_config(get_genesis_by_spec_id(SpecId::DevNet))?,
+        "dev" => development_config(get_genesis_by_spec_id(SpecId::Dev))?,
+        "mainnet" => mainnet_config(get_genesis_by_spec_id(SpecId::Mainnet))?,
         path => GenericChainSpec::from_json_file(std::path::PathBuf::from(path))?,
     };
     Ok(Box::new(chain_spec))
 }
 
-pub fn get_testnet_genesis_by_spec_id(_: SpecId) -> RuntimeGenesisConfig {
+pub fn get_genesis_by_spec_id(_: SpecId) -> RuntimeGenesisConfig {
     empty_genesis()
 }
 
-pub fn get_testnet_endowed_accounts_by_spec_id(spec_id: SpecId) -> Vec<(MultiAccountId, Balance)> {
+pub fn get_endowed_accounts_by_spec_id(spec_id: SpecId) -> Vec<(MultiAccountId, Balance)> {
     match spec_id {
         SpecId::Dev => get_dev_accounts()
             .into_iter()
@@ -165,9 +165,9 @@ fn get_operator_params(spec_id: SpecId) -> GenesisOperatorParams {
 #[expect(dead_code)]
 pub fn get_genesis_domain(spec_id: SpecId) -> Result<GenesisDomain, String> {
     let chain_spec = match spec_id {
-        SpecId::Dev => development_config(get_testnet_genesis_by_spec_id(spec_id))?,
-        SpecId::Chronos => chronos_config(get_testnet_genesis_by_spec_id(spec_id))?,
-        SpecId::DevNet => devnet_config(get_testnet_genesis_by_spec_id(spec_id))?,
+        SpecId::Dev => development_config(get_genesis_by_spec_id(spec_id))?,
+        SpecId::Chronos => chronos_config(get_genesis_by_spec_id(spec_id))?,
+        SpecId::DevNet => devnet_config(get_genesis_by_spec_id(spec_id))?,
         SpecId::Mainnet => return Err("No genesis domain available for mainnet spec.".to_string()),
     };
 
@@ -186,7 +186,7 @@ pub fn get_genesis_domain(spec_id: SpecId) -> Result<GenesisDomain, String> {
         runtime_type: RuntimeType::AutoId,
         runtime_version: auto_id_domain_runtime::VERSION,
         domain_name: "auto-id".to_string(),
-        initial_balances: get_testnet_endowed_accounts_by_spec_id(spec_id),
+        initial_balances: get_endowed_accounts_by_spec_id(spec_id),
         operator_allow_list,
         operator_signing_key,
         domain_runtime_config: DomainRuntimeConfig::default_auto_id(),

--- a/crates/subspace-node/src/domain/evm_chain_spec.rs
+++ b/crates/subspace-node/src/domain/evm_chain_spec.rs
@@ -111,20 +111,20 @@ pub fn devnet_config(
 
 pub fn load_chain_spec(spec_id: &str) -> Result<Box<dyn sc_cli::ChainSpec>, String> {
     let chain_spec = match spec_id {
-        "chronos" => chronos_config(get_testnet_genesis_by_spec_id(SpecId::Chronos))?,
-        "devnet" => devnet_config(get_testnet_genesis_by_spec_id(SpecId::DevNet))?,
-        "dev" => development_config(get_testnet_genesis_by_spec_id(SpecId::Dev))?,
-        "mainnet" => mainnet_config(get_testnet_genesis_by_spec_id(SpecId::Mainnet))?,
+        "chronos" => chronos_config(get_genesis_by_spec_id(SpecId::Chronos))?,
+        "devnet" => devnet_config(get_genesis_by_spec_id(SpecId::DevNet))?,
+        "dev" => development_config(get_genesis_by_spec_id(SpecId::Dev))?,
+        "mainnet" => mainnet_config(get_genesis_by_spec_id(SpecId::Mainnet))?,
         path => GenericChainSpec::from_json_file(std::path::PathBuf::from(path))?,
     };
     Ok(Box::new(chain_spec))
 }
 
-pub fn get_testnet_genesis_by_spec_id(_: SpecId) -> RuntimeGenesisConfig {
+pub fn get_genesis_by_spec_id(_: SpecId) -> RuntimeGenesisConfig {
     empty_genesis()
 }
 
-pub fn get_testnet_endowed_accounts_by_spec_id(spec_id: SpecId) -> Vec<(MultiAccountId, Balance)> {
+pub fn get_endowed_accounts_by_spec_id(spec_id: SpecId) -> Vec<(MultiAccountId, Balance)> {
     match spec_id {
         SpecId::Dev => get_dev_accounts()
             .into_iter()
@@ -192,9 +192,9 @@ fn get_operator_params(spec_id: SpecId) -> GenesisOperatorParams {
 
 pub fn get_genesis_domain(spec_id: SpecId, evm_type: EvmType) -> Result<GenesisDomain, String> {
     let chain_spec = match spec_id {
-        SpecId::Dev => development_config(get_testnet_genesis_by_spec_id(spec_id))?,
-        SpecId::Chronos => chronos_config(get_testnet_genesis_by_spec_id(spec_id))?,
-        SpecId::DevNet => devnet_config(get_testnet_genesis_by_spec_id(spec_id))?,
+        SpecId::Dev => development_config(get_genesis_by_spec_id(spec_id))?,
+        SpecId::Chronos => chronos_config(get_genesis_by_spec_id(spec_id))?,
+        SpecId::DevNet => devnet_config(get_genesis_by_spec_id(spec_id))?,
         SpecId::Mainnet => return Err("No genesis domain available for mainnet spec.".to_string()),
     };
 
@@ -213,7 +213,7 @@ pub fn get_genesis_domain(spec_id: SpecId, evm_type: EvmType) -> Result<GenesisD
         runtime_type: RuntimeType::Evm,
         runtime_version: evm_domain_runtime::VERSION,
         domain_name: "nova".to_string(),
-        initial_balances: get_testnet_endowed_accounts_by_spec_id(spec_id),
+        initial_balances: get_endowed_accounts_by_spec_id(spec_id),
         operator_allow_list,
         operator_signing_key,
         domain_runtime_config: EvmDomainRuntimeConfig { evm_type }.into(),

--- a/docs/farming.md
+++ b/docs/farming.md
@@ -20,7 +20,7 @@ You can find these executables in the [Releases](https://github.com/autonomys/su
 
 ## Polkadot.js wallet
 
-Before running anything you need to have a wallet where you'll receive testnet coins.
+Before running anything you need to have a wallet where you'll receive mainnet coins.
 Install [Polkadot.js extension](https://polkadot.js.org/extension/) into your browser and create a new account there.
 The address of your account will be necessary at the last step.
 


### PR DESCRIPTION
There are some confusing references to "testnet" in code that is also used for mainnet, like:
- CI: Generate testnet chain specifications / domain genesis storages
- Code: `mainnet_config(get_testnet_genesis_by_spec_id(SpecId::Mainnet))`

We also still talk about testnet wallets in the farmer instructions.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
