### PR TITLE
fix bundle count for operators

### DIFF
--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -1217,7 +1217,9 @@ mod pallet {
             let receipt_block_number = *receipt.domain_block_number();
 
             // increment the operator bundle count in the epoch.
-            OperatorBundleCountInEpoch::<T>::mutate(operator_id, |c| c.saturating_add(1));
+            OperatorBundleCountInEpoch::<T>::mutate(operator_id, |c| {
+                *c = c.saturating_add(1);
+            });
 
             #[cfg(not(feature = "runtime-benchmarks"))]
             let mut actual_weight = T::WeightInfo::submit_bundle();

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -131,7 +131,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: Cow::Borrowed("subspace"),
     impl_name: Cow::Borrowed("subspace"),
     authoring_version: 0,
-    spec_version: 7,
+    spec_version: 8,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
Fix to increment bundle count for operators. 

Previously
```
OperatorBundleCountInEpoch::<T>::mutate(operator_id, |c| c.saturating_add(1));
```

is not actually incrementing the count since the value `c` is not mutated but instead we returned the incremented out of the mutate and mutate never actually updates the state.

I have added a test to simulate this behavior.


Also bumped spec_version for chronos runtime upgrade

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
