### PR TITLE
Bump versions for EVM runtime and client versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13432,7 +13432,7 @@ dependencies = [
 
 [[package]]
 name = "subspace-bootstrap-node"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "clap",
  "futures",
@@ -13530,7 +13530,7 @@ dependencies = [
 
 [[package]]
 name = "subspace-farmer"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "async-lock 3.4.0",
@@ -13641,7 +13641,7 @@ dependencies = [
 
 [[package]]
 name = "subspace-gateway"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -13811,7 +13811,7 @@ dependencies = [
 
 [[package]]
 name = "subspace-node"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "auto-id-domain-runtime",
  "bip39",

--- a/crates/subspace-bootstrap-node/Cargo.toml
+++ b/crates/subspace-bootstrap-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subspace-bootstrap-node"
-version = "0.1.4"
+version = "0.1.5"
 authors = [
     "Nazar Mokrynskyi <nazar@mokrynskyi.com>",
     "Shamil Gadelshin <shamilgadelshin@gmail.com>"

--- a/crates/subspace-farmer/Cargo.toml
+++ b/crates/subspace-farmer/Cargo.toml
@@ -2,7 +2,7 @@
 name = "subspace-farmer"
 description = "Farmer for the Subspace Network Blockchain"
 license = "0BSD"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["Nazar Mokrynskyi <nazar@mokrynskyi.com>"]
 edition.workspace = true
 include = [

--- a/crates/subspace-gateway/Cargo.toml
+++ b/crates/subspace-gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subspace-gateway"
-version = "0.1.4"
+version = "0.1.5"
 authors = [
     "Teor <teor@riseup.net>",
     "Shamil Gadelshin <shamilgadelshin@gmail.com>"

--- a/crates/subspace-node/Cargo.toml
+++ b/crates/subspace-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subspace-node"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["Subspace Labs <https://subspace.network>"]
 description = "A Subspace Network Blockchain node."
 edition.workspace = true

--- a/domains/runtime/evm/src/lib.rs
+++ b/domains/runtime/evm/src/lib.rs
@@ -317,7 +317,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: Cow::Borrowed("subspace-evm-domain"),
     impl_name: Cow::Borrowed("subspace-evm-domain"),
     authoring_version: 0,
-    spec_version: 1,
+    spec_version: 2,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
EVM spec is bumped to 2
Client crate versions are bumped to 0.1.5

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
