### PR TITLE
Document how fork choice actually works

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14139,6 +14139,7 @@ dependencies = [
  "subspace-core-primitives",
  "subspace-runtime-primitives",
  "subspace-test-primitives",
+ "subspace-verification",
  "substrate-wasm-builder",
 ]
 

--- a/crates/sc-consensus-subspace/src/aux_schema.rs
+++ b/crates/sc-consensus-subspace/src/aux_schema.rs
@@ -3,7 +3,7 @@
 use parity_scale_codec::{Decode, Encode};
 use sc_client_api::backend::AuxStore;
 use sp_blockchain::{Error as ClientError, Result as ClientResult};
-use subspace_core_primitives::BlockWeight;
+use subspace_core_primitives::BlockForkWeight;
 
 fn load_decode<B, T>(backend: &B, key: &[u8]) -> ClientResult<Option<T>>
 where
@@ -28,7 +28,7 @@ fn block_weight_key<H: Encode>(block_hash: H) -> Vec<u8> {
 /// Write the cumulative chain-weight of a block to aux storage.
 pub(crate) fn write_block_weight<H, F, R>(
     block_hash: H,
-    block_weight: BlockWeight,
+    block_weight: BlockForkWeight,
     write_aux: F,
 ) -> R
 where
@@ -43,6 +43,6 @@ where
 pub(crate) fn load_block_weight<H: Encode, B: AuxStore>(
     backend: &B,
     block_hash: H,
-) -> ClientResult<Option<BlockWeight>> {
+) -> ClientResult<Option<BlockForkWeight>> {
     load_decode(backend, block_weight_key(block_hash).as_slice())
 }

--- a/crates/sc-consensus-subspace/src/block_import.rs
+++ b/crates/sc-consensus-subspace/src/block_import.rs
@@ -44,7 +44,7 @@ use subspace_core_primitives::segments::{HistorySize, SegmentHeader, SegmentInde
 use subspace_core_primitives::solutions::SolutionRange;
 use subspace_core_primitives::{BlockNumber, PublicKey};
 use subspace_proof_of_space::Table;
-use subspace_verification::{PieceCheckParams, VerifySolutionParams, calculate_block_weight};
+use subspace_verification::{PieceCheckParams, VerifySolutionParams, calculate_block_fork_weight};
 use tracing::warn;
 
 /// Notification with number of the block that is about to be imported and acknowledgement sender
@@ -657,7 +657,7 @@ where
 
         // We prioritise narrower (numerically smaller) solution ranges, using an inverse
         // calculation.
-        let added_weight = calculate_block_weight(subspace_digest_items.solution_range);
+        let added_weight = calculate_block_fork_weight(subspace_digest_items.solution_range);
         let total_weight = parent_weight.saturating_add(added_weight);
 
         aux_schema::write_block_weight(block_hash, total_weight, |values| {

--- a/crates/subspace-core-primitives/src/lib.rs
+++ b/crates/subspace-core-primitives/src/lib.rs
@@ -130,7 +130,7 @@ pub type SlotNumber = u64;
 
 /// BlockWeight type for fork choice rules.
 ///
-/// The closer solution's tag is to the target, the heavier it is.
+/// The narrower the solution range, the heavier the block is.
 pub type BlockWeight = u128;
 
 /// A Ristretto Schnorr public key as bytes produced by `schnorrkel` crate.

--- a/crates/subspace-core-primitives/src/lib.rs
+++ b/crates/subspace-core-primitives/src/lib.rs
@@ -128,10 +128,10 @@ pub type BlockHash = [u8; 32];
 /// Slot number in Subspace network.
 pub type SlotNumber = u64;
 
-/// BlockWeight type for fork choice rules.
+/// BlockForkWeight type for fork choice rules.
 ///
 /// The narrower the solution range, the heavier the block is.
-pub type BlockWeight = u128;
+pub type BlockForkWeight = u128;
 
 /// A Ristretto Schnorr public key as bytes produced by `schnorrkel` crate.
 #[derive(

--- a/crates/subspace-verification/Cargo.toml
+++ b/crates/subspace-verification/Cargo.toml
@@ -33,3 +33,5 @@ std = [
     "subspace-kzg?/std",
     "thiserror/std"
 ]
+# Activate test APIs and workarounds
+testing = []

--- a/crates/subspace-verification/src/lib.rs
+++ b/crates/subspace-verification/src/lib.rs
@@ -189,6 +189,15 @@ pub struct VerifySolutionParams {
 /// Calculate the block's contribution to the fork weight, which is derived from the provided
 /// solution range.
 pub fn calculate_block_fork_weight(solution_range: SolutionRange) -> BlockForkWeight {
+    // Work around the test runtime accepting all solutions, which causes blocks to have zero
+    // fork weight. This makes each node keep its own blocks, and never reorg to a common chain.
+    #[cfg(feature = "testing")]
+    let solution_range = if solution_range == SolutionRange::MAX {
+        SolutionRange::MAX - 1
+    } else {
+        solution_range
+    };
+
     BlockForkWeight::from(SolutionRange::MAX - solution_range)
 }
 

--- a/crates/subspace-verification/src/lib.rs
+++ b/crates/subspace-verification/src/lib.rs
@@ -39,7 +39,7 @@ use subspace_core_primitives::segments::{HistorySize, SegmentCommitment};
 #[cfg(feature = "kzg")]
 use subspace_core_primitives::solutions::Solution;
 use subspace_core_primitives::solutions::{RewardSignature, SolutionRange};
-use subspace_core_primitives::{BlockNumber, BlockWeight, PublicKey, ScalarBytes, SlotNumber};
+use subspace_core_primitives::{BlockForkWeight, BlockNumber, PublicKey, ScalarBytes, SlotNumber};
 #[cfg(feature = "kzg")]
 use subspace_kzg::{Commitment, Kzg, Scalar, Witness};
 #[cfg(feature = "kzg")]
@@ -188,8 +188,8 @@ pub struct VerifySolutionParams {
 
 /// Calculate the block's contribution to the fork weight, which is derived from the provided
 /// solution range.
-pub fn calculate_block_weight(solution_range: SolutionRange) -> BlockWeight {
-    BlockWeight::from(SolutionRange::MAX - solution_range)
+pub fn calculate_block_fork_weight(solution_range: SolutionRange) -> BlockForkWeight {
+    BlockForkWeight::from(SolutionRange::MAX - solution_range)
 }
 
 /// Verify whether solution is valid, returns solution distance that is `<= solution_range/2` on

--- a/crates/subspace-verification/src/lib.rs
+++ b/crates/subspace-verification/src/lib.rs
@@ -186,7 +186,8 @@ pub struct VerifySolutionParams {
     pub piece_check_params: Option<PieceCheckParams>,
 }
 
-/// Calculate weight derived from provided solution range
+/// Calculate the block's contribution to the fork weight, which is derived from the provided
+/// solution range.
 pub fn calculate_block_weight(solution_range: SolutionRange) -> BlockWeight {
     BlockWeight::from(SolutionRange::MAX - solution_range)
 }

--- a/test/subspace-test-runtime/Cargo.toml
+++ b/test/subspace-test-runtime/Cargo.toml
@@ -70,7 +70,6 @@ substrate-wasm-builder = { workspace = true, optional = true }
 [features]
 default = ["std"]
 std = [
-    "parity-scale-codec/std",
     "domain-runtime-primitives/std",
     "frame-executive/std",
     "frame-support/std",
@@ -88,10 +87,11 @@ std = [
     "pallet-sudo/std",
     "pallet-timestamp/std",
     "pallet-transaction-fees/std",
-    "pallet-transaction-payment-rpc-runtime-api/std",
     "pallet-transaction-payment/std",
+    "pallet-transaction-payment-rpc-runtime-api/std",
     "pallet-transporter/std",
     "pallet-utility/std",
+    "parity-scale-codec/std",
     "scale-info/std",
     "sp-api/std",
     "sp-block-builder/std",
@@ -112,7 +112,6 @@ std = [
     "sp-std/std",
     "sp-subspace-mmr/std",
     "sp-transaction-pool/std",
-    "sp-subspace-mmr/std",
     "sp-version/std",
     "subspace-core-primitives/std",
     "subspace-runtime-primitives/std",

--- a/test/subspace-test-runtime/Cargo.toml
+++ b/test/subspace-test-runtime/Cargo.toml
@@ -16,11 +16,11 @@ include = [
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-parity-scale-codec = { workspace = true, features = ["derive"] }
 domain-runtime-primitives.workspace = true
 frame-executive.workspace = true
 frame-support.workspace = true
 frame-system.workspace = true
+frame-system-rpc-runtime-api.workspace = true
 pallet-balances.workspace = true
 pallet-domains.workspace = true
 pallet-messenger.workspace = true
@@ -34,8 +34,10 @@ pallet-sudo.workspace = true
 pallet-timestamp.workspace = true
 pallet-transaction-fees.workspace = true
 pallet-transaction-payment.workspace = true
+pallet-transaction-payment-rpc-runtime-api.workspace = true
 pallet-transporter.workspace = true
 pallet-utility.workspace = true
+parity-scale-codec = { workspace = true, features = ["derive"] }
 scale-info = { workspace = true, features = ["derive"] }
 sp-api.workspace = true
 sp-block-builder.workspace = true
@@ -61,8 +63,6 @@ static_assertions.workspace = true
 subspace-core-primitives.workspace = true
 subspace-runtime-primitives.workspace = true
 subspace-test-primitives.workspace = true
-frame-system-rpc-runtime-api.workspace = true
-pallet-transaction-payment-rpc-runtime-api.workspace = true
 
 [build-dependencies]
 substrate-wasm-builder = { workspace = true, optional = true }

--- a/test/subspace-test-runtime/Cargo.toml
+++ b/test/subspace-test-runtime/Cargo.toml
@@ -63,6 +63,8 @@ static_assertions.workspace = true
 subspace-core-primitives.workspace = true
 subspace-runtime-primitives.workspace = true
 subspace-test-primitives.workspace = true
+# Activate a testing workaround for the fork choice rule
+subspace-verification = { workspace = true, features = ["testing"] }
 
 [build-dependencies]
 substrate-wasm-builder = { workspace = true, optional = true }


### PR DESCRIPTION
I'm working on fork monitoring, so I was looking at how our fork choice rule works in detail.

I think the current implementation is valid. But the code comments are an over-simplification - they don't clearly describe how the code chooses between forks.

The implementation sums the chain weights into a single `u128`, which means it is possible (but very unlikely) that a shorter fork can be temporarily chosen as the best fork. This could happen on an era transition, if the solution range differences between the forks are large.

Also, a solution can be accepted by one fork but rejected by others at the start of an era, due to different solution ranges (from different block times).

So downstream consumers can't depend on the longest fork always being chosen every time. But the longest fork will be chosen after more blocks, with increasingly high probability after each new block.

#### Test fixes

This PR also fixes the fork choice weights for the test runtime, where all blocks had zero weight (because the runtime accepts all solutions).

This is a particular issue in tests where multiple nodes produce blocks, because they will all choose their own blocks, and never reorg.

### Feedback requests

Some of the detail in the code comments (or this PR description) might be better in the spec. Please let me know which parts you'd like me to move.

I'll only merge this after we've got both the spec and code changes sorted.

### Why audit?

I would like this audited because the fork choice is an important security property, and it needs to be documented accurately. Missing or outdated documentation makes it easier to introduce security issues accidentally.

### Next steps

After this has been checked, we need to update the spec in a similar way:
https://github.com/subspace/protocol-specs/blob/0591efc437a095237c01b1bc61212743aea0419e/docs/decex/workflow.md?plain=1#L286-L288

(The fork choice is important for compatible implementations.)

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
