### PR TITLE
Fix farmer segment header cache index check

### DIFF
--- a/crates/subspace-farmer/src/node_client/caching_proxy_node_client.rs
+++ b/crates/subspace-farmer/src/node_client/caching_proxy_node_client.rs
@@ -119,7 +119,9 @@ impl SegmentHeaders {
 
     /// Write the sync results to the cache, and reset the sync rate-limit timer.
     fn write_cache(&mut self, extra_segment_headers: Vec<SegmentHeader>) {
-        self.segment_headers.extend(extra_segment_headers);
+        for segment_header in extra_segment_headers {
+            self.push(segment_header);
+        }
         self.last_synced.replace(Instant::now());
     }
 }


### PR DESCRIPTION
This PR restores a segment header order check that was skipped in PR #3660.

This is not security critical, but it defends against node bugs, data corruption, and unusual insecure node to farmer RPC connections.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
