### PR TITLE
Accept EVM ChainID as parameter through Domain Instantiation

### DIFF
--- a/crates/pallet-domains/src/benchmarking.rs
+++ b/crates/pallet-domains/src/benchmarking.rs
@@ -23,6 +23,7 @@ use crate::{
 use alloc::borrow::ToOwned;
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
+use domain_runtime_primitives::EVMChainId;
 use frame_benchmarking::v2::*;
 use frame_support::assert_ok;
 use frame_support::traits::Hooks;
@@ -68,7 +69,7 @@ mod benchmarks {
     #[benchmark]
     fn submit_bundle() {
         let block_tree_pruning_depth = T::BlockTreePruningDepth::get().saturated_into::<u32>();
-        let domain_id = register_domain::<T>();
+        let domain_id = register_domain::<T>(1);
         let (_, operator_id) =
             register_helper_operator::<T>(domain_id, T::MinNominatorStake::get());
 
@@ -156,7 +157,7 @@ mod benchmarks {
 
     #[benchmark]
     fn submit_fraud_proof() {
-        let domain_id = register_domain::<T>();
+        let domain_id = register_domain::<T>(2);
         let (_, operator_id) =
             register_helper_operator::<T>(domain_id, T::MinNominatorStake::get());
 
@@ -216,7 +217,7 @@ mod benchmarks {
     #[benchmark]
     fn handle_bad_receipt(n: Linear<1, MAX_BUNDLE_PER_BLOCK>) {
         let minimum_nominator_stake = T::MinNominatorStake::get();
-        let domain_id = register_domain::<T>();
+        let domain_id = register_domain::<T>(3);
         let mut operator_ids = Vec::new();
         for i in 0..n {
             let (_, operator_id) =
@@ -286,7 +287,7 @@ mod benchmarks {
             T::Currency::minimum_balance() + 1u32.into(),
         );
 
-        let domain_id = register_domain::<T>();
+        let domain_id = register_domain::<T>(4);
         let mut operator_ids = Vec::new();
         for i in 0..(n + s) {
             let (_, operator_id) =
@@ -351,7 +352,7 @@ mod benchmarks {
             T::Currency::minimum_balance() + 1u32.into(),
         );
 
-        let domain_id = register_domain::<T>();
+        let domain_id = register_domain::<T>(5);
         let mut operator_ids = Vec::new();
         for i in 0..n {
             let (_, operator_id) =
@@ -389,7 +390,7 @@ mod benchmarks {
     #[benchmark]
     fn slash_operator(n: Linear<0, MAX_NOMINATORS_TO_SLASH_WITHOUT_OPERATOR>) {
         let minimum_nominator_stake = T::MinNominatorStake::get();
-        let domain_id = register_domain::<T>();
+        let domain_id = register_domain::<T>(6);
 
         let operator_count = 1;
         let nominator_per_operator = n;
@@ -455,7 +456,7 @@ mod benchmarks {
             T::Currency::minimum_balance() + 1u32.into(),
         );
 
-        let domain_id = register_domain::<T>();
+        let domain_id = register_domain::<T>(7);
         let mut operator_ids = Vec::new();
         for i in 0..T::MaxPendingStakingOperation::get() {
             let (_, operator_id) =
@@ -566,7 +567,7 @@ mod benchmarks {
             bundle_slot_probability: (1, 1),
             operator_allow_list: OperatorAllowList::Anyone,
             initial_balances: Default::default(),
-            domain_runtime_config: Default::default(),
+            domain_runtime_info: (8, Default::default()).into(),
         };
 
         assert_ok!(Domains::<T>::set_permissioned_action_allowed_by(
@@ -601,7 +602,7 @@ mod benchmarks {
             T::MinOperatorStake::get() + T::MinNominatorStake::get(),
         );
 
-        let domain_id = register_domain::<T>();
+        let domain_id = register_domain::<T>(9);
         let operator_id = NextOperatorId::<T>::get();
         let key =
             OperatorPublicKey::from_ss58check("5Gv1Uopoqo1k7125oDtFSCmxH4DzuCiBU7HBKu2bF1GZFsEb")
@@ -646,7 +647,7 @@ mod benchmarks {
             minimum_nominator_stake * 2u32.into() + T::MinNominatorStake::get(),
         );
 
-        let domain_id = register_domain::<T>();
+        let domain_id = register_domain::<T>(10);
         let (_, operator_id) = register_helper_operator::<T>(domain_id, minimum_nominator_stake);
 
         // Add one more pending deposit
@@ -671,7 +672,7 @@ mod benchmarks {
 
     #[benchmark]
     fn deregister_operator() {
-        let domain_id = register_domain::<T>();
+        let domain_id = register_domain::<T>(11);
 
         let (operator_owner, operator_id) =
             register_helper_operator::<T>(domain_id, T::MinNominatorStake::get());
@@ -705,7 +706,7 @@ mod benchmarks {
             withdraw_amount * 4u32.into() + T::MinNominatorStake::get(),
         );
 
-        let domain_id = register_domain::<T>();
+        let domain_id = register_domain::<T>(12);
         let (_, operator_id) = register_helper_operator::<T>(domain_id, minimum_nominator_stake);
         assert_ok!(Domains::<T>::nominate_operator(
             RawOrigin::Signed(nominator.clone()).into(),
@@ -750,7 +751,7 @@ mod benchmarks {
         let staking_amount = T::MinOperatorStake::get() * 3u32.into();
         T::Currency::set_balance(&nominator, staking_amount + T::MinNominatorStake::get());
 
-        let domain_id = register_domain::<T>();
+        let domain_id = register_domain::<T>(13);
         let (_, operator_id) = register_helper_operator::<T>(domain_id, minimum_nominator_stake);
         assert_ok!(Domains::<T>::nominate_operator(
             RawOrigin::Signed(nominator.clone()).into(),
@@ -824,7 +825,7 @@ mod benchmarks {
     /// Benchmark `unlock_nominator` extrinsic for a given de-registered operator
     #[benchmark]
     fn unlock_nominator() {
-        let domain_id = register_domain::<T>();
+        let domain_id = register_domain::<T>(14);
         let (operator_owner, operator_id) =
             register_helper_operator::<T>(domain_id, T::MinNominatorStake::get());
         do_finalize_domain_current_epoch::<T>(domain_id)
@@ -856,7 +857,7 @@ mod benchmarks {
 
     #[benchmark]
     fn update_domain_operator_allow_list() {
-        let domain_id = register_domain::<T>();
+        let domain_id = register_domain::<T>(15);
         let _ = register_helper_operator::<T>(domain_id, T::MinNominatorStake::get());
         do_finalize_domain_current_epoch::<T>(domain_id)
             .expect("finalize domain staking should success");
@@ -900,7 +901,7 @@ mod benchmarks {
 
     #[benchmark]
     fn submit_receipt() {
-        let domain_id = register_domain::<T>();
+        let domain_id = register_domain::<T>(16);
         let (_, operator_id) =
             register_helper_operator::<T>(domain_id, T::MinNominatorStake::get());
 
@@ -930,7 +931,7 @@ mod benchmarks {
 
     #[benchmark]
     fn validate_submit_bundle() {
-        let domain_id = register_domain::<T>();
+        let domain_id = register_domain::<T>(17);
 
         // Use `Alice` as signing key
         let signing_key =
@@ -992,7 +993,7 @@ mod benchmarks {
 
     #[benchmark]
     fn validate_singleton_receipt() {
-        let domain_id = register_domain::<T>();
+        let domain_id = register_domain::<T>(18);
 
         // Use `Alice` as signing key
         let signing_key =
@@ -1057,7 +1058,7 @@ mod benchmarks {
 
     #[benchmark]
     fn fraud_proof_pre_check() {
-        let domain_id = register_domain::<T>();
+        let domain_id = register_domain::<T>(19);
         let (_, operator_id) =
             register_helper_operator::<T>(domain_id, T::MinNominatorStake::get());
 
@@ -1125,7 +1126,7 @@ mod benchmarks {
         runtime_id
     }
 
-    fn register_domain<T: Config>() -> DomainId {
+    fn register_domain<T: Config>(chain_id: EVMChainId) -> DomainId {
         let creator = account("domain_creator", 1, SEED);
         T::Currency::set_balance(
             &creator,
@@ -1141,7 +1142,7 @@ mod benchmarks {
             bundle_slot_probability: (1, 1),
             operator_allow_list: OperatorAllowList::Anyone,
             initial_balances: Default::default(),
-            domain_runtime_config: Default::default(),
+            domain_runtime_info: (chain_id, Default::default()).into(),
         };
 
         assert_ok!(Domains::<T>::set_permissioned_action_allowed_by(

--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -13,6 +13,7 @@ pub mod block_tree;
 pub mod bundle_storage_fund;
 pub mod domain_registry;
 pub mod extensions;
+pub mod migrations;
 mod nominator_position;
 pub mod runtime_registry;
 pub mod staking;
@@ -186,7 +187,7 @@ impl<O: Into<Result<RawOrigin, O>> + From<RawOrigin>> EnsureOrigin<O> for Ensure
 }
 
 /// The current storage version.
-const STORAGE_VERSION: StorageVersion = StorageVersion::new(5);
+const STORAGE_VERSION: StorageVersion = StorageVersion::new(6);
 
 /// The number of bundle of a particular domain to be included in the block is probabilistic
 /// and based on the consensus chain slot probability and domain bundle slot probability, usually
@@ -478,20 +479,6 @@ mod pallet {
     /// Stores the next runtime id.
     #[pallet::storage]
     pub(super) type NextRuntimeId<T> = StorageValue<_, RuntimeId, ValueQuery>;
-
-    /// Starting EVM chain ID for evm runtimes.
-    pub struct StartingEVMChainId;
-
-    // impl Get<EVMChainId> for StartingEVMChainId {
-    //     fn get() -> EVMChainId {
-    //         // Starting EVM chainID for domains.
-    //         870
-    //     }
-    // }
-    //
-    // /// Stores the next evm chain id.
-    // #[pallet::storage]
-    // pub(super) type NextEVMChainId<T> = StorageValue<_, EVMChainId, ValueQuery, StartingEVMChainId>;
 
     /// Stored the occupied evm chain id against a domain_id.
     #[pallet::storage]

--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -482,16 +482,20 @@ mod pallet {
     /// Starting EVM chain ID for evm runtimes.
     pub struct StartingEVMChainId;
 
-    impl Get<EVMChainId> for StartingEVMChainId {
-        fn get() -> EVMChainId {
-            // Starting EVM chainID for domains.
-            870
-        }
-    }
+    // impl Get<EVMChainId> for StartingEVMChainId {
+    //     fn get() -> EVMChainId {
+    //         // Starting EVM chainID for domains.
+    //         870
+    //     }
+    // }
+    //
+    // /// Stores the next evm chain id.
+    // #[pallet::storage]
+    // pub(super) type NextEVMChainId<T> = StorageValue<_, EVMChainId, ValueQuery, StartingEVMChainId>;
 
-    /// Stores the next evm chain id.
+    /// Stored the occupied evm chain id against a domain_id.
     #[pallet::storage]
-    pub(super) type NextEVMChainId<T> = StorageValue<_, EVMChainId, ValueQuery, StartingEVMChainId>;
+    pub type EvmChainIds<T: Config> = StorageMap<_, Identity, EVMChainId, DomainId, OptionQuery>;
 
     #[pallet::storage]
     pub type RuntimeRegistry<T: Config> =
@@ -1990,7 +1994,7 @@ mod pallet {
                         bundle_slot_probability: genesis_domain.bundle_slot_probability,
                         operator_allow_list: genesis_domain.operator_allow_list,
                         initial_balances: genesis_domain.initial_balances,
-                        domain_runtime_config: genesis_domain.domain_runtime_config,
+                        domain_runtime_info: genesis_domain.domain_runtime_info,
                     };
                     let domain_owner = genesis_domain.owner_account_id;
                     let domain_id = do_instantiate_domain::<T>(

--- a/crates/pallet-domains/src/migrations.rs
+++ b/crates/pallet-domains/src/migrations.rs
@@ -1,0 +1,5 @@
+//! Migration module for Domains
+
+mod v5_to_v6;
+
+pub use v5_to_v6::VersionCheckedMigrateDomainsV5ToV6;

--- a/crates/pallet-domains/src/migrations/v5_to_v6.rs
+++ b/crates/pallet-domains/src/migrations/v5_to_v6.rs
@@ -1,0 +1,121 @@
+//! Migration for EvmChainIds
+
+use crate::{Config, Pallet};
+use core::marker::PhantomData;
+use frame_support::migrations::VersionedMigration;
+use frame_support::traits::UncheckedOnRuntimeUpgrade;
+use frame_support::weights::Weight;
+
+pub type VersionCheckedMigrateDomainsV5ToV6<T> = VersionedMigration<
+    5,
+    6,
+    VersionUncheckedMigrateV5ToV6<T>,
+    Pallet<T>,
+    <T as frame_system::Config>::DbWeight,
+>;
+
+pub struct VersionUncheckedMigrateV5ToV6<T>(PhantomData<T>);
+impl<T: Config> UncheckedOnRuntimeUpgrade for VersionUncheckedMigrateV5ToV6<T> {
+    fn on_runtime_upgrade() -> Weight {
+        migrate_evm_chain_id::migrate_evm_chain_ids::<T>()
+    }
+}
+
+mod migrate_evm_chain_id {
+    use crate::pallet::DomainRegistry;
+    use crate::{Config, EvmChainIds, Pallet};
+    use domain_runtime_primitives::EVMChainId;
+    use frame_support::pallet_prelude::ValueQuery;
+    use frame_support::storage_alias;
+    use sp_core::Get;
+    use sp_domains::DomainRuntimeInfo;
+    use sp_runtime::Weight;
+
+    #[storage_alias]
+    pub(super) type NextEVMChainId<T: Config> = StorageValue<Pallet<T>, EVMChainId, ValueQuery>;
+
+    pub(super) fn migrate_evm_chain_ids<T: Config>() -> Weight {
+        let (mut read, mut write) = (0, 0);
+        // Kill the unused NextEVMChainId
+        NextEVMChainId::<T>::kill();
+        write += 1;
+
+        DomainRegistry::<T>::iter().for_each(|(domain_id, domain_obj)| {
+            read += 1;
+            // chain_ids are already unique due to incrementer.
+            // so it guarantees no duplicate chain_ids for different domains.
+            if let DomainRuntimeInfo::Evm { chain_id, .. } = domain_obj.domain_runtime_info {
+                EvmChainIds::<T>::insert(chain_id, domain_id);
+                write += 1;
+            }
+        });
+
+        T::DbWeight::get().reads_writes(read, write)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::EvmChainIds;
+    use crate::domain_registry::{DomainConfigParams, DomainObject, into_domain_config};
+    use crate::migrations::v5_to_v6::migrate_evm_chain_id::{
+        NextEVMChainId, migrate_evm_chain_ids,
+    };
+    use crate::pallet::DomainRegistry;
+    use crate::tests::{AccountId, Test, new_test_ext};
+    use domain_runtime_primitives::{Balance, DEFAULT_EVM_CHAIN_ID};
+    use frame_support::weights::RuntimeDbWeight;
+    use sp_domains::{DomainId, EvmDomainRuntimeConfig, OperatorAllowList};
+
+    #[test]
+    fn test_migrate_evm_chain_ids() {
+        let mut ext = new_test_ext();
+
+        // setup Domain registry
+        let creator = 1u128;
+        let created_at = 0u32;
+        let domain_config_params = DomainConfigParams::<AccountId, Balance> {
+            domain_name: "evm-domain".to_owned(),
+            runtime_id: 0,
+            maybe_bundle_limit: None,
+            bundle_slot_probability: (1, 1),
+            operator_allow_list: OperatorAllowList::Anyone,
+            initial_balances: vec![],
+            domain_runtime_info: (DEFAULT_EVM_CHAIN_ID, EvmDomainRuntimeConfig::default()).into(),
+        };
+
+        let domain_obj = DomainObject {
+            owner_account_id: creator,
+            created_at,
+            genesis_receipt_hash: Default::default(),
+            domain_config: into_domain_config::<Test>(domain_config_params.clone()).unwrap(),
+            domain_runtime_info: domain_config_params.domain_runtime_info,
+            domain_instantiation_deposit: Default::default(),
+        };
+        ext.execute_with(|| {
+            DomainRegistry::<Test>::insert(DomainId::new(0), domain_obj);
+            NextEVMChainId::<Test>::set(871);
+        });
+        ext.commit_all().unwrap();
+
+        // migrate
+        ext.execute_with(|| {
+            let weight = migrate_evm_chain_ids::<Test>();
+            let db_weights: RuntimeDbWeight = <Test as frame_system::Config>::DbWeight::get();
+            // we have 2 writes i.e... `NextEVMChainId` storage kill and `EvmChainIds` set
+            // we have 1 read for `DomainRegistry`
+            assert_eq!(weight, db_weights.reads_writes(1, 2));
+        });
+
+        ext.commit_all().unwrap();
+
+        // verify
+        ext.execute_with(|| {
+            assert!(!NextEVMChainId::<Test>::exists());
+            assert_eq!(
+                EvmChainIds::<Test>::get(DEFAULT_EVM_CHAIN_ID),
+                Some(DomainId::new(0))
+            );
+        })
+    }
+}

--- a/crates/pallet-domains/src/runtime_registry.rs
+++ b/crates/pallet-domains/src/runtime_registry.rs
@@ -11,7 +11,7 @@ use crate::{BalanceOf, Config, Event};
 use alloc::string::String;
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
-use domain_runtime_primitives::{AccountId20, EVMChainId, MultiAccountId, TryConvertBack};
+use domain_runtime_primitives::{AccountId20, MultiAccountId, TryConvertBack};
 use frame_support::{PalletError, ensure};
 use frame_system::AccountInfo;
 use frame_system::pallet_prelude::*;
@@ -21,8 +21,8 @@ use sp_core::Hasher;
 use sp_core::crypto::AccountId32;
 use sp_domains::storage::{RawGenesis, StorageData, StorageKey};
 use sp_domains::{
-    AutoIdDomainRuntimeConfig, DomainId, DomainRuntimeConfig, DomainsDigestItem,
-    EvmDomainRuntimeConfig, RuntimeId, RuntimeObject, RuntimeType,
+    AutoIdDomainRuntimeConfig, DomainId, DomainRuntimeInfo, DomainsDigestItem, RuntimeId,
+    RuntimeObject, RuntimeType,
 };
 use sp_runtime::DigestItem;
 use sp_runtime::traits::{CheckedAdd, Zero};
@@ -42,74 +42,6 @@ pub enum Error {
     FailedToDecodeRawGenesis,
     RuntimeCodeNotFoundInRawGenesis,
     InvalidAccountIdType,
-}
-
-/// Domain runtime specific information to create domain raw genesis.
-#[derive(TypeInfo, Debug, Encode, Decode, Clone, PartialEq, Eq)]
-pub enum DomainRuntimeInfo {
-    Evm {
-        /// The dynamic EVM chain id for this domain.
-        chain_id: EVMChainId,
-        /// The EVM-specific domain runtime config.
-        domain_runtime_config: EvmDomainRuntimeConfig,
-    },
-    AutoId {
-        /// The AutoId-specific domain runtime config.
-        domain_runtime_config: AutoIdDomainRuntimeConfig,
-    },
-}
-
-impl Default for DomainRuntimeInfo {
-    fn default() -> Self {
-        Self::Evm {
-            chain_id: 0,
-            domain_runtime_config: EvmDomainRuntimeConfig::default(),
-        }
-    }
-}
-
-impl DomainRuntimeInfo {
-    /// Returns the inner config as a `DomainRuntimeConfig`.
-    pub fn domain_runtime_config(&self) -> DomainRuntimeConfig {
-        match self {
-            Self::Evm {
-                domain_runtime_config,
-                ..
-            } => DomainRuntimeConfig::Evm(domain_runtime_config.clone()),
-            Self::AutoId {
-                domain_runtime_config,
-                ..
-            } => DomainRuntimeConfig::AutoId(domain_runtime_config.clone()),
-        }
-    }
-
-    /// If this is an EVM runtime, returns the chain id.
-    pub fn evm_chain_id(&self) -> Option<EVMChainId> {
-        match self {
-            Self::Evm { chain_id, .. } => Some(*chain_id),
-            _ => None,
-        }
-    }
-
-    pub fn is_evm_domain(&self) -> bool {
-        matches!(self, Self::Evm { .. })
-    }
-
-    pub fn is_private_evm_domain(&self) -> bool {
-        if let Self::Evm {
-            domain_runtime_config,
-            ..
-        } = self
-        {
-            domain_runtime_config.evm_type.is_private_evm_domain()
-        } else {
-            false
-        }
-    }
-
-    pub fn is_auto_id(&self) -> bool {
-        matches!(self, Self::AutoId { .. })
-    }
 }
 
 #[derive(TypeInfo, Debug, Encode, Decode, Clone, PartialEq, Eq)]

--- a/crates/pallet-domains/src/staking.rs
+++ b/crates/pallet-domains/src/staking.rs
@@ -1564,6 +1564,7 @@ pub(crate) mod tests {
         BalanceOf, Error, MAX_NOMINATORS_TO_SLASH, NominatorId, OperatorEpochSharePrice,
         SlashedReason, bundle_storage_fund,
     };
+    use domain_runtime_primitives::DEFAULT_EVM_CHAIN_ID;
     use frame_support::traits::Currency;
     use frame_support::traits::fungible::Mutate;
     use frame_support::weights::Weight;
@@ -1621,7 +1622,7 @@ pub(crate) mod tests {
                 created_at: 0,
                 genesis_receipt_hash: Default::default(),
                 domain_config,
-                domain_runtime_info: Default::default(),
+                domain_runtime_info: (DEFAULT_EVM_CHAIN_ID, Default::default()).into(),
                 domain_instantiation_deposit: Default::default(),
             };
 
@@ -1977,7 +1978,7 @@ pub(crate) mod tests {
                 created_at: 0,
                 genesis_receipt_hash: Default::default(),
                 domain_config,
-                domain_runtime_info: Default::default(),
+                domain_runtime_info: (DEFAULT_EVM_CHAIN_ID, Default::default()).into(),
                 domain_instantiation_deposit: Default::default(),
             };
 

--- a/crates/pallet-domains/src/tests.rs
+++ b/crates/pallet-domains/src/tests.rs
@@ -11,8 +11,8 @@ use crate::{
     OperatorConfig, RawOrigin as DomainOrigin, RuntimeRegistry, ScheduledRuntimeUpgrades,
 };
 use core::mem;
-use domain_runtime_primitives::BlockNumber as DomainBlockNumber;
 use domain_runtime_primitives::opaque::Header as DomainHeader;
+use domain_runtime_primitives::{BlockNumber as DomainBlockNumber, DEFAULT_EVM_CHAIN_ID};
 use frame_support::dispatch::{DispatchInfo, RawOrigin};
 use frame_support::traits::{ConstU64, Currency, Hooks, VariantCount};
 use frame_support::weights::constants::ParityDbWeight;
@@ -606,7 +606,7 @@ pub(crate) fn register_genesis_domain(creator: u128, operator_number: usize) -> 
             bundle_slot_probability: (1, 1),
             operator_allow_list: OperatorAllowList::Anyone,
             initial_balances: Default::default(),
-            domain_runtime_config: Default::default(),
+            domain_runtime_info: (DEFAULT_EVM_CHAIN_ID, Default::default()).into(),
         },
     )
     .unwrap();
@@ -782,7 +782,7 @@ fn test_bundle_format_verification() {
             created_at: Default::default(),
             genesis_receipt_hash: Default::default(),
             domain_config,
-            domain_runtime_info: Default::default(),
+            domain_runtime_info: (DEFAULT_EVM_CHAIN_ID, Default::default()).into(),
             domain_instantiation_deposit: Default::default(),
         };
         DomainRegistry::<Test>::insert(domain_id, domain_obj);

--- a/crates/sp-domains/src/lib.rs
+++ b/crates/sp-domains/src/lib.rs
@@ -30,7 +30,7 @@ use bundle_producer_election::{BundleProducerElectionParams, ProofOfElectionErro
 use core::num::ParseIntError;
 use core::ops::{Add, Sub};
 use core::str::FromStr;
-use domain_runtime_primitives::{EthereumAccountId, MultiAccountId};
+use domain_runtime_primitives::{EVMChainId, EthereumAccountId, MultiAccountId};
 use execution_receipt::{ExecutionReceiptFor, SealedSingletonReceipt};
 use frame_support::storage::storage_prefix;
 use frame_support::{Blake2_128Concat, StorageHasher};
@@ -424,51 +424,45 @@ pub struct AutoIdDomainRuntimeConfig {
     // Currently, there is no specific configuration for AutoId.
 }
 
-/// Configurations for specific domain runtime kinds.
+/// Domain runtime specific information to create domain raw genesis.
 #[derive(TypeInfo, Debug, Encode, Decode, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub enum DomainRuntimeConfig {
-    Evm(EvmDomainRuntimeConfig),
-    AutoId(AutoIdDomainRuntimeConfig),
+pub enum DomainRuntimeInfo {
+    Evm {
+        /// The dynamic EVM chain id for this domain.
+        chain_id: EVMChainId,
+        /// The EVM-specific domain runtime config.
+        domain_runtime_config: EvmDomainRuntimeConfig,
+    },
+    AutoId {
+        /// The AutoId-specific domain runtime config.
+        domain_runtime_config: AutoIdDomainRuntimeConfig,
+    },
 }
 
-impl Default for DomainRuntimeConfig {
-    fn default() -> Self {
-        Self::default_evm()
+impl From<(EVMChainId, EvmDomainRuntimeConfig)> for DomainRuntimeInfo {
+    fn from(v: (EVMChainId, EvmDomainRuntimeConfig)) -> Self {
+        DomainRuntimeInfo::Evm {
+            chain_id: v.0,
+            domain_runtime_config: v.1,
+        }
     }
 }
 
-impl From<EvmDomainRuntimeConfig> for DomainRuntimeConfig {
-    fn from(evm_config: EvmDomainRuntimeConfig) -> Self {
-        DomainRuntimeConfig::Evm(evm_config)
-    }
-}
-
-impl From<AutoIdDomainRuntimeConfig> for DomainRuntimeConfig {
+impl From<AutoIdDomainRuntimeConfig> for DomainRuntimeInfo {
     fn from(auto_id_config: AutoIdDomainRuntimeConfig) -> Self {
-        DomainRuntimeConfig::AutoId(auto_id_config)
+        DomainRuntimeInfo::AutoId {
+            domain_runtime_config: auto_id_config,
+        }
     }
 }
 
-impl DomainRuntimeConfig {
-    pub fn default_evm() -> Self {
-        DomainRuntimeConfig::Evm(EvmDomainRuntimeConfig::default())
-    }
-
-    pub fn default_auto_id() -> Self {
-        DomainRuntimeConfig::AutoId(AutoIdDomainRuntimeConfig::default())
-    }
-
-    pub fn is_evm_domain(&self) -> bool {
-        matches!(self, DomainRuntimeConfig::Evm(_))
-    }
-
-    pub fn is_auto_id(&self) -> bool {
-        matches!(self, DomainRuntimeConfig::AutoId(_))
-    }
-
+impl DomainRuntimeInfo {
     pub fn evm(&self) -> Option<&EvmDomainRuntimeConfig> {
         match self {
-            DomainRuntimeConfig::Evm(evm_config) => Some(evm_config),
+            DomainRuntimeInfo::Evm {
+                domain_runtime_config,
+                ..
+            } => Some(domain_runtime_config),
             _ => None,
         }
     }
@@ -482,9 +476,39 @@ impl DomainRuntimeConfig {
 
     pub fn auto_id(&self) -> Option<&AutoIdDomainRuntimeConfig> {
         match self {
-            DomainRuntimeConfig::AutoId(auto_id_config) => Some(auto_id_config),
+            DomainRuntimeInfo::AutoId {
+                domain_runtime_config,
+            } => Some(domain_runtime_config),
             _ => None,
         }
+    }
+
+    /// If this is an EVM runtime, returns the chain id.
+    pub fn evm_chain_id(&self) -> Option<EVMChainId> {
+        match self {
+            Self::Evm { chain_id, .. } => Some(*chain_id),
+            _ => None,
+        }
+    }
+
+    pub fn is_evm_domain(&self) -> bool {
+        matches!(self, Self::Evm { .. })
+    }
+
+    pub fn is_private_evm_domain(&self) -> bool {
+        if let Self::Evm {
+            domain_runtime_config,
+            ..
+        } = self
+        {
+            domain_runtime_config.evm_type.is_private_evm_domain()
+        } else {
+            false
+        }
+    }
+
+    pub fn is_auto_id(&self) -> bool {
+        matches!(self, Self::AutoId { .. })
     }
 }
 
@@ -502,7 +526,7 @@ pub struct GenesisDomain<AccountId: Ord, Balance> {
     pub bundle_slot_probability: (u64, u64),
     pub operator_allow_list: OperatorAllowList<AccountId>,
     /// Configurations for a specific type of domain runtime, for example, EVM.
-    pub domain_runtime_config: DomainRuntimeConfig,
+    pub domain_runtime_info: DomainRuntimeInfo,
 
     // Genesis operator
     pub signing_key: OperatorPublicKey,

--- a/crates/sp-domains/src/lib.rs
+++ b/crates/sp-domains/src/lib.rs
@@ -428,7 +428,7 @@ pub struct AutoIdDomainRuntimeConfig {
 #[derive(TypeInfo, Debug, Encode, Decode, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum DomainRuntimeInfo {
     Evm {
-        /// The dynamic EVM chain id for this domain.
+        /// The EVM chain id for this domain.
         chain_id: EVMChainId,
         /// The EVM-specific domain runtime config.
         domain_runtime_config: EvmDomainRuntimeConfig,
@@ -495,6 +495,8 @@ impl DomainRuntimeInfo {
         matches!(self, Self::Evm { .. })
     }
 
+    /// Returns true if the domain is configured as a private EVM domain.
+    /// Returns false for public EVM domains and non-EVM domains.
     pub fn is_private_evm_domain(&self) -> bool {
         if let Self::Evm {
             domain_runtime_config,

--- a/crates/subspace-malicious-operator/src/chain_spec.rs
+++ b/crates/subspace-malicious-operator/src/chain_spec.rs
@@ -1,4 +1,4 @@
-use domain_runtime_primitives::{AccountId20Converter, MultiAccountId};
+use domain_runtime_primitives::{AccountId20Converter, DEFAULT_EVM_CHAIN_ID, MultiAccountId};
 use evm_domain_runtime::{AccountId as AccountId20, EVMChainIdConfig, EVMConfig, Precompiles};
 use hex_literal::hex;
 use parity_scale_codec::Encode;
@@ -8,8 +8,8 @@ use sp_core::crypto::AccountId32;
 use sp_core::{Pair, Public, sr25519};
 use sp_domains::storage::RawGenesis;
 use sp_domains::{
-    DomainRuntimeConfig, OperatorAllowList, OperatorPublicKey, PermissionedActionAllowedBy,
-    RuntimeType,
+    DomainRuntimeInfo, EvmDomainRuntimeConfig, EvmType, OperatorAllowList, OperatorPublicKey,
+    PermissionedActionAllowedBy, RuntimeType,
 };
 use sp_runtime::traits::{Convert, IdentifyAccount};
 use sp_runtime::{BuildStorage, MultiSigner, Percent};
@@ -141,7 +141,7 @@ struct GenesisDomainParams {
     raw_genesis_storage: Vec<u8>,
     initial_balances: Vec<(MultiAccountId, Balance)>,
     permissioned_action_allowed_by: PermissionedActionAllowedBy<AccountId>,
-    domain_runtime_config: DomainRuntimeConfig,
+    domain_runtime_info: DomainRuntimeInfo,
 }
 
 pub fn dev_config() -> Result<GenericChainSpec, String> {
@@ -201,7 +201,13 @@ pub fn dev_config() -> Result<GenericChainSpec, String> {
                     raw_genesis_storage: raw_genesis_storage.clone(),
                     initial_balances: endowed_accounts(),
                     permissioned_action_allowed_by: PermissionedActionAllowedBy::Anyone,
-                    domain_runtime_config: DomainRuntimeConfig::default_evm(),
+                    domain_runtime_info: (
+                        DEFAULT_EVM_CHAIN_ID,
+                        EvmDomainRuntimeConfig {
+                            evm_type: EvmType::Public,
+                        },
+                    )
+                        .into(),
                 },
             ))
             .map_err(|error| format!("Failed to serialize genesis config: {error}"))?,
@@ -275,7 +281,7 @@ fn subspace_genesis_config(
                 nomination_tax: Percent::from_percent(5),
                 minimum_nominator_stake: 100 * AI3,
                 initial_balances: genesis_domain_params.initial_balances,
-                domain_runtime_config: genesis_domain_params.domain_runtime_config,
+                domain_runtime_info: genesis_domain_params.domain_runtime_info,
             }],
         },
     }

--- a/crates/subspace-node/src/chain_spec.rs
+++ b/crates/subspace-node/src/chain_spec.rs
@@ -435,7 +435,7 @@ fn subspace_genesis_config(
                     nomination_tax: Percent::from_percent(5),
                     minimum_nominator_stake: 100 * AI3,
                     initial_balances: genesis_domain.initial_balances,
-                    domain_runtime_config: genesis_domain.domain_runtime_config,
+                    domain_runtime_info: genesis_domain.domain_runtime_info,
                 }
             })
             .collect()

--- a/crates/subspace-node/src/domain/auto_id_chain_spec.rs
+++ b/crates/subspace-node/src/domain/auto_id_chain_spec.rs
@@ -12,7 +12,7 @@ use sc_chain_spec::GenericChainSpec;
 use sc_service::ChainType;
 use sp_core::crypto::{AccountId32, UncheckedFrom};
 use sp_domains::storage::RawGenesis;
-use sp_domains::{DomainRuntimeConfig, OperatorAllowList, OperatorPublicKey, RuntimeType};
+use sp_domains::{DomainRuntimeInfo, OperatorAllowList, OperatorPublicKey, RuntimeType};
 use sp_runtime::BuildStorage;
 use sp_runtime::traits::Convert;
 use subspace_runtime_primitives::{AI3, Balance};
@@ -189,6 +189,8 @@ pub fn get_genesis_domain(spec_id: SpecId) -> Result<GenesisDomain, String> {
         initial_balances: get_endowed_accounts_by_spec_id(spec_id),
         operator_allow_list,
         operator_signing_key,
-        domain_runtime_config: DomainRuntimeConfig::default_auto_id(),
+        domain_runtime_info: DomainRuntimeInfo::AutoId {
+            domain_runtime_config: Default::default(),
+        },
     })
 }

--- a/crates/subspace-node/src/domain/cli.rs
+++ b/crates/subspace-node/src/domain/cli.rs
@@ -17,7 +17,7 @@ use sp_blockchain::HeaderBackend;
 use sp_domain_digests::AsPredigest;
 use sp_domains::storage::RawGenesis;
 use sp_domains::{
-    DomainId, DomainRuntimeConfig, OperatorAllowList, OperatorId, OperatorPublicKey, RuntimeType,
+    DomainId, DomainRuntimeInfo, OperatorAllowList, OperatorId, OperatorPublicKey, RuntimeType,
 };
 use sp_runtime::DigestItem;
 use sp_runtime::generic::BlockId;
@@ -471,7 +471,7 @@ pub struct GenesisDomain {
     pub initial_balances: Vec<(MultiAccountId, Balance)>,
     pub operator_allow_list: OperatorAllowList<AccountId>,
     pub operator_signing_key: OperatorPublicKey,
-    pub domain_runtime_config: DomainRuntimeConfig,
+    pub domain_runtime_info: DomainRuntimeInfo,
 }
 
 /// Genesis Operator list params

--- a/crates/subspace-node/src/domain/evm_chain_spec.rs
+++ b/crates/subspace-node/src/domain/evm_chain_spec.rs
@@ -2,7 +2,7 @@
 
 use crate::chain_spec_utils::{chain_spec_properties, get_public_key_from_seed};
 use crate::domain::cli::{GenesisDomain, GenesisOperatorParams, SpecId};
-use domain_runtime_primitives::{AccountId20Converter, MultiAccountId};
+use domain_runtime_primitives::{AccountId20Converter, DEFAULT_EVM_CHAIN_ID, MultiAccountId};
 use evm_domain_runtime::{
     AccountId, BalancesConfig, EVMChainIdConfig, EVMConfig, Precompiles, RuntimeGenesisConfig,
     SystemConfig, WASM_BINARY,
@@ -216,6 +216,6 @@ pub fn get_genesis_domain(spec_id: SpecId, evm_type: EvmType) -> Result<GenesisD
         initial_balances: get_endowed_accounts_by_spec_id(spec_id),
         operator_allow_list,
         operator_signing_key,
-        domain_runtime_config: EvmDomainRuntimeConfig { evm_type }.into(),
+        domain_runtime_info: (DEFAULT_EVM_CHAIN_ID, EvmDomainRuntimeConfig { evm_type }).into(),
     })
 }

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -134,7 +134,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_version: 5,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
-    transaction_version: 0,
+    transaction_version: 1,
     system_version: 2,
 };
 
@@ -1152,6 +1152,7 @@ pub type Executive = frame_executive::Executive<
     frame_system::ChainContext<Runtime>,
     Runtime,
     AllPalletsWithSystem,
+    pallet_domains::migrations::VersionCheckedMigrateDomainsV5ToV6<Runtime>,
 >;
 
 impl pallet_subspace::extensions::MaybeSubspaceCall<Runtime> for RuntimeCall {

--- a/domains/primitives/runtime/src/lib.rs
+++ b/domains/primitives/runtime/src/lib.rs
@@ -73,6 +73,9 @@ pub const SLOT_DURATION: u64 = 1000;
 /// The EVM chain Id type
 pub type EVMChainId = u64;
 
+/// Default EVM chain ID used for testing and Genesis domains for Devnet and Local net.
+pub const DEFAULT_EVM_CHAIN_ID: EVMChainId = 870;
+
 /// Alias to 512-bit hash when used in the context of a transaction signature on the EVM chain.
 pub type EthereumSignature = EVMSignature;
 

--- a/test/subspace-test-client/src/auto_id_domain_chain_spec.rs
+++ b/test/subspace-test-client/src/auto_id_domain_chain_spec.rs
@@ -9,7 +9,7 @@ use sp_core::crypto::AccountId32;
 use sp_core::{Pair, Public, sr25519};
 use sp_domains::storage::RawGenesis;
 use sp_domains::{
-    DomainRuntimeConfig, GenesisDomain, OperatorAllowList, OperatorPublicKey, RuntimeType,
+    DomainRuntimeInfo, GenesisDomain, OperatorAllowList, OperatorPublicKey, RuntimeType,
 };
 use sp_runtime::traits::{Convert, IdentifyAccount};
 use sp_runtime::{BuildStorage, MultiSigner, Percent};
@@ -97,6 +97,8 @@ pub fn get_genesis_domain(
             .map(|k| (AccountIdConverter::convert(k), 2_000_000 * AI3))
             .collect(),
 
-        domain_runtime_config: DomainRuntimeConfig::default_auto_id(),
+        domain_runtime_info: DomainRuntimeInfo::AutoId {
+            domain_runtime_config: Default::default(),
+        },
     })
 }

--- a/test/subspace-test-client/src/evm_domain_chain_spec.rs
+++ b/test/subspace-test-client/src/evm_domain_chain_spec.rs
@@ -1,7 +1,7 @@
 //! Chain specification for the evm domain.
 
 use crate::chain_spec::get_from_seed;
-use domain_runtime_primitives::AccountId20Converter;
+use domain_runtime_primitives::{AccountId20Converter, DEFAULT_EVM_CHAIN_ID};
 use evm_domain_test_runtime::{
     AccountId as AccountId20, Precompiles, RuntimeGenesisConfig, Signature,
 };
@@ -137,6 +137,6 @@ pub fn get_genesis_domain(
             .map(|k| (AccountId20Converter::convert(k), 2_000_000 * AI3))
             .collect(),
 
-        domain_runtime_config: EvmDomainRuntimeConfig { evm_type }.into(),
+        domain_runtime_info: (DEFAULT_EVM_CHAIN_ID, EvmDomainRuntimeConfig { evm_type }).into(),
     })
 }


### PR DESCRIPTION
This PR brings following changes
- Accept EVM chainID as a parameter of Runtime Info at the time of Domain instantiation
- Removes existing `NextEvmChainId` storage used to allocate evm chainID for new EVM domains.
- Migration for existing EVM chains to store already allocated EVM chain IDs into storage to avoid re-allocation.
- Bumped TransactionVersion since `instantiate_domain` parameter type has changed


spec_version will be bumped before runtime release

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
