### PR TITLE
Improve farmer piece cache writing performance, and add debugging logs

### DIFF
--- a/crates/subspace-farmer/src/cluster/controller/stream_map.rs
+++ b/crates/subspace-farmer/src/cluster/controller/stream_map.rs
@@ -57,7 +57,7 @@ where
         }
     }
 
-    /// Polls the next entry in `in_progress` and moves the next task from `queue` to `in_progress` if there is any.
+    /// Polls the next entry in `in_progress` and moves the next task from `queue` to `in_progress` if there is one.
     /// If there are no more tasks to execute, returns `None`.
     fn poll_next_entry(&mut self, cx: &mut Context<'_>) -> Poll<Option<(Index, R)>> {
         if let Some((index, res)) = std::task::ready!(self.in_progress.poll_next_unpin(cx)) {

--- a/crates/subspace-farmer/src/disk_piece_cache.rs
+++ b/crates/subspace-farmer/src/disk_piece_cache.rs
@@ -342,7 +342,7 @@ impl DiskPieceCache {
         })
     }
 
-    /// Store piece in cache at specified offset, replacing existing piece if there is any
+    /// Store piece in cache at specified offset, replacing existing piece if there is one.
     ///
     /// NOTE: it is possible to do concurrent reads and writes, higher level logic must ensure this
     /// doesn't happen for the same piece being accessed!

--- a/crates/subspace-farmer/src/farm.rs
+++ b/crates/subspace-farmer/src/farm.rs
@@ -194,11 +194,13 @@ pub trait PieceCache: Send + Sync + fmt::Debug {
 /// Result of piece storing check
 #[derive(Debug, Copy, Clone, Encode, Decode)]
 pub enum MaybePieceStoredResult {
-    /// Definitely not stored
+    /// Piece is not stored already, and can't be added because the cache/plot is full.
     No,
-    /// Maybe has vacant slot to store
+    /// Cache might have a vacant slot to store this piece.
+    /// Vacant slots are not guaranteed, they can be overwritten by another piece or newly plotted
+    /// sector at any time.
     Vacant,
-    /// Maybe still stored
+    /// Piece is already stored in the cache.
     Yes,
 }
 
@@ -210,14 +212,16 @@ pub enum MaybePieceStoredResult {
 /// again, which is slower and uses a lot of Internet bandwidth.
 #[async_trait]
 pub trait PlotCache: Send + Sync + fmt::Debug {
-    /// Check if piece is potentially stored in this cache (not guaranteed to be because it might be
-    /// overridden with sector any time)
+    /// Check if a piece is already stored in this cache, or it can be added to this cache.
+    /// The piece is not guaranteed to be stored, because it might be overwritten with a new
+    /// sector any time.
     async fn is_piece_maybe_stored(
         &self,
         key: &RecordKey,
     ) -> Result<MaybePieceStoredResult, FarmError>;
 
-    /// Store piece in cache if there is free space, otherwise `Ok(false)` is returned
+    /// Store piece in cache if there is free space, and return `Ok(true)`.
+    /// Returns `Ok(false)` if there is no free space, or the farm or process is shutting down.
     async fn try_store_piece(
         &self,
         piece_index: PieceIndex,

--- a/crates/subspace-farmer/src/farm.rs
+++ b/crates/subspace-farmer/src/farm.rs
@@ -137,7 +137,7 @@ pub trait PieceCache: Send + Sync + fmt::Debug {
         FarmError,
     >;
 
-    /// Store piece in cache at specified offset, replacing existing piece if there is any.
+    /// Store piece in cache at specified offset, replacing existing piece if there is one.
     ///
     /// NOTE: it is possible to do concurrent reads and writes, higher level logic must ensure this
     /// doesn't happen for the same piece being accessed!

--- a/crates/subspace-farmer/src/farmer_piece_getter.rs
+++ b/crates/subspace-farmer/src/farmer_piece_getter.rs
@@ -271,7 +271,8 @@ where
         let fut = async move {
             let tx = &tx;
 
-            debug!("Getting pieces from farmer cache");
+            let piece_count = piece_indices.len();
+            debug!(%piece_count, "Getting pieces from farmer cache");
             let mut pieces_not_found_in_farmer_cache = Vec::new();
             let mut pieces_in_farmer_cache =
                 self.inner.farmer_caches.get_pieces(piece_indices).await;
@@ -291,7 +292,8 @@ where
 
             debug!(
                 remaining_piece_count = %pieces_not_found_in_farmer_cache.len(),
-                "Getting pieces from DSN cache"
+                %piece_count,
+                "Getting pieces from DSN cache",
             );
             let mut pieces_not_found_in_dsn_cache = Vec::new();
             let mut pieces_in_dsn_cache = self
@@ -322,7 +324,8 @@ where
 
             debug!(
                 remaining_piece_count = %pieces_not_found_in_dsn_cache.len(),
-                "Getting pieces from node"
+                %piece_count,
+                "Getting pieces from node",
             );
             let pieces_not_found_on_node = pieces_not_found_in_dsn_cache
                 .into_iter()
@@ -361,7 +364,8 @@ where
 
             debug!(
                 remaining_piece_count = %pieces_not_found_on_node.len(),
-                "Some pieces were not easily reachable"
+                %piece_count,
+                "Some pieces were not easily reachable",
             );
             pieces_not_found_on_node
                 .into_iter()

--- a/crates/subspace-farmer/src/single_disk_farm/plot_cache.rs
+++ b/crates/subspace-farmer/src/single_disk_farm/plot_cache.rs
@@ -170,7 +170,7 @@ impl DiskPlotCache {
 
         // Make sure offset is after anything that is already plotted
         if element_offset < plotted_bytes {
-            // Remove entry since it was overridden with a sector already
+            // Remove entry since it was overwritten with a sector already
             self.cached_pieces.write().map.remove(key);
             MaybePieceStoredResult::No
         } else {
@@ -216,7 +216,7 @@ impl DiskPlotCache {
 
         // Make sure offset is after anything that is already plotted
         if element_offset < plotted_bytes {
-            // Just to be safe, avoid any overlap of write locks
+            // Just to be safe, avoid any overlap of read and write locks
             drop(sectors_metadata);
             let mut cached_pieces = self.cached_pieces.write();
             // No space to store more pieces anymore
@@ -256,7 +256,7 @@ impl DiskPlotCache {
 
         AsyncJoinOnDrop::new(write_fut, false).await??;
 
-        // Just to be safe, avoid any overlap of write locks
+        // Just to be safe, avoid any overlap of read and write locks
         drop(sectors_metadata);
         // Store newly written piece in the map
         self.cached_pieces

--- a/crates/subspace-farmer/src/single_disk_farm/plot_cache.rs
+++ b/crates/subspace-farmer/src/single_disk_farm/plot_cache.rs
@@ -229,8 +229,16 @@ impl DiskPlotCache {
         }
 
         let Some(file) = self.file.upgrade() else {
+            // File has been dropped, farm or process is shutting down
             return Ok(false);
         };
+
+        trace!(
+            %offset,
+            ?piece_index,
+            %plotted_sectors_count,
+            "Found available piece cache free space offset, writing piece",
+        );
 
         let write_fut = tokio::task::spawn_blocking({
             let piece_index_bytes = piece_index.to_bytes();

--- a/crates/subspace-networking/src/node_runner.rs
+++ b/crates/subspace-networking/src/node_runner.rs
@@ -1540,7 +1540,7 @@ impl NodeRunner {
     }
 
     fn ban_peer(&mut self, peer_id: PeerId) {
-        // Remove temporary ban if there is any before creating a permanent one
+        // Remove temporary ban if there is one, before creating a permanent one.
         self.temporary_bans.lock().remove(&peer_id);
 
         debug!(?peer_id, "Banning peer on network level");

--- a/domains/client/block-preprocessor/src/lib.rs
+++ b/domains/client/block-preprocessor/src/lib.rs
@@ -401,7 +401,7 @@ where
             maybe_invalid_bundle_type.replace(InvalidBundleType::IllegalTx(extrinsic_index));
         }
 
-        // If there is any invalid tx then return the error before checking the bundle weight,
+        // If there is any invalid tx, then return the error before checking the bundle weight,
         // which is a check of the whole bundle and should only perform when all tx are valid.
         if let Some(invalid_bundle_type) = maybe_invalid_bundle_type {
             return Ok(BundleValidity::Invalid(invalid_bundle_type));


### PR DESCRIPTION
This PR makes two different kinds of changes:

#### Piece Cache Write Locking Performance

When writing a piece, we acquire a write lock, then check for free space. Since free space almost always goes down, we can check for free space using a read lock, then return early if there isn't any. This is much faster than waiting for a write lock for every check.

We still need to re-check for free space after the write lock, because there might have been an intervening write after the read lock was released.

#### Piece Cache Logging

We've been seeing some piece cache stalls, but we're not sure where they are coming from in the code.

This PR:
- fixes incorrect/redundant piece cache storage return values, propagates them to callers, and documents them (these values were only used for logging)
- debug logs whether pieces were stored
- debug logs each piece fetch batch
- adds extra info to some debug logs

#### Snapshot Build

https://github.com/autonomys/subspace/actions/runs/17113459583

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
