### PR TITLE
add gh-action to cleanup space on runner before our builds

### DIFF
--- a/.github/workflows/snapshot-build.yml
+++ b/.github/workflows/snapshot-build.yml
@@ -42,6 +42,17 @@ jobs:
       fail-fast: false
 
     steps:
+      - name: Free Disk Space
+        uses: endersonmenezes/free-disk-space@6c4664f43348c8c7011b53488d5ca65e9fc5cd1a  # v3.0
+        with:
+          remove_android: true
+          remove_dotnet: true
+          remove_haskell: true
+          remove_tool_cache: true
+          remove_swap: true
+          rm_cmd: "rmz"
+          rmz_version: "3.1.1"
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf # v3.2.0
 


### PR DESCRIPTION
Seems like the runners are running out of space.Most likely due to a change introduced recently as this was not the case a few days back.

Added a gh-action that cleanups useless things on runner before we do our build. This gave us around 20GB more and snapshot builds passed here - https://github.com/autonomys/subspace/actions/runs/19532819361

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
