### PR TITLE
Set hip platform to AMD explicitly

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -197,6 +197,7 @@ jobs:
         env:
           # Why `PROGRA~1` instead of `Program Files`? Because Windows!
           HIPCC: C:\PROGRA~1\AMD\ROCm\6.1\bin\hipcc.bin.exe
+          HIP_PLATFORM: amd
         run: |
           cargo -Zgitoxide -Zgit clippy --locked --all-targets --features rocm -- -D warnings
         if: runner.os == 'Windows'

--- a/.github/workflows/snapshot-build.yml
+++ b/.github/workflows/snapshot-build.yml
@@ -253,6 +253,7 @@ jobs:
         env:
           # Why `PROGRA~1` instead of `Program Files`? Because Windows!
           HIPCC: C:\PROGRA~1\AMD\ROCm\6.1\bin\hipcc.bin.exe
+          HIP_PLATFORM: amd
         run: |
           cargo -Zgitoxide -Zgit build --locked -Z build-std --target ${{ matrix.build.target }} --profile production --bin subspace-farmer --features rocm
           move ${{ env.PRODUCTION_TARGET }}/subspace-farmer.exe ${{ env.PRODUCTION_TARGET }}/subspace-farmer-rocm.exe


### PR DESCRIPTION
Seems like something has changed with hipcc on windows overnight or something on windows. Have to confirm if the gh-runner ami had a breaking change of sorts.

Two issues:
- For some reason, windows decided to fail when command has pattern `C:\Program Files\...` since hipcc started invoking nvcc without any quotes :(
- It seems like with recent change, hipcc is using nvcc even in ROCm leading to bad command args. Discovered after fixing the above.

I'm not sure which of the two issues lead to other but I think its hipcc.
To get things going, I had to set HIP_PLATFORM to AMD explicitly for CI to go through. If not, since nvcc was installed on gh-runner, from env https://github.com/ROCm/llvm-project/tree/amd-staging/amd/hipcc#envVar
seems like hipcc assumed nvidia platform if nvcc is present. Not sure why this decision was made or if I'm reading this correctly

This was good few hours of my life down the drain

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
