### PR TITLE
Enable ethereum rpc endpoints for farmerless dev node

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3106,8 +3106,10 @@ version = "0.1.0"
 dependencies = [
  "auto-id-domain-test-runtime",
  "cross-domain-message-gossip",
+ "domain-block-preprocessor",
  "domain-check-weight",
  "domain-client-operator",
+ "domain-eth-service",
  "domain-runtime-primitives",
  "domain-service",
  "domain-test-primitives",
@@ -3124,6 +3126,7 @@ dependencies = [
  "sc-network-sync",
  "sc-service",
  "sc-tracing",
+ "sc-transaction-pool",
  "sc-transaction-pool-api",
  "sc-utils",
  "serde",

--- a/domains/test/service/Cargo.toml
+++ b/domains/test/service/Cargo.toml
@@ -15,7 +15,9 @@ include = [
 domain-check-weight.workspace = true
 auto-id-domain-test-runtime.workspace = true
 cross-domain-message-gossip.workspace = true
+domain-block-preprocessor.workspace = true
 domain-client-operator.workspace = true
+domain-eth-service.workspace = true
 domain-service.workspace = true
 domain-test-primitives.workspace = true
 domain-runtime-primitives.workspace = true
@@ -32,6 +34,7 @@ sc-network.workspace = true
 sc-network-sync.workspace = true
 sc-service.workspace = true
 sc-tracing.workspace = true
+sc-transaction-pool.workspace = true
 sc-transaction-pool-api.workspace = true
 sc-utils.workspace = true
 serde = { workspace = true, features = ["derive"] }


### PR DESCRIPTION
## Summary

Adds Ethereum JSON-RPC support to EVM domain nodes built via `domain-test-service`, enabling the farmerless dev node to expose both Substrate and Ethereum RPC endpoints when running with `--domain`.

## Motivation

The farmerless dev node successfully starts an EVM domain when using the `--domain` flag, but it only exposed Substrate RPC endpoints. Ethereum-specific endpoints (`eth_call`, `eth_sendTransaction`, `eth_chainId`, etc.) were missing because the domain node was built with `DefaultProvider` instead of `EthProvider`.

This prevented developers from testing Ethereum-compatible dApps and smart contracts against the dev node.

## Implementation Details

### Changes

1. **Made `DomainNode::build` generic over `Provider`** (private internal function)
   - Added type parameter with appropriate trait bounds
   - Allows passing either `DefaultProvider` or `EthProvider`

2. **EVM domains now use `EthProvider`**
   - `build_evm_node()` and `build_evm_node_with()` create an `EthProvider`
   - Configures Frontier (Ethereum compatibility layer) with sensible defaults
   - Enables dev signer for easy transaction testing

### Configuration Values

The `EthConfiguration` uses CLI defaults from `domain-eth-service`, with one intentional change:
- `enable_dev_signer: true` — Exposes pre-funded dev accounts via `eth_accounts` RPC

## Dependencies

Added to `domain-test-service`:
- `domain-eth-service` — Core dependency providing `EthProvider`
- `domain-block-preprocessor` — Required for `Provider` trait bounds
- `sc-transaction-pool` — Required for `Provider` trait bounds

All dependencies already exist in the workspace.

## Testing

```bash
# Start farmerless dev node with EVM domain
cargo run -p subspace-farmerless-dev-node -- --domain --domain-rpc-port 9945

# Test Ethereum RPC (new functionality)
curl -X POST http://127.0.0.1:9945 \
  -H "Content-Type: application/json" \
  -d '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}'

# Should return chain ID instead of "method not found"
```


### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
