### PR TITLE
Update runtime-benchmark script to run benchmarks for specified pallets through ENV

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -32,6 +32,7 @@ env:
   SPOT: ${{ contains(github.ref, 'gh-readonly-queue') && '/spot=false' || '' }}
   # Run faster benchmark checks in CI
   BENCHMARK_TYPE: check
+  VERBOSE: true
 
 jobs:
   cargo-fmt:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,6 +30,8 @@ env:
   # runner config. This environment variable helps us avoid nested strings inside complex actions
   # expressions.
   SPOT: ${{ contains(github.ref, 'gh-readonly-queue') && '/spot=false' || '' }}
+  # Run faster benchmark checks in CI
+  BENCHMARK_TYPE: check
 
 jobs:
   cargo-fmt:
@@ -370,7 +372,7 @@ jobs:
 
       - name: runtime-benchmark.sh check
         run: |
-          scripts/runtime-benchmark.sh check
+          scripts/runtime-benchmark.sh
 
   # This job checks all crates individually, including no_std and other featureless builds.
   # We need to check crates individually for missing features, because cargo does feature

--- a/scripts/runtime-benchmark.sh
+++ b/scripts/runtime-benchmark.sh
@@ -140,7 +140,7 @@ SUBSPACE_RUNTIME_PALLETS=$(cat ./crates/subspace-runtime/src/lib.rs | \
 
 # Filter using filter_pallets()
 SUBSPACE_RUNTIME_PALLETS=($(filter_pallets "${SUBSPACE_RUNTIME_PALLETS[@]}"))
-
+echo "Subspace Runtime Pallet list: ${SUBSPACE_RUNTIME_PALLETS[*]}"
 for PALLET in "${SUBSPACE_RUNTIME_PALLETS[@]}"; do
   echo "Generating benchmarks for ${PALLET}"
   ./target/$PROFILE/subspace-node benchmark pallet \
@@ -187,7 +187,7 @@ EVM_DOMAIN_RUNTIME_PALLETS=$(cat domains/runtime/evm/src/lib.rs | \
 
 # Filter using filter_pallets()
 EVM_DOMAIN_RUNTIME_PALLETS=($(filter_pallets "${EVM_DOMAIN_RUNTIME_PALLETS[@]}"))
-echo "Pallet list: ${EVM_DOMAIN_RUNTIME_PALLETS[*]}"
+echo "EVM Domain Pallet list: ${EVM_DOMAIN_RUNTIME_PALLETS[*]}"
 for PALLET in "${EVM_DOMAIN_RUNTIME_PALLETS[@]}"; do
   echo "Generating benchmarks for ${PALLET}"
   ./target/$PROFILE/subspace-node domain benchmark pallet \
@@ -226,7 +226,7 @@ AUTO_ID_DOMAIN_RUNTIME_PALLETS=$(cat domains/runtime/auto-id/src/lib.rs | \
 
 # Filter using filter_pallets()
 AUTO_ID_DOMAIN_RUNTIME_PALLETS=($(filter_pallets "${AUTO_ID_DOMAIN_RUNTIME_PALLETS[@]}"))
-echo "Pallet list: ${AUTO_ID_DOMAIN_RUNTIME_PALLETS[*]}"
+echo "AUTO_ID Domain Pallet list: ${AUTO_ID_DOMAIN_RUNTIME_PALLETS[*]}"
 for PALLET in "${AUTO_ID_DOMAIN_RUNTIME_PALLETS[@]}"; do
   echo "Generating benchmarks for ${PALLET}"
   ./target/$PROFILE/subspace-node domain benchmark pallet \

--- a/scripts/runtime-benchmark.sh
+++ b/scripts/runtime-benchmark.sh
@@ -226,7 +226,7 @@ AUTO_ID_DOMAIN_RUNTIME_PALLETS=$(cat domains/runtime/auto-id/src/lib.rs | \
 
 # Filter using filter_pallets()
 AUTO_ID_DOMAIN_RUNTIME_PALLETS=($(filter_pallets "${AUTO_ID_DOMAIN_RUNTIME_PALLETS[@]}"))
-echo "AUTO_ID Domain Pallet list: ${AUTO_ID_DOMAIN_RUNTIME_PALLETS[*]}"
+echo "Auto ID Domain Pallet list: ${AUTO_ID_DOMAIN_RUNTIME_PALLETS[*]}"
 for PALLET in "${AUTO_ID_DOMAIN_RUNTIME_PALLETS[@]}"; do
   echo "Generating benchmarks for ${PALLET}"
   ./target/$PROFILE/subspace-node domain benchmark pallet \

--- a/scripts/runtime-benchmark.sh
+++ b/scripts/runtime-benchmark.sh
@@ -122,7 +122,7 @@ SUBSPACE_RUNTIME_PALLETS=$(cat ./crates/subspace-runtime/src/lib.rs | \
 )
 
 # Filter using filter_pallets()
-SUBSPACE_RUNTIME_PALLETS=($(filter_pallets "$SUBSPACE_RUNTIME_PALLETS"))
+SUBSPACE_RUNTIME_PALLETS=($(filter_pallets "${SUBSPACE_RUNTIME_PALLETS[@]}"))
 
 for PALLET in "${SUBSPACE_RUNTIME_PALLETS[@]}"; do
   echo "Generating benchmarks for ${PALLET}"
@@ -147,7 +147,7 @@ SUBSPACE_RUNTIME_PRIMITIVES=(
 BENCH_SETTINGS="$CORE_BENCH_SETTINGS $EXTRA_ITERATION_SETTINGS"
 
 # Filter using filter_pallets()
-SUBSPACE_RUNTIME_PRIMITIVES=($(filter_pallets "$SUBSPACE_RUNTIME_PRIMITIVES"))
+SUBSPACE_RUNTIME_PRIMITIVES=($(filter_pallets "${SUBSPACE_RUNTIME_PRIMITIVES[@]}"))
 echo "Primitives Pallet list: ${SUBSPACE_RUNTIME_PRIMITIVES[*]}"
 for PALLET in "${SUBSPACE_RUNTIME_PRIMITIVES[@]}"; do
   echo "Generating benchmarks for ${PALLET}"
@@ -169,7 +169,7 @@ EVM_DOMAIN_RUNTIME_PALLETS=$(cat domains/runtime/evm/src/lib.rs | \
 )
 
 # Filter using filter_pallets()
-EVM_DOMAIN_RUNTIME_PALLETS=($(filter_pallets "$EVM_DOMAIN_RUNTIME_PALLETS"))
+EVM_DOMAIN_RUNTIME_PALLETS=($(filter_pallets "${EVM_DOMAIN_RUNTIME_PALLETS[@]}"))
 echo "Pallet list: ${EVM_DOMAIN_RUNTIME_PALLETS[*]}"
 for PALLET in "${EVM_DOMAIN_RUNTIME_PALLETS[@]}"; do
   echo "Generating benchmarks for ${PALLET}"
@@ -185,7 +185,7 @@ done
 EVM_RUNTIME_PRIMITIVES=(
   "pallet_evm_tracker"
 )
-EVM_RUNTIME_PRIMITIVES=($(filter_pallets "$EVM_RUNTIME_PRIMITIVES"))
+EVM_RUNTIME_PRIMITIVES=($(filter_pallets "${EVM_RUNTIME_PRIMITIVES[@]}"))
 echo "EVM Primitives Pallet list: ${EVM_RUNTIME_PRIMITIVES[*]}"
 BENCH_SETTINGS="$CORE_BENCH_SETTINGS $ITERATION_SETTINGS"
 for PALLET in "${EVM_RUNTIME_PRIMITIVES[@]}"; do
@@ -208,7 +208,7 @@ AUTO_ID_DOMAIN_RUNTIME_PALLETS=$(cat domains/runtime/auto-id/src/lib.rs | \
 )
 
 # Filter using filter_pallets()
-AUTO_ID_DOMAIN_RUNTIME_PALLETS=($(filter_pallets "$AUTO_ID_DOMAIN_RUNTIME_PALLETS"))
+AUTO_ID_DOMAIN_RUNTIME_PALLETS=($(filter_pallets "${AUTO_ID_DOMAIN_RUNTIME_PALLETS[@]}"))
 echo "Pallet list: ${AUTO_ID_DOMAIN_RUNTIME_PALLETS[*]}"
 for PALLET in "${AUTO_ID_DOMAIN_RUNTIME_PALLETS[@]}"; do
   echo "Generating benchmarks for ${PALLET}"


### PR DESCRIPTION
PR updates the `runtime-benchmarks.sh` to generate benchmarks for specific pallets passed through `PALLETS` environment variable. If `PALLETS` is unset or empty, then scripts generates benchmarks for all the pallets which is the same behavior as before.

Closes: #3707

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
