### PR TITLE
Warning log when consensus block execution is more than reference execution and cleanup of resolved TODO

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10573,6 +10573,7 @@ dependencies = [
  "sp-inherents",
  "sp-objects",
  "sp-runtime",
+ "sp-weights",
  "subspace-archiving",
  "subspace-core-primitives",
  "subspace-erasure-coding",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12445,6 +12445,7 @@ dependencies = [
  "sp-runtime-interface",
  "sp-std",
  "sp-timestamp",
+ "sp-weights",
  "subspace-core-primitives",
  "subspace-kzg",
  "subspace-proof-of-space",

--- a/crates/sc-consensus-subspace/Cargo.toml
+++ b/crates/sc-consensus-subspace/Cargo.toml
@@ -39,6 +39,7 @@ sp-core.workspace = true
 sp-inherents.workspace = true
 sp-objects = { workspace = true, features = ["std"] }
 sp-runtime.workspace = true
+sp-weights.workspace = true
 subspace-archiving.workspace = true
 subspace-core-primitives.workspace = true
 subspace-erasure-coding.workspace = true

--- a/crates/sp-consensus-subspace/Cargo.toml
+++ b/crates/sp-consensus-subspace/Cargo.toml
@@ -29,6 +29,7 @@ sp-runtime.workspace = true
 sp-runtime-interface.workspace = true
 sp-std.workspace = true
 sp-timestamp.workspace = true
+sp-weights.workspace = true
 subspace-core-primitives.workspace = true
 subspace-kzg = { workspace = true, optional = true }
 subspace-proof-of-space.workspace = true
@@ -54,6 +55,7 @@ std = [
     "sp-runtime-interface/std",
     "sp-std/std",
     "sp-timestamp/std",
+    "sp-weights/std",
     "subspace-core-primitives/std",
     "subspace-kzg/std",
     "subspace-proof-of-space/std",

--- a/crates/sp-consensus-subspace/src/lib.rs
+++ b/crates/sp-consensus-subspace/src/lib.rs
@@ -23,6 +23,7 @@ use sp_runtime::{ConsensusEngineId, Justification};
 use sp_runtime_interface::pass_by::PassBy;
 use sp_runtime_interface::{pass_by, runtime_interface};
 use sp_std::num::NonZeroU32;
+use sp_weights::Weight;
 use subspace_core_primitives::hashes::Blake3Hash;
 use subspace_core_primitives::pot::{PotCheckpoints, PotOutput, PotSeed};
 use subspace_core_primitives::segments::{
@@ -573,6 +574,7 @@ impl PotParameters {
 
 sp_api::decl_runtime_apis! {
     /// API necessary for block authorship with Subspace.
+    #[api_version(2)]
     pub trait SubspaceApi<RewardAddress: Encode + Decode> {
         /// Proof of time parameters
         fn pot_parameters() -> PotParameters;
@@ -613,6 +615,10 @@ sp_api::decl_runtime_apis! {
 
         /// Get Subspace blockchain constants
         fn chain_constants() -> ChainConstants;
+
+        /// Returns the consumed weight of the block.
+        /// Available from api_version >= 2
+        fn block_weight() -> Weight;
     }
 }
 

--- a/crates/subspace-fake-runtime-api/src/lib.rs
+++ b/crates/subspace-fake-runtime-api/src/lib.rs
@@ -166,6 +166,10 @@ sp_api::impl_runtime_apis! {
         fn chain_constants() -> ChainConstants {
             unreachable!()
         }
+
+        fn block_weight() -> Weight {
+            unreachable!()
+        }
     }
 
     impl sp_domains::DomainsApi<Block, DomainHeader> for Runtime {

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -1479,6 +1479,10 @@ impl_runtime_apis! {
                 min_sector_lifetime: MinSectorLifetime::get(),
             }
         }
+
+        fn block_weight() -> Weight {
+            System::block_weight().total()
+        }
     }
 
     impl sp_domains::DomainsApi<Block, DomainHeader> for Runtime {

--- a/domains/pallets/executive/src/lib.rs
+++ b/domains/pallets/executive/src/lib.rs
@@ -83,8 +83,6 @@ type ExtrinsicOf<T> = <BlockOf<T> as BlockT>::Extrinsic;
 type BlockOf<T> = <T as frame_system::Config>::Block;
 type BlockHashOf<T> = <BlockOf<T> as BlockT>::Hash;
 
-// TODO: not store the intermediate storage root in the state but
-// calculate the storage root outside the runtime after executing the extrinsic directly.
 #[frame_support::pallet]
 mod pallet {
     use crate::weights::WeightInfo;
@@ -183,8 +181,7 @@ mod pallet {
     #[pallet::hooks]
     impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
         fn on_initialize(_block_number: BlockNumberFor<T>) -> Weight {
-            // TODO: Probably needs a different value
-            Weight::from_parts(1, 0)
+            Weight::zero()
         }
     }
 }

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -1525,6 +1525,10 @@ impl_runtime_apis! {
                 min_sector_lifetime: MinSectorLifetime::get(),
             }
         }
+
+        fn block_weight() -> Weight {
+            System::block_weight().total()
+        }
     }
 
     impl sp_domains::DomainsApi<Block, DomainHeader> for Runtime {


### PR DESCRIPTION
This PR adds a new runtime_api to get the executed block weight to calculate the reference execution time and compare that with actual execution time. This is useful for us to check if the weights are indeed underestimated.

Also removed TODO that are already resolved

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
