### PR TITLE
Add Farmerless Dev Node with Manual Block Production RPCs

### DIFF
--- a/.github/workflows/rustsec-audit.yml
+++ b/.github/workflows/rustsec-audit.yml
@@ -24,4 +24,5 @@ jobs:
           # TODO: Remove second once Substrate upgrades litep2p and sc-network and we no longer have ring 0.16 in our dependencies
           # TODO: Remove third once Substrate upgrades wasmtime and we no longer have wasmtime <= 9 in our dependencies
           # TODO: Remove fourth once Substrate upgrades wasmtime and we no longer have wasmtime <= 23 in our dependencies
-          ignore: RUSTSEC-2024-0336, RUSTSEC-2025-0009, RUSTSEC-2023-0091, RUSTSEC-2024-0438
+          # TODO: Remove fifth once Substrate upgrades wasmtime and we no longer have wasmtime < 24.0.5 in our dependencies (RUSTSEC-2025-0118)
+          ignore: RUSTSEC-2024-0336, RUSTSEC-2025-0009, RUSTSEC-2023-0091, RUSTSEC-2024-0438, RUSTSEC-2025-0118

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.idea
+/.vscode
 /target
 /test/subspace-test-fuzzer/target
 /test/subspace-test-fuzzer/output

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13626,8 +13626,10 @@ dependencies = [
 name = "subspace-farmerless-dev-node"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "clap",
  "domain-test-service",
+ "jsonrpsee 0.24.8",
  "sc-cli",
  "sc-service",
  "sp-keyring",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13623,6 +13623,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "subspace-farmerless-dev-node"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "domain-test-service",
+ "sc-cli",
+ "sc-service",
+ "sp-keyring",
+ "subspace-test-service",
+ "tempfile",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "subspace-gateway"
 version = "0.1.4"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ members = [
     "test/subspace-test-fuzzer",
     "test/subspace-test-runtime",
     "test/subspace-test-service",
+    "test/subspace-farmerless-dev-node",
 ]
 
 [workspace.dependencies]

--- a/domains/test/service/src/domain.rs
+++ b/domains/test/service/src/domain.rs
@@ -41,6 +41,7 @@ use sp_runtime::traits::{AsSystemOriginSigner, Dispatchable, NumberFor};
 use sp_session::SessionKeys;
 use sp_transaction_pool::runtime_api::TaggedTransactionQueue;
 use std::future::Future;
+use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
 use subspace_runtime_primitives::opaque::Block as CBlock;
@@ -146,6 +147,8 @@ where
         maybe_operator_id: Option<OperatorId>,
         role: Role,
         mock_consensus_node: &mut MockConsensusNode,
+        rpc_addr: Option<SocketAddr>,
+        rpc_port: Option<u16>,
     ) -> Self {
         let mut domain_config = node_config(
             domain_id,
@@ -156,6 +159,8 @@ where
             role,
             base_path.clone(),
             Box::new(create_domain_spec()) as Box<_>,
+            rpc_addr,
+            rpc_port,
         )
         .expect("could not generate domain node Configuration");
 
@@ -573,6 +578,8 @@ pub struct DomainNodeBuilder {
     skip_empty_bundle_production: bool,
     base_path: BasePath,
     maybe_operator_id: Option<OperatorId>,
+    rpc_addr: Option<SocketAddr>,
+    rpc_port: Option<u16>,
 }
 
 impl DomainNodeBuilder {
@@ -588,6 +595,8 @@ impl DomainNodeBuilder {
             skip_empty_bundle_production: false,
             base_path,
             maybe_operator_id: None,
+            rpc_addr: None,
+            rpc_port: None,
         }
     }
 
@@ -620,6 +629,18 @@ impl DomainNodeBuilder {
         self
     }
 
+    /// Set RPC address for the domain node
+    pub fn rpc_addr(mut self, addr: SocketAddr) -> Self {
+        self.rpc_addr = Some(addr);
+        self
+    }
+
+    /// Set RPC port for the domain node
+    pub fn rpc_port(mut self, port: u16) -> Self {
+        self.rpc_port = Some(port);
+        self
+    }
+
     /// Build an EVM domain node
     pub async fn build_evm_node(
         self,
@@ -642,6 +663,8 @@ impl DomainNodeBuilder {
             self.maybe_operator_id,
             role,
             mock_consensus_node,
+            self.rpc_addr,
+            self.rpc_port,
         )
         .await
     }
@@ -668,6 +691,8 @@ impl DomainNodeBuilder {
             self.maybe_operator_id,
             role,
             mock_consensus_node,
+            self.rpc_addr,
+            self.rpc_port,
         )
         .await
     }
@@ -691,6 +716,8 @@ impl DomainNodeBuilder {
             self.maybe_operator_id,
             role,
             mock_consensus_node,
+            self.rpc_addr,
+            self.rpc_port,
         )
         .await
     }

--- a/domains/test/service/src/lib.rs
+++ b/domains/test/service/src/lib.rs
@@ -113,7 +113,7 @@ pub fn node_config(
             RpcConfiguration {
                 addr: Some(vec![RpcEndpoint {
                     batch_config: RpcBatchRequestConfig::Disabled,
-                    max_connections: 10,
+                    max_connections: 100,
                     listen_addr,
                     rpc_methods: Default::default(),
                     rate_limit: None,
@@ -121,8 +121,8 @@ pub fn node_config(
                     rate_limit_whitelisted_ips: vec![],
                     max_payload_in_mb: 15,
                     max_payload_out_mb: 15,
-                    max_subscriptions_per_connection: 10,
-                    max_buffer_capacity_per_connection: 10,
+                    max_subscriptions_per_connection: 100,
+                    max_buffer_capacity_per_connection: 100,
                     cors: None,
                     retry_random_port: true,
                     is_optional: false,

--- a/domains/test/service/src/lib.rs
+++ b/domains/test/service/src/lib.rs
@@ -31,7 +31,7 @@ use sc_network::multiaddr;
 use sc_service::config::{
     DatabaseSource, ExecutorConfiguration, KeystoreConfig, MultiaddrWithPeerId,
     NetworkConfiguration, OffchainWorkerConfig, PruningMode, RpcBatchRequestConfig,
-    RpcConfiguration, WasmExecutionMethod, WasmtimeInstantiationStrategy,
+    RpcConfiguration, RpcEndpoint, WasmExecutionMethod, WasmtimeInstantiationStrategy,
 };
 use sc_service::{
     BasePath, BlocksPruning, ChainSpec, Configuration as ServiceConfiguration,
@@ -48,6 +48,7 @@ use sp_runtime::generic;
 use sp_runtime::generic::SignedPayload;
 use sp_runtime::traits::{AsSystemOriginSigner, Dispatchable};
 use std::fmt::{Debug, Display};
+use std::net::SocketAddr;
 use std::str::FromStr;
 
 /// The domain id of the evm domain
@@ -72,6 +73,8 @@ pub fn node_config(
     role: Role,
     base_path: BasePath,
     chain_spec: Box<dyn ChainSpec>,
+    rpc_addr: Option<SocketAddr>,
+    rpc_port: Option<u16>,
 ) -> Result<ServiceConfiguration, ServiceError> {
     let root = base_path.path().to_path_buf();
 
@@ -104,6 +107,59 @@ pub fn node_config(
 
     network_config.transport = TransportConfig::MemoryOnly;
 
+    let rpc_configuration = match rpc_addr {
+        Some(listen_addr) => {
+            let port = rpc_port.unwrap_or(9945);
+            RpcConfiguration {
+                addr: Some(vec![RpcEndpoint {
+                    batch_config: RpcBatchRequestConfig::Disabled,
+                    max_connections: 10,
+                    listen_addr,
+                    rpc_methods: Default::default(),
+                    rate_limit: None,
+                    rate_limit_trust_proxy_headers: false,
+                    rate_limit_whitelisted_ips: vec![],
+                    max_payload_in_mb: 15,
+                    max_payload_out_mb: 15,
+                    max_subscriptions_per_connection: 10,
+                    max_buffer_capacity_per_connection: 10,
+                    cors: None,
+                    retry_random_port: true,
+                    is_optional: false,
+                }]),
+                max_request_size: 15,
+                max_response_size: 15,
+                id_provider: None,
+                max_subs_per_conn: 1024,
+                port,
+                message_buffer_capacity: 1024,
+                batch_config: RpcBatchRequestConfig::Disabled,
+                max_connections: 1000,
+                cors: None,
+                methods: Default::default(),
+                rate_limit: None,
+                rate_limit_whitelisted_ips: vec![],
+                rate_limit_trust_proxy_headers: false,
+            }
+        }
+        None => RpcConfiguration {
+            addr: None,
+            max_request_size: 0,
+            max_response_size: 0,
+            id_provider: None,
+            max_subs_per_conn: 0,
+            port: 0,
+            message_buffer_capacity: 0,
+            batch_config: RpcBatchRequestConfig::Disabled,
+            max_connections: 0,
+            cors: None,
+            methods: Default::default(),
+            rate_limit: None,
+            rate_limit_whitelisted_ips: vec![],
+            rate_limit_trust_proxy_headers: false,
+        },
+    };
+
     Ok(ServiceConfiguration {
         impl_name: "domain-test-node".to_string(),
         impl_version: "0.1".to_string(),
@@ -127,22 +183,7 @@ pub fn node_config(
             default_heap_pages: None,
             runtime_cache_size: 2,
         },
-        rpc: RpcConfiguration {
-            addr: None,
-            max_request_size: 0,
-            max_response_size: 0,
-            id_provider: None,
-            max_subs_per_conn: 0,
-            port: 0,
-            message_buffer_capacity: 0,
-            batch_config: RpcBatchRequestConfig::Disabled,
-            max_connections: 0,
-            cors: None,
-            methods: Default::default(),
-            rate_limit: None,
-            rate_limit_whitelisted_ips: vec![],
-            rate_limit_trust_proxy_headers: false,
-        },
+        rpc: rpc_configuration,
         prometheus_config: None,
         telemetry_endpoints: None,
         offchain_worker: OffchainWorkerConfig {

--- a/test/subspace-farmerless-dev-node/Cargo.toml
+++ b/test/subspace-farmerless-dev-node/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "subspace-farmerless-dev-node"
+version = "0.1.0"
+edition = "2024"
+license = "GPL-3.0-or-later"
+publish = false
+
+[[bin]]
+name = "subspace-farmerless-dev-node"
+path = "src/main.rs"
+
+[dependencies]
+clap = { workspace = true, features = ["derive"] }
+sc-cli = { workspace = true, default-features = false }
+sc-service = { workspace = true, default-features = false }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tempfile = { workspace = true }
+tracing = { workspace = true }
+sp-keyring = { workspace = true }
+
+subspace-test-service = { workspace = true }
+domain-test-service = { workspace = true }
+

--- a/test/subspace-farmerless-dev-node/Cargo.toml
+++ b/test/subspace-farmerless-dev-node/Cargo.toml
@@ -17,6 +17,8 @@ tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tempfile = { workspace = true }
 tracing = { workspace = true }
 sp-keyring = { workspace = true }
+jsonrpsee = { workspace = true, features = ["macros", "server-core"] }
+async-trait = { workspace = true }
 
 subspace-test-service = { workspace = true }
 domain-test-service = { workspace = true }

--- a/test/subspace-farmerless-dev-node/README.md
+++ b/test/subspace-farmerless-dev-node/README.md
@@ -1,0 +1,38 @@
+# Subspace Farmerless Dev Node
+
+Developer utility binary that boots a local Subspace consensus node (mocked farmerless setup) and, optionally, an EVM domain node for integration testing and manual experimentation. It wraps helpers from `subspace-test-service` and `domain-test-service` so that devs can exercise cross-domain flows without spinning up a full farmer.
+
+## Prerequisites
+
+- Rust toolchain with `cargo`
+- Workspace dependencies built once (`cargo build -p subspace-farmerless-dev-node`)
+
+## Usage
+
+From the workspace root:
+
+```
+cargo run -p subspace-farmerless-dev-node -- [FLAGS/OPTIONS]
+```
+
+Common flags:
+
+- `--finalize-depth <K>`: Enforce finalization depth; omit to disable.
+- `--domain`: Start the EVM domain node alongside consensus.
+- `--base-path <PATH>`: Persist data instead of using a temp dir.
+- `--rpc-host <IP>` / `--rpc-port <PORT>`: Consensus RPC interface (defaults `127.0.0.1:9944`).
+- `--domain-rpc-host <IP>` / `--domain-rpc-port <PORT>`: Domain RPC interface (defaults `127.0.0.1:9945`).
+- `--block-interval-ms <MS>`: Slot and block production cadence (default `6000`; use `0` to disable auto-production).
+
+To inspect the full CLI help, run:
+
+```
+cargo run -p subspace-farmerless-dev-node -- --help
+```
+
+## Typical Scenarios
+
+- **Quick smoke test:** `cargo run -p subspace-farmerless-dev-node` (produces consensus blocks every 6s using temp storage).
+- **Run with domain node:** `cargo run -p subspace-farmerless-dev-node -- --domain`.
+- **Fast integration testing:** `cargo run -p subspace-farmerless-dev-node -- --block-interval-ms 500 --domain`.
+- **Manual block production:** `cargo run -p subspace-farmerless-dev-node -- --block-interval-ms 0` and trigger blocks via RPC helpers.

--- a/test/subspace-farmerless-dev-node/README.md
+++ b/test/subspace-farmerless-dev-node/README.md
@@ -35,4 +35,49 @@ cargo run -p subspace-farmerless-dev-node -- --help
 - **Quick smoke test:** `cargo run -p subspace-farmerless-dev-node` (produces consensus blocks every 6s using temp storage).
 - **Run with domain node:** `cargo run -p subspace-farmerless-dev-node -- --domain`.
 - **Fast integration testing:** `cargo run -p subspace-farmerless-dev-node -- --block-interval-ms 500 --domain`.
-- **Manual block production:** `cargo run -p subspace-farmerless-dev-node -- --block-interval-ms 0` and trigger blocks via RPC helpers.
+- **Manual block production:** `cargo run -p subspace-farmerless-dev-node -- --block-interval-ms 0 --domain` and trigger blocks via RPC helpers.
+
+## Manual Block Production RPCs
+
+When `--block-interval-ms 0` is set, the node exposes JSON-RPC endpoints for manual block production:
+
+### `dev_produceBlock`
+
+Produce a single consensus block.
+
+**Parameters:**
+
+- `wait_for_bundle` (optional, boolean): If `true`, wait for domain bundle submission before producing the block. Defaults to `false`.
+
+**Example:**
+
+```bash
+curl -H "Content-Type: application/json" \
+     --data '{"jsonrpc":"2.0","id":1,"method":"dev_produceBlock","params":[true]}' \
+     http://127.0.0.1:9944
+```
+
+### `dev_produceBlocks`
+
+Produce multiple consensus blocks.
+
+**Parameters:**
+
+- `count` (required, number): Number of blocks to produce.
+- `wait_for_bundle` (optional, boolean): If `true`, wait for domain bundle submission before each block. Defaults to `false`.
+
+**Example:**
+
+```bash
+# Produce 5 blocks without waiting for bundles
+curl -H "Content-Type: application/json" \
+     --data '{"jsonrpc":"2.0","id":1,"method":"dev_produceBlocks","params":[5]}' \
+     http://127.0.0.1:9944
+
+# Produce 5 blocks, waiting for bundles
+curl -H "Content-Type: application/json" \
+     --data '{"jsonrpc":"2.0","id":1,"method":"dev_produceBlocks","params":[5,true]}' \
+     http://127.0.0.1:9944
+```
+
+**Note:** When `wait_for_bundle` is `true`, the domain node must be running (`--domain` flag) or the RPC call will timeout waiting for bundle submission.

--- a/test/subspace-farmerless-dev-node/src/main.rs
+++ b/test/subspace-farmerless-dev-node/src/main.rs
@@ -160,7 +160,7 @@ fn main() {
                 tokio::select! {
                     _ = tokio::signal::ctrl_c() => break,
                     _ = tokio::time::sleep(Duration::from_millis(block_interval_ms)) => {
-                        if let Err(err) = consensus_for_loop.produce_block(true).await {
+                        if let Err(err) = consensus_for_loop.produce_block(cli.domain).await {
                             error!(%err, "Failed to auto-produce block");
                         }
                     }

--- a/test/subspace-farmerless-dev-node/src/main.rs
+++ b/test/subspace-farmerless-dev-node/src/main.rs
@@ -1,0 +1,157 @@
+use clap::Parser;
+use domain_test_service::{DomainNodeBuilder, EcdsaKeyring};
+use sc_cli::LoggerBuilder;
+use sc_service::{BasePath, Role};
+use sp_keyring::Sr25519Keyring;
+use std::net::{IpAddr, SocketAddr};
+use std::path::PathBuf;
+use std::time::Duration;
+use subspace_test_service::{MockConsensusNode, MockConsensusNodeRpcConfig};
+use tempfile::TempDir;
+use tokio::runtime::Builder as TokioBuilder;
+
+#[derive(Debug, Parser)]
+#[command(
+    name = "subspace-farmerless-testnet",
+    about = "Starts consensus and domain test nodes together (farmerless)"
+)]
+struct Cli {
+    /// Finalization depth (K). Omit to disable finalization enforcement.
+    #[arg(long)]
+    finalize_depth: Option<u32>,
+
+    /// Whether to start the EVM domain node
+    #[arg(long, default_value_t = false)]
+    domain: bool,
+
+    /// Base path for node data. Defaults to a unique temporary directory per run.
+    #[arg(long)]
+    base_path: Option<PathBuf>,
+
+    /// Consensus RPC host/interface
+    #[arg(long, default_value = "127.0.0.1")]
+    rpc_host: IpAddr,
+
+    /// Consensus RPC port
+    #[arg(long, default_value_t = 9944)]
+    rpc_port: u16,
+
+    /// Domain RPC host/interface
+    #[arg(long, default_value = "127.0.0.1")]
+    domain_rpc_host: IpAddr,
+
+    /// Domain RPC port
+    #[arg(long, default_value_t = 9945)]
+    domain_rpc_port: u16,
+
+    /// Block production interval in milliseconds (consensus). Use 0 to disable.
+    #[arg(long, default_value_t = 6000)]
+    block_interval_ms: u64,
+}
+
+fn init_logger() {
+    let mut logger = LoggerBuilder::new("");
+    logger.with_colors(false);
+    let _ = logger.init();
+}
+
+fn compute_base_path(cli: &Cli) -> (PathBuf, Option<TempDir>) {
+    match cli.base_path.clone() {
+        Some(p) => (p, None),
+        None => {
+            let tmp = TempDir::new().expect("Must be able to create temporary directory");
+            (tmp.path().to_path_buf(), Some(tmp))
+        }
+    }
+}
+
+fn build_runtime() -> tokio::runtime::Runtime {
+    TokioBuilder::new_multi_thread()
+        .enable_all()
+        .build()
+        .expect("Tokio runtime must build")
+}
+
+fn start_consensus_node(
+    tokio_handle: tokio::runtime::Handle,
+    base_path: PathBuf,
+    finalize_depth: Option<u32>,
+    rpc_host: IpAddr,
+    rpc_port: u16,
+) -> MockConsensusNode {
+    let private_evm = false;
+    let consensus_key = Sr25519Keyring::Alice;
+    let rpc_addr = SocketAddr::new(rpc_host, rpc_port);
+    let rpc_config = MockConsensusNodeRpcConfig {
+        base_path: BasePath::new(base_path),
+        finalize_block_depth: finalize_depth,
+        private_evm,
+        evm_owner: None,
+        rpc_addr: Some(rpc_addr),
+        rpc_port: Some(rpc_port),
+    };
+    let mut node = MockConsensusNode::run_with_rpc_options(tokio_handle, consensus_key, rpc_config);
+    node.start_network();
+    node
+}
+
+fn main() {
+    init_logger();
+
+    let cli = Cli::parse();
+    let (base_path, _temp_dir_guard) = compute_base_path(&cli);
+    let block_interval_ms = cli.block_interval_ms;
+
+    let runtime = build_runtime();
+    let _enter = runtime.enter();
+    let tokio_handle = runtime.handle().clone();
+
+    // Start consensus
+    let consensus_base = base_path.join("consensus");
+    let mut consensus = start_consensus_node(
+        tokio_handle.clone(),
+        consensus_base,
+        cli.finalize_depth,
+        cli.rpc_host,
+        cli.rpc_port,
+    );
+
+    // Optionally start domain (EVM)
+    let domain = if cli.domain {
+        let domain_base = BasePath::new(base_path.join("auto-evm"));
+        let domain_addr = SocketAddr::new(cli.domain_rpc_host, cli.domain_rpc_port);
+        Some(runtime.block_on(async {
+            DomainNodeBuilder::new(tokio_handle.clone(), domain_base)
+                .rpc_addr(domain_addr)
+                .rpc_port(cli.domain_rpc_port)
+                .build_evm_node(Role::Authority, EcdsaKeyring::Alice, &mut consensus)
+                .await
+        }))
+    } else {
+        None
+    };
+    consensus.start_cross_domain_gossip_message_worker();
+
+    if block_interval_ms > 0 {
+        // Keep domain node alive - move it into the async block but don't move consensus
+        let _domain_guard = domain;
+        runtime.block_on(async {
+            loop {
+                tokio::select! {
+                    _ = tokio::signal::ctrl_c() => break,
+                    _ = tokio::time::sleep(Duration::from_millis(block_interval_ms)) => {
+                            let slot = consensus.produce_slot();
+                            let _ = consensus.notify_new_slot_and_wait_for_bundle(slot).await;
+                            let _ = consensus.produce_block_with_slot(slot).await;
+
+                    }
+                }
+            }
+        });
+        return;
+    }
+
+    runtime.block_on(async {
+        let _ = tokio::signal::ctrl_c().await;
+    });
+}

--- a/test/subspace-farmerless-dev-node/src/manual_rpc.rs
+++ b/test/subspace-farmerless-dev-node/src/manual_rpc.rs
@@ -1,0 +1,224 @@
+use async_trait::async_trait;
+use jsonrpsee::core::RpcResult;
+use jsonrpsee::proc_macros::rpc;
+use jsonrpsee::types::error::{CALL_EXECUTION_FAILED_CODE, ErrorCode, ErrorObjectOwned};
+use std::thread;
+use subspace_test_service::MockConsensusNode;
+use tokio::runtime::Builder as TokioBuilder;
+use tokio::sync::{mpsc, oneshot};
+use tracing::warn;
+
+pub enum ConsensusCommand {
+    ProduceBlock {
+        wait_for_bundle: bool,
+        respond_to: oneshot::Sender<Result<(), String>>,
+    },
+    ProduceBlocks {
+        count: u64,
+        wait_for_bundle: bool,
+        respond_to: oneshot::Sender<Result<(), String>>,
+    },
+    Shutdown {
+        respond_to: oneshot::Sender<()>,
+    },
+}
+
+#[derive(Clone)]
+pub struct ConsensusControl {
+    sender: mpsc::UnboundedSender<ConsensusCommand>,
+}
+
+impl ConsensusControl {
+    fn new(sender: mpsc::UnboundedSender<ConsensusCommand>) -> Self {
+        Self { sender }
+    }
+
+    async fn send_command<T>(
+        &self,
+        make_command: impl FnOnce(oneshot::Sender<T>) -> ConsensusCommand,
+    ) -> Result<T, String> {
+        let (respond_to, respond_from) = oneshot::channel();
+        self.sender
+            .send(make_command(respond_to))
+            .map_err(|_| "Consensus task terminated".to_string())?;
+        respond_from
+            .await
+            .map_err(|_| "Consensus task terminated".to_string())
+    }
+
+    pub async fn produce_block(&self, wait_for_bundle: bool) -> Result<(), String> {
+        self.send_command(|respond_to| ConsensusCommand::ProduceBlock {
+            wait_for_bundle,
+            respond_to,
+        })
+        .await
+        .and_then(|r| r)
+    }
+
+    pub async fn produce_blocks(&self, count: u64, wait_for_bundle: bool) -> Result<(), String> {
+        self.send_command(|respond_to| ConsensusCommand::ProduceBlocks {
+            count,
+            wait_for_bundle,
+            respond_to,
+        })
+        .await
+        .and_then(|r| r)
+    }
+
+    pub async fn shutdown(&self) -> Result<(), String> {
+        self.send_command(|respond_to| ConsensusCommand::Shutdown { respond_to })
+            .await
+    }
+}
+
+pub type ConsensusCommandReceiver = mpsc::UnboundedReceiver<ConsensusCommand>;
+
+pub fn consensus_control_channel() -> (ConsensusControl, ConsensusCommandReceiver) {
+    let (sender, receiver) = mpsc::unbounded_channel();
+    (ConsensusControl::new(sender), receiver)
+}
+
+#[rpc(server)]
+pub trait FarmerlessDevRpc {
+    /// Produce a single consensus block.
+    #[method(name = "dev_produceBlock")]
+    async fn produce_block(&self, wait_for_bundle: Option<bool>) -> RpcResult<()>;
+
+    /// Produce `count` consensus blocks.
+    #[method(name = "dev_produceBlocks")]
+    async fn produce_blocks(&self, count: u64, wait_for_bundle: Option<bool>) -> RpcResult<()>;
+}
+
+#[derive(Clone)]
+struct FarmerlessDevRpcImpl {
+    consensus: ConsensusControl,
+}
+
+fn to_rpc_error(err: impl std::fmt::Display) -> ErrorObjectOwned {
+    ErrorObjectOwned::owned(
+        ErrorCode::ServerError(CALL_EXECUTION_FAILED_CODE).code(),
+        err.to_string(),
+        None::<()>,
+    )
+}
+
+#[async_trait]
+impl FarmerlessDevRpcServer for FarmerlessDevRpcImpl {
+    async fn produce_block(&self, wait_for_bundle: Option<bool>) -> RpcResult<()> {
+        let wait_for_bundle = wait_for_bundle.unwrap_or(false);
+        self.consensus
+            .produce_block(wait_for_bundle)
+            .await
+            .map_err(to_rpc_error)
+    }
+
+    async fn produce_blocks(&self, count: u64, wait_for_bundle: Option<bool>) -> RpcResult<()> {
+        if count == 0 {
+            return Ok(());
+        }
+
+        let wait_for_bundle = wait_for_bundle.unwrap_or(false);
+        self.consensus
+            .produce_blocks(count, wait_for_bundle)
+            .await
+            .map_err(to_rpc_error)
+    }
+}
+
+pub fn manual_block_production_rpc(consensus: ConsensusControl) -> jsonrpsee::RpcModule<()> {
+    let mut module = jsonrpsee::RpcModule::new(());
+    module
+        .merge(FarmerlessDevRpcImpl { consensus }.into_rpc())
+        .expect("manual block RPC merge must succeed");
+    module
+}
+
+async fn produce_single_block(
+    consensus: &mut MockConsensusNode,
+    wait_for_bundle: bool,
+) -> Result<(), String> {
+    if wait_for_bundle {
+        let (slot, _) = consensus
+            .produce_slot_and_wait_for_bundle_submission()
+            .await;
+        consensus
+            .produce_block_with_slot(slot)
+            .await
+            .map_err(|err| err.to_string())
+    } else {
+        let slot = consensus.produce_slot();
+        consensus
+            .produce_block_with_slot(slot)
+            .await
+            .map_err(|err| err.to_string())
+    }
+}
+
+async fn produce_multiple_blocks(
+    consensus: &mut MockConsensusNode,
+    count: u64,
+    wait_for_bundle: bool,
+) -> Result<(), String> {
+    if wait_for_bundle {
+        for _ in 0..count {
+            produce_single_block(consensus, true).await?;
+        }
+        Ok(())
+    } else {
+        consensus
+            .produce_blocks(count)
+            .await
+            .map_err(|err| err.to_string())
+    }
+}
+
+async fn run_consensus_command_loop(
+    mut consensus: MockConsensusNode,
+    mut commands: ConsensusCommandReceiver,
+) {
+    while let Some(command) = commands.recv().await {
+        match command {
+            ConsensusCommand::ProduceBlock {
+                wait_for_bundle,
+                respond_to,
+            } => {
+                let result = produce_single_block(&mut consensus, wait_for_bundle).await;
+                if respond_to.send(result).is_err() {
+                    warn!("Caller dropped receiver for ProduceBlock command");
+                }
+            }
+            ConsensusCommand::ProduceBlocks {
+                count,
+                wait_for_bundle,
+                respond_to,
+            } => {
+                let result = produce_multiple_blocks(&mut consensus, count, wait_for_bundle).await;
+                if respond_to.send(result).is_err() {
+                    warn!("Caller dropped receiver for ProduceBlocks command");
+                }
+            }
+            ConsensusCommand::Shutdown { respond_to } => {
+                if respond_to.send(()).is_err() {
+                    warn!("Caller dropped receiver for Shutdown command");
+                }
+                break;
+            }
+        }
+    }
+}
+
+pub fn spawn_consensus_worker(
+    consensus: MockConsensusNode,
+    commands: ConsensusCommandReceiver,
+) -> thread::JoinHandle<()> {
+    thread::Builder::new()
+        .name("consensus-control".into())
+        .spawn(move || {
+            let rt = TokioBuilder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("Failed to create control runtime");
+            rt.block_on(run_consensus_command_loop(consensus, commands));
+        })
+        .expect("Failed to spawn consensus control thread")
+}

--- a/test/subspace-test-client/src/chain_spec.rs
+++ b/test/subspace-test-client/src/chain_spec.rs
@@ -135,7 +135,7 @@ fn create_genesis_config(
         runtime_configs: RuntimeConfigsConfig {
             enable_domains: true,
             enable_dynamic_cost_of_storage: false,
-            enable_balance_transfers: false,
+            enable_balance_transfers: true,
             confirmation_depth_k: 100u32,
             council_democracy_config_params: CouncilDemocracyConfigParams::default(),
             domain_block_pruning_depth: 10u32,

--- a/test/subspace-test-service/src/lib.rs
+++ b/test/subspace-test-service/src/lib.rs
@@ -42,8 +42,8 @@ use sc_network::{
 };
 use sc_service::config::{
     DatabaseSource, ExecutorConfiguration, KeystoreConfig, MultiaddrWithPeerId,
-    OffchainWorkerConfig, RpcBatchRequestConfig, RpcConfiguration, WasmExecutionMethod,
-    WasmtimeInstantiationStrategy,
+    OffchainWorkerConfig, RpcBatchRequestConfig, RpcConfiguration, RpcEndpoint,
+    WasmExecutionMethod, WasmtimeInstantiationStrategy,
 };
 use sc_service::{
     BasePath, BlocksPruning, Configuration, NetworkStarter, Role, SpawnTasksParams, TaskManager,
@@ -84,6 +84,7 @@ use sp_timestamp::Timestamp;
 use std::collections::HashMap;
 use std::error::Error;
 use std::marker::PhantomData;
+use std::net::SocketAddr;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::time;
@@ -127,6 +128,8 @@ pub fn node_config(
     private_evm: bool,
     evm_owner_account: Option<AccountId>,
     base_path: BasePath,
+    rpc_addr: Option<SocketAddr>,
+    rpc_port: Option<u16>,
 ) -> Configuration {
     let root = base_path.path();
     let role = if run_farmer {
@@ -157,6 +160,59 @@ pub fn node_config(
 
     network_config.force_synced = force_synced;
 
+    let rpc_configuration = match rpc_addr {
+        Some(listen_addr) => {
+            let port = rpc_port.unwrap_or(9944);
+            RpcConfiguration {
+                addr: Some(vec![RpcEndpoint {
+                    batch_config: RpcBatchRequestConfig::Disabled,
+                    max_connections: 10,
+                    listen_addr,
+                    rpc_methods: Default::default(),
+                    rate_limit: None,
+                    rate_limit_trust_proxy_headers: false,
+                    rate_limit_whitelisted_ips: vec![],
+                    max_payload_in_mb: 15,
+                    max_payload_out_mb: 15,
+                    max_subscriptions_per_connection: 10,
+                    max_buffer_capacity_per_connection: 10,
+                    cors: None,
+                    retry_random_port: true,
+                    is_optional: false,
+                }]),
+                max_request_size: 15,
+                max_response_size: 15,
+                id_provider: None,
+                max_subs_per_conn: 1024,
+                port,
+                message_buffer_capacity: 1024,
+                batch_config: RpcBatchRequestConfig::Disabled,
+                max_connections: 1000,
+                cors: None,
+                methods: Default::default(),
+                rate_limit: None,
+                rate_limit_whitelisted_ips: vec![],
+                rate_limit_trust_proxy_headers: false,
+            }
+        }
+        None => RpcConfiguration {
+            addr: None,
+            max_request_size: 0,
+            max_response_size: 0,
+            id_provider: None,
+            max_subs_per_conn: 0,
+            port: 0,
+            message_buffer_capacity: 0,
+            batch_config: RpcBatchRequestConfig::Disabled,
+            max_connections: 0,
+            cors: None,
+            methods: Default::default(),
+            rate_limit: None,
+            rate_limit_whitelisted_ips: vec![],
+            rate_limit_trust_proxy_headers: false,
+        },
+    };
+
     Configuration {
         impl_name: "subspace-test-node".to_string(),
         impl_version: "0.1".to_string(),
@@ -181,22 +237,7 @@ pub fn node_config(
             runtime_cache_size: 2,
         },
         wasm_runtime_overrides: Default::default(),
-        rpc: RpcConfiguration {
-            addr: None,
-            max_request_size: 0,
-            max_response_size: 0,
-            id_provider: None,
-            max_subs_per_conn: 0,
-            port: 0,
-            message_buffer_capacity: 0,
-            batch_config: RpcBatchRequestConfig::Disabled,
-            max_connections: 0,
-            cors: None,
-            methods: Default::default(),
-            rate_limit: None,
-            rate_limit_whitelisted_ips: vec![],
-            rate_limit_trust_proxy_headers: false,
-        },
+        rpc: rpc_configuration,
         prometheus_config: None,
         telemetry_endpoints: None,
         offchain_worker: OffchainWorkerConfig {
@@ -393,52 +434,34 @@ pub struct MockConsensusNode {
     base_path: BasePath,
 }
 
+/// Configuration values required to run a mock consensus node with custom RPC options.
+pub struct MockConsensusNodeRpcConfig {
+    /// The node's base path.
+    pub base_path: BasePath,
+    /// Optional block finalization depth override.
+    pub finalize_block_depth: Option<NumberFor<Block>>,
+    /// Whether to enable the private EVM domain.
+    pub private_evm: bool,
+    /// Optional EVM owner key.
+    pub evm_owner: Option<Sr25519Keyring>,
+    /// Optional RPC listen address override.
+    pub rpc_addr: Option<SocketAddr>,
+    /// Optional RPC listen port override.
+    pub rpc_port: Option<u16>,
+}
+
 impl MockConsensusNode {
-    /// Run a mock consensus node
-    pub fn run(
-        tokio_handle: tokio::runtime::Handle,
-        key: Sr25519Keyring,
-        base_path: BasePath,
-    ) -> MockConsensusNode {
-        Self::run_with_finalization_depth(tokio_handle, key, base_path, None, false, None)
-    }
-
-    /// Run a mock consensus node with a private EVM domain
-    pub fn run_with_private_evm(
-        tokio_handle: tokio::runtime::Handle,
-        key: Sr25519Keyring,
-        evm_owner: Option<Sr25519Keyring>,
-        base_path: BasePath,
-    ) -> MockConsensusNode {
-        Self::run_with_finalization_depth(tokio_handle, key, base_path, None, true, evm_owner)
-    }
-
-    /// Run a mock consensus node with finalization depth
-    pub fn run_with_finalization_depth(
-        tokio_handle: tokio::runtime::Handle,
+    fn run_with_configuration(
+        mut config: Configuration,
         key: Sr25519Keyring,
         base_path: BasePath,
         finalize_block_depth: Option<NumberFor<Block>>,
-        private_evm: bool,
-        evm_owner: Option<Sr25519Keyring>,
+        rpc_builder: Box<
+            dyn Fn() -> Result<RpcModule<()>, sc_service::Error> + Send + Sync + 'static,
+        >,
     ) -> MockConsensusNode {
         let log_prefix = key.into();
 
-        let mut config = node_config(
-            tokio_handle,
-            key,
-            vec![],
-            false,
-            false,
-            false,
-            private_evm,
-            evm_owner.map(|key| key.to_account_id()),
-            base_path.clone(),
-        );
-
-        // Set `transaction_pool.ban_time` to 0 such that duplicated tx will not immediately rejected
-        // by `TemporarilyBanned`
-        // rest of the options are taken from default
         let tx_pool_options = Options {
             ban_time: Duration::from_millis(0),
             ..Default::default()
@@ -523,7 +546,7 @@ impl MockConsensusNode {
             keystore: keystore_container.keystore(),
             task_manager: &mut task_manager,
             transaction_pool: transaction_pool.clone(),
-            rpc_builder: Box::new(|_| Ok(RpcModule::new(()))),
+            rpc_builder: Box::new(move |_| rpc_builder()),
             backend: backend.clone(),
             system_rpc_tx,
             config,
@@ -556,7 +579,6 @@ impl MockConsensusNode {
         let (consensus_msg_sink, consensus_msg_receiver) =
             tracing_unbounded("consensus_message_channel", 100);
 
-        // Start cross domain message listener for Consensus chain to receive messages from domains in the network
         let consensus_listener =
             cross_domain_message_gossip::start_cross_chain_message_listener::<_, _, _, _, _, _, _>(
                 ChainId::Consensus,
@@ -613,6 +635,100 @@ impl MockConsensusNode {
             finalize_block_depth,
             base_path,
         }
+    }
+
+    /// Run a mock consensus node
+    pub fn run(
+        tokio_handle: tokio::runtime::Handle,
+        key: Sr25519Keyring,
+        base_path: BasePath,
+    ) -> MockConsensusNode {
+        Self::run_with_finalization_depth(tokio_handle, key, base_path, None, false, None)
+    }
+
+    /// Run a mock consensus node with a private EVM domain
+    pub fn run_with_private_evm(
+        tokio_handle: tokio::runtime::Handle,
+        key: Sr25519Keyring,
+        evm_owner: Option<Sr25519Keyring>,
+        base_path: BasePath,
+    ) -> MockConsensusNode {
+        Self::run_with_finalization_depth(tokio_handle, key, base_path, None, true, evm_owner)
+    }
+
+    /// Run a mock consensus node with finalization depth
+    pub fn run_with_finalization_depth(
+        tokio_handle: tokio::runtime::Handle,
+        key: Sr25519Keyring,
+        base_path: BasePath,
+        finalize_block_depth: Option<NumberFor<Block>>,
+        private_evm: bool,
+        evm_owner: Option<Sr25519Keyring>,
+    ) -> MockConsensusNode {
+        let rpc_config = MockConsensusNodeRpcConfig {
+            base_path,
+            finalize_block_depth,
+            private_evm,
+            evm_owner,
+            rpc_addr: None,
+            rpc_port: None,
+        };
+
+        Self::run_with_rpc_builder(
+            tokio_handle,
+            key,
+            rpc_config,
+            Box::new(|| Ok(RpcModule::new(()))),
+        )
+    }
+
+    /// Run a mock consensus node with a custom RPC builder and RPC address/port options.
+    pub fn run_with_rpc_builder(
+        tokio_handle: tokio::runtime::Handle,
+        key: Sr25519Keyring,
+        rpc_config: MockConsensusNodeRpcConfig,
+        rpc_builder: Box<
+            dyn Fn() -> Result<RpcModule<()>, sc_service::Error> + Send + Sync + 'static,
+        >,
+    ) -> MockConsensusNode {
+        let MockConsensusNodeRpcConfig {
+            base_path,
+            finalize_block_depth,
+            private_evm,
+            evm_owner,
+            rpc_addr,
+            rpc_port,
+        } = rpc_config;
+
+        let config = node_config(
+            tokio_handle,
+            key,
+            vec![],
+            false,
+            false,
+            false,
+            private_evm,
+            evm_owner.map(|key| key.to_account_id()),
+            base_path.clone(),
+            rpc_addr,
+            rpc_port,
+        );
+
+        Self::run_with_configuration(config, key, base_path, finalize_block_depth, rpc_builder)
+    }
+
+    /// Run a mock consensus node with RPC options using the default empty RPC module.
+    pub fn run_with_rpc_options(
+        tokio_handle: tokio::runtime::Handle,
+        key: Sr25519Keyring,
+        rpc_config: MockConsensusNodeRpcConfig,
+    ) -> MockConsensusNode {
+        Self::run_with_rpc_builder(
+            tokio_handle,
+            key,
+            rpc_config,
+            Box::new(|| Ok(RpcModule::new(()))),
+        )
     }
 
     /// Start the mock consensus node network

--- a/test/subspace-test-service/src/lib.rs
+++ b/test/subspace-test-service/src/lib.rs
@@ -166,7 +166,7 @@ pub fn node_config(
             RpcConfiguration {
                 addr: Some(vec![RpcEndpoint {
                     batch_config: RpcBatchRequestConfig::Disabled,
-                    max_connections: 10,
+                    max_connections: 100,
                     listen_addr,
                     rpc_methods: Default::default(),
                     rate_limit: None,
@@ -174,8 +174,8 @@ pub fn node_config(
                     rate_limit_whitelisted_ips: vec![],
                     max_payload_in_mb: 15,
                     max_payload_out_mb: 15,
-                    max_subscriptions_per_connection: 10,
-                    max_buffer_capacity_per_connection: 10,
+                    max_subscriptions_per_connection: 100,
+                    max_buffer_capacity_per_connection: 100,
                     cors: None,
                     retry_random_port: true,
                     is_optional: false,


### PR DESCRIPTION
## Summary

Introduces a new developer utility binary (`subspace-farmerless-dev-node`) that enables running consensus and domain nodes without a farmer, with optional manual block production via JSON-RPC endpoints. Refactors RPC configuration in test services to support optional RPC endpoints while maintaining backwards compatibility.

### Other Changes

- Add RUSTSEC-2025-0118 (wasmtime unsound API vulnerability) to rustsec audit ignore list until polkadot-sdk dependency upgrades wasmtime from 8.0.1.
- `.gitignore` updated to exclude `.vscode` directory

## Motivation and Context

Developers need a lightweight way to:

- Test consensus and domain flows without spinning up a full farmer
- Manually control block production for debugging and integration testing
- Run consensus and domain nodes with RPC access for inspection

Previously, developers had to use complex test harnesses or run full nodes. This PR provides a simple, standalone binary that wraps existing test service helpers.

## Implementation Details

### New Binary: `subspace-farmerless-dev-node`

A CLI tool that:

- Starts a consensus node (mocked farmerless setup)
- Optionally starts an EVM domain node
- Supports automatic block production (configurable interval) or manual production via RPC
- Exposes JSON-RPC endpoints for manual block control

**Key Features:**

- `--block-interval-ms`: Set automatic block production interval (0 disables)
- `--domain`: Enable EVM domain node
- `--rpc-host`/`--rpc-port`: Configure consensus RPC endpoint
- `--domain-rpc-host`/`--domain-rpc-port`: Configure domain RPC endpoint

### Manual Block Production RPCs

When RPC is enabled (via `--rpc-host`/`--rpc-port`), exposes two JSON-RPC methods for manual block production:

- **`dev_produceBlock`**: Produce a single consensus block
  - Optional `wait_for_bundle` parameter to wait for domain bundle submission
- **`dev_produceBlocks`**: Produce multiple consensus blocks
  - Required `count` parameter
  - Optional `wait_for_bundle` parameter

### RPC Configuration Refactoring

**`subspace-test-service`:**

- Introduced `MockConsensusNodeRpcConfig` struct to consolidate RPC configuration parameters
- Added `run_with_rpc_builder()` and `run_with_rpc_options()` methods
- RPC is disabled by default (backwards compatible)
- Only enables RPC when `rpc_addr` is provided

**`domain-test-service`:**

- Added `rpc_addr()` and `rpc_port()` builder methods to `DomainNodeBuilder`
- RPC configuration passed through to `node_config()`
- RPC is disabled by default (backwards compatible)
- Only enables RPC when `rpc_addr` is provided

**Benefits:**

- Reduces argument count (addresses clippy warnings)
- Cleaner API with configuration struct
- Maintains backwards compatibility for existing test code

## Testing

- Manual testing performed:

  - Binary starts successfully with various flag combinations
  - Manual RPC endpoints work correctly
  - Auto block production works correctly
  - Shutdown handles Ctrl+C gracefully
  - Domain node integration works when `--domain` flag is used
  - Auto SDK integration tests pass targeting the new binary

- Existing tests remain unaffected (backwards compatibility maintained)

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
