### PR TITLE
Burn EIP-1559 priority fees instead of giving to Zero EVM Account

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12612,6 +12612,7 @@ dependencies = [
  "domain-block-builder",
  "domain-block-preprocessor",
  "domain-runtime-primitives",
+ "domain-test-primitives",
  "domain-test-service",
  "domain-test-utils",
  "ethereum",

--- a/crates/sp-domains-fraud-proof/Cargo.toml
+++ b/crates/sp-domains-fraud-proof/Cargo.toml
@@ -44,6 +44,7 @@ thiserror.workspace = true
 [dev-dependencies]
 criterion.workspace = true
 domain-block-preprocessor.workspace = true
+domain-test-primitives.workspace = true
 domain-test-service.workspace = true
 domain-test-utils.workspace = true
 ethereum.workspace = true

--- a/domains/runtime/evm/src/lib.rs
+++ b/domains/runtime/evm/src/lib.rs
@@ -675,7 +675,11 @@ parameter_types! {
     pub PrecompilesValue: Precompiles = Precompiles::default();
 }
 
-type InnerEVMCurrencyAdapter = pallet_evm::EVMCurrencyAdapter<Balances, ()>;
+/// UnbalancedHandler that will just burn any unbalanced funds
+pub struct UnbalancedHandler {}
+impl OnUnbalanced<NegativeImbalance> for UnbalancedHandler {}
+
+type InnerEVMCurrencyAdapter = pallet_evm::EVMCurrencyAdapter<Balances, UnbalancedHandler>;
 
 // Implementation of [`pallet_transaction_payment::OnChargeTransaction`] that charges evm transaction
 // fees from the transaction sender and collect all the fees (including both the base fee and tip) in
@@ -714,9 +718,11 @@ impl pallet_evm::OnChargeEVMTransaction<Runtime> for EVMCurrencyAdapter {
     }
 
     fn pay_priority_fee(tip: Self::LiquidityInfo) {
-        <InnerEVMCurrencyAdapter as pallet_evm::OnChargeEVMTransaction<Runtime>>::pay_priority_fee(
-            tip,
-        );
+        if let Some(fee) = tip {
+            // handle the priority fee just like the base fee.
+            // for eip-1559, total fees will be base_fee + priority_fee
+            UnbalancedHandler::on_unbalanced(fee)
+        }
     }
 }
 

--- a/domains/test/utils/src/test_ethereum.rs
+++ b/domains/test/utils/src/test_ethereum.rs
@@ -9,7 +9,7 @@ use frame_support::pallet_prelude::DispatchClass;
 use frame_system::pallet_prelude::RuntimeCallFor;
 use hex_literal::hex;
 use pallet_evm::GasWeightMapping;
-use sp_core::{Get, U256};
+use sp_core::{Get, H160, U256};
 use sp_domains::PermissionedActionAllowedBy;
 
 /// The kind of account list to generate.
@@ -121,6 +121,24 @@ pub fn max_extrinsic_gas<TestRuntime: frame_system::Config + pallet_evm::Config>
     <TestRuntime as pallet_evm::Config>::GasWeightMapping::weight_to_gas(max_extrinsic)
 }
 
+pub fn generate_legacy_transfer_txn<TestRuntime: frame_system::Config + pallet_evm::Config>(
+    account_info: AccountInfo,
+    nonce: U256,
+    gas_price: U256,
+    to: H160,
+    value: U256,
+) -> Transaction {
+    LegacyUnsignedTransaction {
+        nonce,
+        gas_price,
+        gas_limit: U256::from(21000),
+        action: ethereum::TransactionAction::Call(to),
+        value,
+        input: vec![],
+    }
+    .sign(&account_info.private_key)
+}
+
 pub fn generate_legacy_tx<TestRuntime: frame_system::Config + pallet_evm::Config>(
     account_info: AccountInfo,
     nonce: U256,
@@ -139,6 +157,24 @@ pub fn generate_legacy_tx<TestRuntime: frame_system::Config + pallet_evm::Config
     .sign(&account_info.private_key)
 }
 
+pub fn generate_eip2930_transfer_txn<TestRuntime: frame_system::Config + pallet_evm::Config>(
+    account_info: AccountInfo,
+    nonce: U256,
+    gas_price: U256,
+    to: H160,
+    value: U256,
+) -> Transaction {
+    EIP2930UnsignedTransaction {
+        nonce,
+        gas_price,
+        gas_limit: U256::from(21000),
+        action: ethereum::TransactionAction::Call(to),
+        value,
+        input: vec![],
+    }
+    .sign(&account_info.private_key, None)
+}
+
 pub fn generate_eip2930_tx<TestRuntime: frame_system::Config + pallet_evm::Config>(
     account_info: AccountInfo,
     nonce: U256,
@@ -153,6 +189,25 @@ pub fn generate_eip2930_tx<TestRuntime: frame_system::Config + pallet_evm::Confi
         action,
         value: U256::one(),
         input,
+    }
+    .sign(&account_info.private_key, None)
+}
+
+pub fn generate_eip1559_transfer_txn<TestRuntime: frame_system::Config + pallet_evm::Config>(
+    account_info: AccountInfo,
+    nonce: U256,
+    gas_price: U256,
+    to: H160,
+    value: U256,
+) -> Transaction {
+    EIP1559UnsignedTransaction {
+        nonce,
+        max_priority_fee_per_gas: gas_price,
+        max_fee_per_gas: gas_price.saturating_mul(U256::from(2)),
+        gas_limit: U256::from(21000),
+        action: ethereum::TransactionAction::Call(to),
+        value,
+        input: vec![],
     }
     .sign(&account_info.private_key, None)
 }


### PR DESCRIPTION
For EIP-1559 evm transactions, users can set priority fee apart from the base_fee. Per EVM spec, priority is fee is given to block author and base_fee is burned as expected.

For AutoEvm, we do not have a block author on EVM and as a result, the fee is deposited to Zero EVM account instead of burning the fees. 

This PR handles the case when there is a Priority fee, we instead just burn it along with base_fee and give the fees to operators on consensus chain.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
