### PR TITLE
Bump executable versions to 0.1.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13438,7 +13438,7 @@ dependencies = [
 
 [[package]]
 name = "subspace-bootstrap-node"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "clap",
  "futures",
@@ -13536,7 +13536,7 @@ dependencies = [
 
 [[package]]
 name = "subspace-farmer"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "async-lock 3.4.0",
@@ -13630,7 +13630,7 @@ dependencies = [
 
 [[package]]
 name = "subspace-gateway"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -13800,7 +13800,7 @@ dependencies = [
 
 [[package]]
 name = "subspace-node"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "auto-id-domain-runtime",
  "bip39",

--- a/crates/subspace-bootstrap-node/Cargo.toml
+++ b/crates/subspace-bootstrap-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subspace-bootstrap-node"
-version = "0.1.3"
+version = "0.1.4"
 authors = [
     "Nazar Mokrynskyi <nazar@mokrynskyi.com>",
     "Shamil Gadelshin <shamilgadelshin@gmail.com>"

--- a/crates/subspace-farmer/Cargo.toml
+++ b/crates/subspace-farmer/Cargo.toml
@@ -2,7 +2,7 @@
 name = "subspace-farmer"
 description = "Farmer for the Subspace Network Blockchain"
 license = "0BSD"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["Nazar Mokrynskyi <nazar@mokrynskyi.com>"]
 edition.workspace = true
 include = [

--- a/crates/subspace-gateway/Cargo.toml
+++ b/crates/subspace-gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subspace-gateway"
-version = "0.1.3"
+version = "0.1.4"
 authors = [
     "Teor <teor@riseup.net>",
     "Shamil Gadelshin <shamilgadelshin@gmail.com>"

--- a/crates/subspace-node/Cargo.toml
+++ b/crates/subspace-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subspace-node"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["Subspace Labs <https://subspace.network>"]
 description = "A Subspace Network Blockchain node."
 edition.workspace = true


### PR DESCRIPTION
This PR was generated using:
```sh
scripts/bump-versions.sh client 0.1.3 0.1.4
```

I think we should merge these other PRs before release:
- [x] #3716
- [x] #3720

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
