### PR TITLE
Pin ziggy dependencies

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -377,7 +377,7 @@ jobs:
         run: sudo apt install -y protobuf-compiler binutils-dev coreutils
 
       - name: install ziggy
-        run: cargo install --force ziggy cargo-afl honggfuzz grcov
+        run: cargo install --locked --force ziggy cargo-afl honggfuzz grcov
 
       - name: test fuzzer
         run: scripts/run-fuzzer.sh


### PR DESCRIPTION
Until now, ziggy and deps installation is donw without locked deps and this is unstable and one recent example is zerocopy where the recent release is not compatible with our toolchain version.

This PR ensures the deps are locked to remove that instability

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
