### PR TITLE
Upgrade rust-kzg to reduce farmer stack overflows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6163,7 +6163,7 @@ dependencies = [
 [[package]]
 name = "kzg"
 version = "0.1.0"
-source = "git+https://github.com/grandinetech/rust-kzg?rev=6c8fcc623df3d7e8c0f30951a49bfea764f90bf4#6c8fcc623df3d7e8c0f30951a49bfea764f90bf4"
+source = "git+https://github.com/grandinetech/rust-kzg?rev=8f5f1a0f73b3c529c77cb880ff8d265830c7d7ac#8f5f1a0f73b3c529c77cb880ff8d265830c7d7ac"
 dependencies = [
  "blst",
  "num_cpus",
@@ -10011,7 +10011,7 @@ dependencies = [
 [[package]]
 name = "rust-kzg-blst"
 version = "0.1.0"
-source = "git+https://github.com/grandinetech/rust-kzg?rev=6c8fcc623df3d7e8c0f30951a49bfea764f90bf4#6c8fcc623df3d7e8c0f30951a49bfea764f90bf4"
+source = "git+https://github.com/grandinetech/rust-kzg?rev=8f5f1a0f73b3c529c77cb880ff8d265830c7d7ac#8f5f1a0f73b3c529c77cb880ff8d265830c7d7ac"
 dependencies = [
  "blst",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -312,7 +312,6 @@ blake2 = { opt-level = 3 }
 blake3 = { opt-level = 3 }
 blake2b_simd = { opt-level = 3 }
 blst = { opt-level = 3 }
-rust-kzg-blst = { opt-level = 3 }
 chacha20 = { opt-level = 3 }
 chacha20poly1305 = { opt-level = 3 }
 cranelift-codegen = { opt-level = 3 }
@@ -359,6 +358,15 @@ uint = { opt-level = 3 }
 x25519-dalek = { opt-level = 3 }
 yamux = { opt-level = 3 }
 zeroize = { opt-level = 3 }
+
+# These crates are always compiled with small code size, to mitigate farmer stack overflows.
+# For details, see: https://github.com/autonomys/subspace/issues/3698
+rust-kzg-blst = { opt-level = "s" }
+rayon-core = { opt-level = "s" }
+
+[profile.release.package]
+rust-kzg-blst = { opt-level = "s" }
+rayon-core = { opt-level = "s" }
 
 [profile.release]
 # Substrate runtime requires unwinding.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ hex = { version = "0.4.3", default-features = false }
 hex-literal = "0.4.1"
 hwlocality = "1.0.0-alpha.6"
 jsonrpsee = "0.24.5"
-kzg = { git = "https://github.com/grandinetech/rust-kzg", rev = "6c8fcc623df3d7e8c0f30951a49bfea764f90bf4", default-features = false }
+kzg = { git = "https://github.com/grandinetech/rust-kzg", rev = "8f5f1a0f73b3c529c77cb880ff8d265830c7d7ac", default-features = false }
 libc = "0.2.159"
 libp2p = { version = "0.54.2", git = "https://github.com/subspace/rust-libp2p", rev = "4ff21ede371f14ea0b90075f676ae21239ef8fbf", default-features = false }
 libp2p-swarm-test = { version = "0.5.0", git = "https://github.com/subspace/rust-libp2p", rev = "4ff21ede371f14ea0b90075f676ae21239ef8fbf" }
@@ -162,7 +162,7 @@ reqwest = { version = "0.12.9", default-features = false }
 ring = "0.17.8"
 rlp = "0.6"
 rs_merkle = { version = "1.4.2", default-features = false }
-rust-kzg-blst = { git = "https://github.com/grandinetech/rust-kzg", rev = "6c8fcc623df3d7e8c0f30951a49bfea764f90bf4", default-features = false }
+rust-kzg-blst = { git = "https://github.com/grandinetech/rust-kzg", rev = "8f5f1a0f73b3c529c77cb880ff8d265830c7d7ac", default-features = false }
 sc-basic-authorship = { git = "https://github.com/subspace/polkadot-sdk", rev = "e831132867930ca90a7088c7246301ab29f015ba" }
 sc-block-builder = { git = "https://github.com/subspace/polkadot-sdk", rev = "e831132867930ca90a7088c7246301ab29f015ba" }
 sc-chain-spec = { git = "https://github.com/subspace/polkadot-sdk", rev = "e831132867930ca90a7088c7246301ab29f015ba" }


### PR DESCRIPTION
This PR upgrades our rust-kzg fork from branch subspace-v2 to subspace-v3, which cherry-picks the stack overflow mitigation in https://github.com/grandinetech/rust-kzg/pull/310

The subspace-v2 branch didn't exist, so I created it based on the previous dependency commit.

I'm still testing this branch on my farmer, which has reliably overflowed its stack every time I add a 2 GB farm to it.

Since this issue is in rust-kzg-blst, it could also technically impact the node, for example, when it is reconstructing a lot of segments.

Close #3698

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
