### PR TITLE
Ensure nominator reward amount is infaliable when their calculated stake is less than actual deposit

### DIFF
--- a/crates/pallet-domains/src/staking_epoch.rs
+++ b/crates/pallet-domains/src/staking_epoch.rs
@@ -556,8 +556,7 @@ pub(crate) fn do_slash_operator<T: Config>(
             let nominator_reward = nominator_staked_amount
                 .checked_add(&amount_ready_to_withdraw)
                 .ok_or(TransitionError::BalanceOverflow)?
-                .checked_sub(&amount_to_slash_in_holding)
-                .ok_or(TransitionError::BalanceUnderflow)?;
+                .saturating_sub(amount_to_slash_in_holding);
 
             mint_into_treasury::<T>(nominator_reward)?;
 


### PR DESCRIPTION
This PR fixes an issue when calculating nominator_reward amount when nominator has no rewards but slash occurs.
The checked_sub fails because we always floor the share value when they deposit and converting shares to stake will lead to less stake than the amount they have deposited.

When such situation happens, checked_sub will fail. So using saturating_sub 

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
