### PR TITLE
short-circuit the operator bundle check and fix deviations

### DIFF
--- a/crates/pallet-domains/src/staking.rs
+++ b/crates/pallet-domains/src/staking.rs
@@ -256,6 +256,19 @@ impl<Balance, Share, DomainBlockNumber, ReceiptHash>
             OperatorStatus::Registered | OperatorStatus::Deactivated(_)
         )
     }
+
+    /// Returns true if the operator can submit a bundle.
+    pub fn can_operator_submit_bundle<T: Config>(&self, operator_id: OperatorId) -> bool {
+        let status = self.status::<T>(operator_id);
+        // negate result if the operator is slashed, pending_slash, deactivated, or InvalidBundle
+        !matches!(
+            status,
+            OperatorStatus::Slashed
+                | OperatorStatus::PendingSlash
+                | OperatorStatus::InvalidBundle(_)
+                | OperatorStatus::Deactivated(_)
+        )
+    }
 }
 
 #[derive(TypeInfo, Debug, Encode, Decode, Clone, PartialEq, Eq)]


### PR DESCRIPTION
Audit issue: https://github.com/autonomys/srlabs-audit/issues/24

`LastEpochStakingDistribution`: This storage is only used within a block when the first bundle in the block triggers the epoch transition. When epoch is transitioned, we store the previous epoch details so that next set of bundles with in the same block will not fail due to change in stake due to current epoch. During the block finalization, we clear the `LastEpochStakingDistribution` storage so this is empty for blocks that do not trigger epoch transition.

Lets talk about Deactivated operators. Operator can be deactivated at any point in time.

### Block that triggers epoch transition with deactivate operator transaction 
If sudo submits deactivate operator and operator also submits one or many bundles, during the validation operator submit_bundle will always be valid since state is not cached unlike pre_dispatch. 

During the pre_dispatch, there are multiple situations
if operator's bundles are included before operator deactivate transaction, then those are valid bundles and are included in the block and executed successfully.

if deactivate operator txn was executed before any submit_bundles, the `LastEpochStakingDistribution` will not have deactivate operator stake and deactivated operator's submit bundles are invalid and are ignored.

if deactivate operator txn was executed after first submit_bundle which sets `LastEpochStakingDistribution`, the deactivated operator's bundles are invalid but they are still included. This is the case this issue talks about. IMO, this is okay since operator is deactivated since they are not producing bundles but if they produce bundle, no reason not to include them. But this behavior deviates from the above case.

if deactivate operator txn was executed after multiple submit_bundle which also include bundle from operator who is about to be deactivated, then that bundle is accepted but any bundles from operator after deactivate txn will still be accepted which also deviates from first behavior.

### Block that **does not** triggers epoch transition with deactivate operator transaction 
If sudo submits deactivate operator and operator also submits one or many bundles, during the validation operator submit_bundle will always be valid since state is not cached unlike pre_dispatch. 

During the pre_dispatch, there are multiple situations
if operator's bundles are included before operator deactivate transaction, then those are valid bundles and are included in the block and executed successfully.

if deactivate operator txn was executed before any submit_bundles, deactivates operator stake does not exist and deactivated operator's submit bundles are invalid and are ignored.

if deactivate operator txn was executed after multiple submit_bundle which also include bundle from operator who is about to be deactivated, then that bundle is accepted but any bundles from operator after deactivate txn will not be accepted.


Edge case happens when epoch is transitioned and there are slight deviations in sub-cases. 

This PR ensures that during the mentioned cases in the epoch transition, behavior is consistent where operator deactivation extrinsic is included before operaor's submitted bundles, those bundles are excluded.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
