### PR TITLE
Remove self-hosted runners

### DIFF
--- a/.github/workflows/chain-spec-snapshot-build.yml
+++ b/.github/workflows/chain-spec-snapshot-build.yml
@@ -13,8 +13,7 @@ on:
 
 jobs:
   chains-spec:
-    runs-on: ${{ fromJson(github.repository_owner == 'autonomys' &&
-      '"runs-on=${{ github.run_id }}-${{ github.run_attempt }}/runner=self-hosted-ubuntu-22.04-x86-64/spot=false"' || '"ubuntu-22.04"') }}
+    runs-on: ubuntu-22.04
     permissions:
       contents: write
       packages: write

--- a/.github/workflows/domain-genesis-storage-snapshot-build.yml
+++ b/.github/workflows/domain-genesis-storage-snapshot-build.yml
@@ -13,8 +13,7 @@ on:
 
 jobs:
   domain-genesis-storage:
-    runs-on: ${{ fromJson(github.repository_owner == 'autonomys' &&
-      '"runs-on=${{ github.run_id }}-${{ github.run_attempt }}/runner=self-hosted-ubuntu-22.04-x86-64/spot=false"' || '"ubuntu-22.04"') }}
+    runs-on: ubuntu-22.04
     permissions:
       contents: write
       packages: write

--- a/.github/workflows/runtime-snapshot-build.yml
+++ b/.github/workflows/runtime-snapshot-build.yml
@@ -14,8 +14,7 @@ on:
 
 jobs:
   runtime:
-    runs-on: ${{ fromJson(github.repository_owner == 'autonomys' &&
-      '"runs-on=${{ github.run_id }}-${{ github.run_attempt }}/runner=self-hosted-ubuntu-22.04-x86-64/spot=false"' || '"ubuntu-22.04"') }}
+    runs-on: ubuntu-22.04
     permissions:
       contents: write
       packages: write

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,10 +26,6 @@ env:
   # For slow tests, this can be reduced using `#[property_test(config = "ProptestConfig { .. }")]`.
   PROPTEST_CASES: 10000
   PROPTEST_MAX_GLOBAL_REJECTS: 100000
-  # Disable spot instances in the GitHub merge queue. Otherwise, inherit the spot setting from the
-  # runner config. This environment variable helps us avoid nested strings inside complex actions
-  # expressions.
-  SPOT: ${{ contains(github.ref, 'gh-readonly-queue') && '/spot=false' || '' }}
   # Run faster benchmark checks in CI
   BENCHMARK_TYPE: check
   VERBOSE: true
@@ -37,7 +33,6 @@ env:
 jobs:
   cargo-fmt:
     name: cargo-fmt (Linux x86-64)
-    # Format checks do not require significant resources, so we use a free runner.
     runs-on: ubuntu-22.04
 
     steps:
@@ -51,14 +46,7 @@ jobs:
     name: cargo-clippy (${{ strategy.job-index == 0 && 'Linux x86-64' || (strategy.job-index == 1 && 'Windows x86-64' || 'macOS arm64') }})
     strategy:
       matrix:
-        # Disable spot instances in the GitHub merge queue, and disable runs-on entirely for forks
-        os: ${{ fromJson(github.repository_owner == 'autonomys' &&
-          '[
-            "runs-on=${{ github.run_id }}-${{ github.run_attempt }}/runner=self-hosted-ubuntu-22.04-x86-64/extras=s3-cache${{ env.SPOT }}",
-            ["self-hosted", "windows-server-2022-x86-64"],
-            ["self-hosted", "macos-14-arm64"]
-          ]' ||
-          '["ubuntu-22.04", "windows-2022", "macos-14"]') }}
+        os: ["ubuntu-22.04", "windows-2022", "macos-14"]
 
     runs-on: ${{ matrix.os }}
 
@@ -205,8 +193,7 @@ jobs:
   cargo-runtime-build:
     name: cargo-runtime-build (Linux x86-64)
     # If clippy and tests pass on all OSes, it is unlikely that a runtime build will pass on Linux, but fail on other OSes.
-    runs-on: ${{ fromJson(github.repository_owner == 'autonomys' &&
-      '"runs-on=${{ github.run_id }}-${{ github.run_attempt }}/runner=self-hosted-ubuntu-22.04-x86-64/extras=s3-cache${{ env.SPOT }}"' || '"ubuntu-22.04"') }}
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: runs-on/action@cd2b598b0515d39d78c38a02d529db87d2196d1e # v2.0.3
@@ -255,13 +242,7 @@ jobs:
     name: cargo-test (${{ strategy.job-index == 0 && 'Linux x86-64' || (strategy.job-index == 1 && 'Windows x86-64' || 'macOS arm64') }})
     strategy:
       matrix:
-        os: ${{ fromJson(github.repository_owner == 'autonomys' &&
-          '[
-            "runs-on=${{ github.run_id }}-${{ github.run_attempt }}/runner=self-hosted-ubuntu-22.04-x86-64/extras=s3-cache${{ env.SPOT }}",
-            ["self-hosted", "windows-server-2022-x86-64"],
-            ["self-hosted", "macos-14-arm64"]
-          ]' ||
-          '["ubuntu-22.04", "windows-2022", "macos-14"]') }}
+        os: ["ubuntu-22.04", "windows-2022", "macos-14"]
     runs-on: ${{ matrix.os }}
     # Don't use the full 6 hours if a test hangs
     timeout-minutes: 120
@@ -335,8 +316,7 @@ jobs:
   check-runtime-benchmarks:
     name: check-runtime-benchmarks (Linux x86-64)
     # We always run benchmarks on our Linux reference machine
-    runs-on: ${{ fromJson(github.repository_owner == 'autonomys' &&
-      '"runs-on=${{ github.run_id }}-${{ github.run_attempt }}/runner=self-hosted-ubuntu-22.04-x86-64/extras=s3-cache${{ env.SPOT }}"' || '"ubuntu-22.04"') }}
+    runs-on: ubuntu-22.04
 
     # Don't use the full 6 hours if a benchmark hangs
     timeout-minutes: 120
@@ -408,8 +388,7 @@ jobs:
   cargo-check-individually:
     name: cargo-check-individually (Linux x86-64)
     # If clippy and tests pass on all OSes, it is unlikely that a crate build will pass on Linux but fail on other OSes.
-    runs-on: ${{ fromJson(github.repository_owner == 'autonomys' &&
-      '"runs-on=${{ github.run_id }}-${{ github.run_attempt }}/runner=self-hosted-ubuntu-22.04-x86-64/extras=s3-cache${{ env.SPOT }}"' || '"ubuntu-22.04"') }}
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: runs-on/action@cd2b598b0515d39d78c38a02d529db87d2196d1e # v2.0.3
@@ -451,8 +430,7 @@ jobs:
   cargo-unused-deps:
     name: cargo-unused-deps (Linux x86-64)
     # We need to use Linux to check GPU dependencies (or Windows, but it's slow)
-    runs-on: ${{ fromJson(github.repository_owner == 'autonomys' &&
-      '"runs-on=${{ github.run_id }}-${{ github.run_attempt }}/runner=self-hosted-ubuntu-22.04-x86-64/extras=s3-cache${{ env.SPOT }}"' || '"ubuntu-22.04"') }}
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: runs-on/action@cd2b598b0515d39d78c38a02d529db87d2196d1e # v2.0.3

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -108,7 +108,7 @@ jobs:
           cuda: '12.4.1'
           method: network
           sub-packages: '["nvcc", "cudart"]'
-        if: runner.os == 'Linux' || runner.os == 'Windows'
+        if: runner.os == 'Linux'|| runner.os == 'Windows'
 
       - name: Configure ROCm cache (Windows)
         uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
@@ -116,7 +116,7 @@ jobs:
         with:
           path: C:\Program Files\AMD\ROCm
           key: ${{ runner.os }}-rocm
-        if: runner.os == 'Windows'
+        if: runner.os == 'Windows' && false
 
       - name: ROCm toolchain
         run: |
@@ -163,7 +163,7 @@ jobs:
           # TODO: we might be able to share clippy and check-individually caches
           key: ${{ runner.os }}-${{ github.job }}-target-${{ hashFiles('./Cargo.toml') }}-${{ hashFiles('./rust-toolchain.toml') }}
         # Windows caching is very slow, and we already have sccache on Linux
-        if: runner.os == 'macOS'
+        if: runner.os == 'macOS' && false
 
       # Checks benchmark code style and syntax (but clippy does not do code generation checks)
       - name: cargo clippy

--- a/.github/workflows/snapshot-build.yml
+++ b/.github/workflows/snapshot-build.yml
@@ -20,8 +20,7 @@ env:
 jobs:
   # This will build container images and then extract executables out of them
   ubuntu:
-    runs-on: ${{ fromJson(github.repository_owner == 'autonomys' &&
-      '"runs-on=${{ github.run_id }}-${{ github.run_attempt }}/runner=self-hosted-ubuntu-22.04-x86-64/spot=false"' || '"ubuntu-22.04"') }}
+    runs-on: ubuntu-22.04
     permissions:
       contents: write
       packages: write
@@ -48,26 +47,11 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.7.1
-        if: github.repository_owner == 'autonomys'
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.7.1
         with:
           # Limit concurrency so it can complete with small official runners
           buildkitd-config-inline: |
             [worker.oci]
               max-parallelism = 1
-        if: github.repository_owner != 'autonomys'
-
-      # This is to manage the concurrency of the builds and prevent self-hosted runners from running out of memory
-      - name: Set up Docker Buildx (self-hosted runner)
-        uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.7.1
-        with:
-          # Limit concurrency so it can reduce the likelihood of running out of memory
-          buildkitd-config-inline: |
-            [worker.oci]
-              max-parallelism = 3
-        if: github.repository_owner == 'autonomys'
 
       - name: Log into registry
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
@@ -157,14 +141,14 @@ jobs:
     strategy:
       matrix:
         build:
-          - os: ${{ fromJson(github.repository_owner == 'autonomys' && '["self-hosted", "macos-14-arm64"]' || '"macos-14"') }}
+          - os: macos-14
             target: aarch64-apple-darwin
             suffix: macos-aarch64-${{ github.ref_name }}
-          - os: ${{ fromJson(github.repository_owner == 'autonomys' && '["self-hosted", "windows-server-2022-x86-64"]' || '"windows-2022"') }}
+          - os: windows-2022
             target: x86_64-pc-windows-msvc
             suffix: windows-x86_64-skylake-${{ github.ref_name }}
             rustflags: "-C target-cpu=skylake"
-          - os: ${{ fromJson(github.repository_owner == 'autonomys' && '["self-hosted", "windows-server-2022-x86-64"]' || '"windows-2022"') }}
+          - os: windows-2022
             target: x86_64-pc-windows-msvc
             suffix: windows-x86_64-v2-${{ github.ref_name }}
             rustflags: "-C target-cpu=x86-64-v2"


### PR DESCRIPTION
Removes self-hosted runners
- Disabled windows cache as this is not helpful. Maybe we can revisit this in the future.
- Disabled macos deps cache for macos in clippy. For some reason, cached deps seems to break hwlocal. Need to figure out if this is due to change in envs from selhosted to github runners

@jfrank-summit 

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
