### PR TITLE
Add farmerless dev node docker image

### DIFF
--- a/.github/workflows/snapshot-build.yml
+++ b/.github/workflows/snapshot-build.yml
@@ -39,6 +39,9 @@ jobs:
           - image: bootstrap-node
             base-artifact: subspace-bootstrap-node
             upload-executables: false
+          - image: farmerless-dev-node
+            base-artifact: subspace-farmerless-dev-node
+            upload-executables: false
       fail-fast: false
 
     steps:

--- a/docker/farmerless-dev-node.Dockerfile
+++ b/docker/farmerless-dev-node.Dockerfile
@@ -1,0 +1,114 @@
+# This Dockerfile supports both native building and cross-compilation to x86-64, aarch64 and riscv64
+FROM --platform=$BUILDPLATFORM ubuntu:22.04
+
+ARG PROFILE=production
+ARG RUSTFLAGS
+# Incremental compilation here isn't helpful
+ENV CARGO_INCREMENTAL=0
+ENV PKG_CONFIG_ALLOW_CROSS=true
+
+ARG BUILDARCH
+ARG TARGETARCH
+
+WORKDIR /code
+
+RUN \
+    apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        ca-certificates \
+        protobuf-compiler \
+        curl \
+        git \
+        llvm \
+        clang \
+        automake \
+        libtool \
+        pkg-config \
+        make
+
+RUN \
+    if [ $BUILDARCH != "arm64" ] && [ $TARGETARCH = "arm64" ]; then \
+      DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+          g++-aarch64-linux-gnu \
+          gcc-aarch64-linux-gnu \
+          libc6-dev-arm64-cross \
+    ; fi
+
+RUN \
+    if [ $BUILDARCH != "riscv64" ] && [ $TARGETARCH = "riscv64" ]; then \
+      DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+          g++-riscv64-linux-gnu \
+          gcc-riscv64-linux-gnu \
+          libc6-dev-riscv64-cross \
+    ; fi
+
+RUN \
+    if [ $BUILDARCH != "amd64" ] && [ $TARGETARCH = "amd64" ]; then \
+      DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+          g++-x86-64-linux-gnu \
+          gcc-x86-64-linux-gnu \
+          libc6-dev-amd64-cross \
+    ; fi
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain none
+
+# Up until this line all Rust images in this repo should be the same to share the same layers
+
+COPY . /code
+
+ARG SUBSTRATE_CLI_GIT_COMMIT_HASH
+ARG TARGETVARIANT
+
+RUN \
+    if [ $BUILDARCH != "arm64" ] && [ $TARGETARCH = "arm64" ]; then \
+      export RUSTFLAGS="$RUSTFLAGS -C linker=aarch64-linux-gnu-gcc" \
+    ; fi && \
+    if [ $BUILDARCH != "riscv64" ] && [ $TARGETARCH = "riscv64" ]; then \
+      export RUSTFLAGS="$RUSTFLAGS -C linker=riscv64-linux-gnu-gcc" \
+    ; fi && \
+    if [ $TARGETARCH = "amd64" ] && [ "$RUSTFLAGS" = "" ]; then \
+      case "$TARGETVARIANT" in \
+        # x86-64-v2 with AES-NI
+        "v2") export RUSTFLAGS="-C target-cpu=x86-64-v2" ;; \
+        # x86-64-v3 with AES-NI
+        "v3") export RUSTFLAGS="-C target-cpu=x86-64-v3 -C target-feature=+aes" ;; \
+        # v4 is compiled for Zen 4+
+        "v4") export RUSTFLAGS="-C target-cpu=znver4" ;; \
+        # Default build is for Skylake
+        *) export RUSTFLAGS="-C target-cpu=skylake" ;; \
+      esac \
+    ; fi && \
+    if [ $BUILDARCH != "amd64" ] && [ $TARGETARCH = "amd64" ]; then \
+      export RUSTFLAGS="$RUSTFLAGS -C linker=x86_64-linux-gnu-gcc" \
+    ; fi && \
+    RUSTC_TARGET_ARCH=$(echo $TARGETARCH | sed "s/amd64/x86_64/g" | sed "s/arm64/aarch64/g" | sed "s/riscv64/riscv64gc/g") && \
+    /root/.cargo/bin/cargo -Zgitoxide -Zgit build \
+        --locked \
+        -Z build-std \
+        --profile $PROFILE \
+        --bin subspace-farmerless-dev-node \
+        --target $RUSTC_TARGET_ARCH-unknown-linux-gnu && \
+    mv target/*/*/subspace-farmerless-dev-node subspace-farmerless-dev-node && \
+    rm -rf target
+
+FROM ubuntu:22.04
+
+RUN \
+    apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ca-certificates curl && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+HEALTHCHECK CMD curl -v http://localhost:9944/health
+
+COPY --from=0 /code/subspace-farmerless-dev-node /subspace-farmerless-dev-node
+
+RUN mkdir /var/subspace && chown nobody:nogroup /var/subspace
+
+VOLUME /var/subspace
+
+USER nobody:nogroup
+
+ENTRYPOINT ["/subspace-farmerless-dev-node"]
+
+

--- a/docker/farmerless-dev-node.Dockerfile.dockerignore
+++ b/docker/farmerless-dev-node.Dockerfile.dockerignore
@@ -1,0 +1,12 @@
+# Exclude everything
+*
+# Then just include only the files required for builds
+!/crates
+!/domains
+!/shared
+!/test
+!/Cargo.lock
+!/Cargo.toml
+!/rust-toolchain.toml
+
+


### PR DESCRIPTION
## Overview

In order to facilitate developer worksflows and testing, it is useful to have a reproducible farmerless dev node image that can be used in local development environments and in CI pipelines for integration testing. The build follows the same approach as the other container builds in the repository.

## Implementation details

- The build stage installs the Rust toolchain plus arch-specific cross-compilers whenever the build and target architectures differ, mirroring the approach used in the other container builds.
- Cargo builds `subspace-farmerless-dev-node` with `-Z build-std` and `--locked` to keep deps reproducible, then copies the resulting binary into a minimal Ubuntu runtime image that exposes `/var/subspace` as a volume.
- The `.dockerignore` keeps the context lean to improve cache reuse and CI runtimes.
- Snapshot workflow now includes the `farmerless-dev-node` image in the docker matrix so it is built, tagged, and scanned alongside the other artifacts.
### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
