### PR TITLE
update bootnodes for mainnet, chronos, and devnet

### DIFF
--- a/crates/sc-subspace-chain-specs/res/chain-spec-raw-chronos.json
+++ b/crates/sc-subspace-chain-specs/res/chain-spec-raw-chronos.json
@@ -5,8 +5,7 @@
     "Custom": "Autonomys Chronos Testnet"
   },
   "bootNodes": [
-    "/dns/bootstrap-0.chronos.autonomys.xyz/tcp/30333/p2p/12D3KooWFf1TpfEFPQ6cun4dg2VkF3kiDNzzx7tJKe2AXbtkfmPq",
-    "/dns/bootstrap-1.chronos.autonomys.xyz/tcp/30333/p2p/12D3KooWEroye8oyKBaUeG75gieACsuqp7xLeuiP4EBrJjSs1GQw"
+    "/dns/bootstrap-0.chronos.autonomys.xyz/tcp/30333/p2p/12D3KooWFf1TpfEFPQ6cun4dg2VkF3kiDNzzx7tJKe2AXbtkfmPq"
   ],
   "telemetryEndpoints": [
     [
@@ -18,13 +17,11 @@
   "properties": {
     "domainsBootstrapNodes": {
       "0": [
-        "/dns/bootstrap-0.auto-evm.chronos.autonomys.xyz/tcp/30334/p2p/12D3KooWHNLN7sgAF1r2HDo3zh62Znv58BANxjqJ1RqEKHK38Bkg",
-        "/dns/bootstrap-1.auto-evm.chronos.autonomys.xyz/tcp/30334/p2p/12D3KooWS544NucYd6RMuV86P66jtur3X6N1GGVojz3jDRiJrLcu"
+        "/dns/bootstrap-0.auto-evm.chronos.autonomys.xyz/tcp/30334/p2p/12D3KooWHNLN7sgAF1r2HDo3zh62Znv58BANxjqJ1RqEKHK38Bkg"
       ]
     },
     "dsnBootstrapNodes": [
-      "/dns/bootstrap-0.chronos.autonomys.xyz/tcp/30533/p2p/12D3KooWN5eUiDCN3bozUJZizuvETfnz96Qg6wS27ixXARgRVVGd",
-      "/dns/bootstrap-1.chronos.autonomys.xyz/tcp/30533/p2p/12D3KooWQ4CQ7zbt6GSpiYwAjERtQVhNXrqTsS22iSLjjXqHPzuX"
+      "/dns/bootstrap-0.chronos.autonomys.xyz/tcp/30533/p2p/12D3KooWN5eUiDCN3bozUJZizuvETfnz96Qg6wS27ixXARgRVVGd"
     ],
     "potExternalEntropy": "000000000000000000002d7e53dd67e5db28b6d07e3a4b301b1fd9c8865da8c7",
     "ss58Format": 6094,

--- a/crates/sc-subspace-chain-specs/res/chain-spec-raw-devnet.json
+++ b/crates/sc-subspace-chain-specs/res/chain-spec-raw-devnet.json
@@ -5,8 +5,7 @@
     "Custom": "Testnet"
   },
   "bootNodes": [
-    "/dns/bootstrap-0.devnet.subspace.network/tcp/30333/p2p/12D3KooWLdPnDksKX43hEgV4N9EeJzm6x8wPWkHCvRaFBZvj4GBg",
-    "/dns/bootstrap-1.devnet.subspace.network/tcp/30333/p2p/12D3KooWM4PT6vTWji9y9BmHc1dZKH7EE6nSfX1bZMUejFviJypz"
+    "/dns/bootstrap-0.devnet.autonomys.xyz/tcp/30333/p2p/12D3KooWLdPnDksKX43hEgV4N9EeJzm6x8wPWkHCvRaFBZvj4GBg"
   ],
   "telemetryEndpoints": [
     [
@@ -18,12 +17,11 @@
   "properties": {
     "domainsBootstrapNodes": {
       "0": [
-        "/dns/bootstrap-0.auto-evm.devnet.subspace.network/tcp/30334/p2p/12D3KooWH1erywk3TmZZL1bUmt4kmfbc6yx7whPjsVkt9mdjm2sg"
+        "/dns/bootstrap-0.auto-evm.devnet.autonomys.xyz/tcp/30334/p2p/12D3KooWH1erywk3TmZZL1bUmt4kmfbc6yx7whPjsVkt9mdjm2sg"
       ]
     },
     "dsnBootstrapNodes": [
-      "/dns/bootstrap-0.devnet.subspace.network/tcp/30533/p2p/12D3KooWJgLU8DmkXwBpQtHgSURFfJ4f2SyuNVBgVY96aDJsDWFK",
-      "/dns/bootstrap-1.devnet.subspace.network/tcp/30533/p2p/12D3KooWEaTUuF6H36UWu1WrxE3ccGVB8UXavQ2FF1xmJ8SNC38V"
+      "/dns/bootstrap-0.devnet.autonomys.xyz/tcp/30533/p2p/12D3KooWJgLU8DmkXwBpQtHgSURFfJ4f2SyuNVBgVY96aDJsDWFK"
     ],
     "potExternalEntropy": null,
     "ss58Format": 6094,


### PR DESCRIPTION
For mainnet:
- Removed old subspace.network bootnodes and added new autonomys.xyz node
- Old nodes will be shutdown once the there is a new release

For chronos:
- Removed nodes that are not operational anymore

For devet, non-operational but to be conssistent:
- Updated the bootnodes 

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
