### PR TITLE
upgrade to libp2p 0.56.0

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -377,7 +377,7 @@ jobs:
         run: sudo apt install -y protobuf-compiler binutils-dev coreutils
 
       - name: install ziggy
-        run: cargo install --locked --force ziggy cargo-afl honggfuzz grcov
+        run: cargo install --locked --force ziggy@1.3.5 cargo-afl@0.17.0 honggfuzz@0.5.58 grcov@0.10.5
 
       - name: test fuzzer
         run: scripts/run-fuzzer.sh

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,7 +112,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "mio",
- "socket2 0.5.9",
+ "socket2",
  "tokio",
  "tracing",
 ]
@@ -193,7 +193,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "smallvec",
- "socket2 0.5.9",
+ "socket2",
  "time",
  "url",
 ]
@@ -837,21 +837,9 @@ checksum = "30ca9a001c1e8ba5149f91a74362376cc6bc5b919d92d988668657bd570bdcec"
 dependencies = [
  "async-task",
  "concurrent-queue",
- "fastrand 2.1.1",
- "futures-lite 2.3.0",
+ "fastrand",
+ "futures-lite",
  "slab",
-]
-
-[[package]]
-name = "async-fs"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "279cf904654eeebfa37ac9bb1598880884924aab82e290aa65c9e77a0e142e06"
-dependencies = [
- "async-lock 2.8.0",
- "autocfg",
- "blocking",
- "futures-lite 1.13.0",
 ]
 
 [[package]]
@@ -860,44 +848,9 @@ version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebcd09b382f40fcd159c2d695175b2ae620ffa5f3bd6f664131efff4e8b9e04a"
 dependencies = [
- "async-lock 3.4.0",
+ "async-lock",
  "blocking",
- "futures-lite 2.3.0",
-]
-
-[[package]]
-name = "async-global-executor"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
-dependencies = [
- "async-channel 2.3.1",
- "async-executor",
- "async-io 2.3.4",
- "async-lock 3.4.0",
- "blocking",
- "futures-lite 2.3.0",
- "once_cell",
-]
-
-[[package]]
-name = "async-io"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fc5b45d93ef0529756f812ca52e44c221b35341892d3dcc34132ac02f3dd2af"
-dependencies = [
- "async-lock 2.8.0",
- "autocfg",
- "cfg-if",
- "concurrent-queue",
- "futures-lite 1.13.0",
- "log",
- "parking",
- "polling 2.8.0",
- "rustix 0.37.27",
- "slab",
- "socket2 0.4.10",
- "waker-fn",
+ "futures-lite",
 ]
 
 [[package]]
@@ -906,26 +859,17 @@ version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "444b0228950ee6501b3568d3c93bf1176a1fdbc3b758dcd9475046d30f4dc7e8"
 dependencies = [
- "async-lock 3.4.0",
+ "async-lock",
  "cfg-if",
  "concurrent-queue",
  "futures-io",
- "futures-lite 2.3.0",
+ "futures-lite",
  "parking",
- "polling 3.7.3",
+ "polling",
  "rustix 0.38.37",
  "slab",
  "tracing",
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "async-lock"
-version = "2.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "287272293e9d8c41773cec55e365490fe034813a2f172f502d6ddcf75b2f582b"
-dependencies = [
- "event-listener 2.5.3",
 ]
 
 [[package]]
@@ -975,24 +919,13 @@ dependencies = [
 
 [[package]]
 name = "async-net"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0434b1ed18ce1cf5769b8ac540e33f01fa9471058b5e89da9e06f3c882a8c12f"
-dependencies = [
- "async-io 1.13.0",
- "blocking",
- "futures-lite 1.13.0",
-]
-
-[[package]]
-name = "async-net"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b948000fad4873c1c9339d60f2623323a0cfd3816e5181033c6a5cb68b2accf7"
 dependencies = [
- "async-io 2.3.4",
+ "async-io",
  "blocking",
- "futures-lite 2.3.0",
+ "futures-lite",
 ]
 
 [[package]]
@@ -1006,36 +939,19 @@ dependencies = [
 
 [[package]]
 name = "async-process"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea6438ba0a08d81529c69b36700fa2f95837bfe3e776ab39cde9c14d9149da88"
-dependencies = [
- "async-io 1.13.0",
- "async-lock 2.8.0",
- "async-signal",
- "blocking",
- "cfg-if",
- "event-listener 3.1.0",
- "futures-lite 1.13.0",
- "rustix 0.38.37",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "async-process"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63255f1dc2381611000436537bbedfe83183faa303a5a0edaf191edef06526bb"
 dependencies = [
  "async-channel 2.3.1",
- "async-io 2.3.4",
- "async-lock 3.4.0",
+ "async-io",
+ "async-lock",
  "async-signal",
  "async-task",
  "blocking",
  "cfg-if",
  "event-listener 5.3.1",
- "futures-lite 2.3.0",
+ "futures-lite",
  "rustix 0.38.37",
  "tracing",
 ]
@@ -1046,8 +962,8 @@ version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "637e00349800c0bdf8bfc21ebbc0b6524abea702b0da4168ac00d070d0c0b9f3"
 dependencies = [
- "async-io 2.3.4",
- "async-lock 3.4.0",
+ "async-io",
+ "async-lock",
  "atomic-waker",
  "cfg-if",
  "futures-core",
@@ -1056,32 +972,6 @@ dependencies = [
  "signal-hook-registry",
  "slab",
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "async-std"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c634475f29802fde2b8f0b505b1bd00dfe4df7d4a000f0b36f7671197d5c3615"
-dependencies = [
- "async-channel 1.9.0",
- "async-global-executor",
- "async-io 2.3.4",
- "async-lock 3.4.0",
- "crossbeam-utils",
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-lite 2.3.0",
- "gloo-timers",
- "kv-log-macro",
- "log",
- "memchr",
- "once_cell",
- "pin-project-lite",
- "pin-utils",
- "slab",
- "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -1141,17 +1031,6 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "attohttpc"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d9a9bf8b79a749ee0b911b91b671cc2b6c670bdbc7e3dfd537576ddc94bb2a2"
-dependencies = [
- "http 0.2.12",
- "log",
- "url",
-]
-
-[[package]]
-name = "attohttpc"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a13149d0cf3f7f9b9261fad4ec63b2efbf9a80665f52def86282d26255e6331"
@@ -1162,6 +1041,18 @@ dependencies = [
  "rustls 0.22.4",
  "url",
  "webpki-roots 0.26.6",
+]
+
+[[package]]
+name = "attohttpc"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16e2cdb6d5ed835199484bb92bb8b3edd526effe995c61732580439c1a67e2e9"
+dependencies = [
+ "base64 0.22.1",
+ "http 1.1.0",
+ "log",
+ "url",
 ]
 
 [[package]]
@@ -1358,7 +1249,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 [[package]]
 name = "binary-merkle-tree"
 version = "16.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "hash-db",
  "log",
@@ -1579,7 +1470,7 @@ dependencies = [
  "async-channel 2.3.1",
  "async-task",
  "futures-io",
- "futures-lite 2.3.0",
+ "futures-lite",
  "piper",
 ]
 
@@ -2483,7 +2374,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-parachain-inherent"
 version = "0.17.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2492,7 +2383,7 @@ dependencies = [
  "cumulus-test-relay-sproof-builder",
  "parity-scale-codec",
  "sc-client-api",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78)",
  "sp-inherents",
  "sp-runtime",
  "sp-state-machine",
@@ -2503,7 +2394,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-core"
 version = "0.18.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "parity-scale-codec",
  "polkadot-core-primitives",
@@ -2519,7 +2410,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-parachain-inherent"
 version = "0.18.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2533,7 +2424,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-proof-size-hostfunction"
 version = "0.12.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "sp-externalities",
  "sp-runtime-interface",
@@ -2543,7 +2434,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-storage-weight-reclaim"
 version = "11.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-proof-size-hostfunction",
@@ -2560,7 +2451,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-interface"
 version = "0.23.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2579,7 +2470,7 @@ dependencies = [
 [[package]]
 name = "cumulus-test-relay-sproof-builder"
 version = "0.19.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
@@ -3667,7 +3558,7 @@ dependencies = [
  "impl-serde",
  "primitive-types",
  "scale-info",
- "uint 0.10.0",
+ "uint",
 ]
 
 [[package]]
@@ -3675,17 +3566,6 @@ name = "event-listener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
-
-[[package]]
-name = "event-listener"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d93877bcde0eb80ca09131a08d23f0a5c18a620b01db137dba666d18cd9b30c2"
-dependencies = [
- "concurrent-queue",
- "parking",
- "pin-project-lite",
-]
 
 [[package]]
 name = "event-listener"
@@ -3935,15 +3815,6 @@ checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
 
 [[package]]
 name = "fastrand"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
-dependencies = [
- "instant",
-]
-
-[[package]]
-name = "fastrand"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
@@ -4102,7 +3973,7 @@ dependencies = [
  "rustc-hex",
  "serde",
  "serde_json",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78)",
 ]
 
 [[package]]
@@ -4233,7 +4104,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 [[package]]
 name = "fork-tree"
 version = "13.0.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -4361,7 +4232,7 @@ checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 [[package]]
 name = "frame-benchmarking"
 version = "40.2.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -4385,7 +4256,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "48.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "Inflector",
  "array-bytes",
@@ -4459,7 +4330,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "40.0.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "aquamarine",
  "frame-support",
@@ -4501,7 +4372,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "40.1.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "aquamarine",
  "array-bytes",
@@ -4542,7 +4413,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "33.0.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -4555,14 +4426,14 @@ dependencies = [
  "proc-macro-warning",
  "proc-macro2",
  "quote",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78)",
  "syn 2.0.111",
 ]
 
 [[package]]
 name = "frame-support-procedural-tools"
 version = "13.0.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate 3.2.0",
@@ -4574,7 +4445,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "12.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4584,7 +4455,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "40.2.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "cfg-if",
  "docify",
@@ -4603,7 +4474,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "40.0.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4617,7 +4488,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "36.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "docify",
  "parity-scale-codec",
@@ -4627,7 +4498,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.46.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -4697,9 +4568,8 @@ dependencies = [
 
 [[package]]
 name = "futures-bounded"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91f328e7fb845fc832912fb6a34f40cf6d1888c92f974d1893a54e97b5ff542e"
+version = "0.3.0"
+source = "git+https://github.com/thomaseizinger/rust-futures-bounded?rev=012803d343b5c604e65d3c238a8cd7a145616447#012803d343b5c604e65d3c238a8cd7a145616447"
 dependencies = [
  "futures-timer",
  "futures-util",
@@ -4741,26 +4611,11 @@ checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-lite"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce"
-dependencies = [
- "fastrand 1.9.0",
- "futures-core",
- "futures-io",
- "memchr",
- "parking",
- "pin-project-lite",
- "waker-fn",
-]
-
-[[package]]
-name = "futures-lite"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52527eb5074e35e9339c6b4e8d12600c7128b68fb25dcb9fa9dec18f7c25f3a5"
 dependencies = [
- "fastrand 2.1.1",
+ "fastrand",
  "futures-core",
  "futures-io",
  "parking",
@@ -4907,9 +4762,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasi 0.14.2+wasi-0.2.4",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -4958,18 +4815,6 @@ name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
-
-[[package]]
-name = "gloo-timers"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
-dependencies = [
- "futures-channel",
- "futures-core",
- "js-sys",
- "wasm-bindgen",
-]
 
 [[package]]
 name = "governor"
@@ -5124,6 +4969,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5185,31 +5039,6 @@ checksum = "b07f60793ff0a4d9cef0f18e63b5357e06209987153a64648c972c1e5aff336f"
 
 [[package]]
 name = "hickory-proto"
-version = "0.24.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92652067c9ce6f66ce53cc38d1169daa36e6e7eb7dd3b63b5103bd9d97117248"
-dependencies = [
- "async-trait",
- "cfg-if",
- "data-encoding",
- "enum-as-inner",
- "futures-channel",
- "futures-io",
- "futures-util",
- "idna",
- "ipnet",
- "once_cell",
- "rand 0.8.5",
- "socket2 0.5.9",
- "thiserror 1.0.64",
- "tinyvec",
- "tokio",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "hickory-proto"
 version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
@@ -5226,32 +5055,12 @@ dependencies = [
  "once_cell",
  "rand 0.9.0",
  "ring 0.17.13",
+ "socket2",
  "thiserror 2.0.12",
  "tinyvec",
  "tokio",
  "tracing",
  "url",
-]
-
-[[package]]
-name = "hickory-resolver"
-version = "0.24.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbb117a1ca520e111743ab2f6688eddee69db4e0ea242545a604dce8a66fd22e"
-dependencies = [
- "cfg-if",
- "futures-util",
- "hickory-proto 0.24.4",
- "ipconfig",
- "lru-cache",
- "once_cell",
- "parking_lot 0.12.3",
- "rand 0.8.5",
- "resolv-conf",
- "smallvec",
- "thiserror 1.0.64",
- "tokio",
- "tracing",
 ]
 
 [[package]]
@@ -5262,7 +5071,7 @@ checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
 dependencies = [
  "cfg-if",
  "futures-util",
- "hickory-proto 0.25.2",
+ "hickory-proto",
  "ipconfig",
  "moka",
  "once_cell",
@@ -5496,7 +5305,7 @@ dependencies = [
  "http-body",
  "hyper",
  "pin-project-lite",
- "socket2 0.5.9",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -5682,19 +5491,22 @@ dependencies = [
 
 [[package]]
 name = "if-watch"
-version = "3.2.0"
+version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6b0422c86d7ce0e97169cc42e04ae643caf278874a7a3c87b8150a220dc7e1e"
+checksum = "cdf9d64cfcf380606e64f9a0bcf493616b65331199f984151a6fa11a7b3cde38"
 dependencies = [
- "async-io 2.3.4",
+ "async-io",
  "core-foundation 0.9.4",
  "fnv",
  "futures",
  "if-addrs",
  "ipnet",
  "log",
+ "netlink-packet-core",
+ "netlink-packet-route",
+ "netlink-proto",
+ "netlink-sys",
  "rtnetlink",
- "smol 1.3.0",
  "system-configuration",
  "tokio",
  "windows 0.51.1",
@@ -5702,12 +5514,12 @@ dependencies = [
 
 [[package]]
 name = "igd-next"
-version = "0.15.1"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76b0d7d4541def58a37bf8efc559683f21edce7c82f0d866c93ac21f7e098f93"
+checksum = "516893339c97f6011282d5825ac94fc1c7aad5cad26bdc2d0cee068c0bf97f97"
 dependencies = [
  "async-trait",
- "attohttpc 0.24.1",
+ "attohttpc 0.30.1",
  "bytes",
  "futures",
  "http 1.1.0",
@@ -5715,7 +5527,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "log",
- "rand 0.8.5",
+ "rand 0.9.0",
  "tokio",
  "url",
  "xmltree",
@@ -5744,7 +5556,7 @@ checksum = "803d15461ab0dcc56706adf266158acbc44ccf719bf7d0af30705f58b90a4b8c"
 dependencies = [
  "integer-sqrt",
  "num-traits",
- "uint 0.10.0",
+ "uint",
 ]
 
 [[package]]
@@ -5882,7 +5694,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
 dependencies = [
- "socket2 0.5.9",
+ "socket2",
  "widestring",
  "windows-sys 0.48.0",
  "winreg",
@@ -5992,10 +5804,11 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.70"
+version = "0.3.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
+checksum = "464a3709c7f55f1f721e5389aa6ea4e3bc6aba669353300af094b29ffbdde1d8"
 dependencies = [
+ "once_cell",
  "wasm-bindgen",
 ]
 
@@ -6169,15 +5982,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33070833c9ee02266356de0c43f723152bd38bd96ddf52c82b3af10c9138b28"
 
 [[package]]
-name = "kv-log-macro"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
-dependencies = [
- "log",
-]
-
-[[package]]
 name = "kvdb"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6245,8 +6049,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p"
-version = "0.54.2"
-source = "git+https://github.com/subspace/rust-libp2p?rev=4ff21ede371f14ea0b90075f676ae21239ef8fbf#4ff21ede371f14ea0b90075f676ae21239ef8fbf"
+version = "0.56.0"
+source = "git+https://github.com/subspace/rust-libp2p?rev=0c2e22fe724e5101bc5ad5763b1c3d7aa452870a#0c2e22fe724e5101bc5ad5763b1c3d7aa452870a"
 dependencies = [
  "bytes",
  "either",
@@ -6282,8 +6086,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-allow-block-list"
-version = "0.4.2"
-source = "git+https://github.com/subspace/rust-libp2p?rev=4ff21ede371f14ea0b90075f676ae21239ef8fbf#4ff21ede371f14ea0b90075f676ae21239ef8fbf"
+version = "0.6.0"
+source = "git+https://github.com/subspace/rust-libp2p?rev=0c2e22fe724e5101bc5ad5763b1c3d7aa452870a#0c2e22fe724e5101bc5ad5763b1c3d7aa452870a"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
@@ -6292,12 +6096,11 @@ dependencies = [
 
 [[package]]
 name = "libp2p-autonat"
-version = "0.13.1"
-source = "git+https://github.com/subspace/rust-libp2p?rev=4ff21ede371f14ea0b90075f676ae21239ef8fbf#4ff21ede371f14ea0b90075f676ae21239ef8fbf"
+version = "0.15.0"
+source = "git+https://github.com/subspace/rust-libp2p?rev=0c2e22fe724e5101bc5ad5763b1c3d7aa452870a#0c2e22fe724e5101bc5ad5763b1c3d7aa452870a"
 dependencies = [
  "async-trait",
  "asynchronous-codec 0.7.0",
- "bytes",
  "either",
  "futures",
  "futures-bounded",
@@ -6317,8 +6120,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-connection-limits"
-version = "0.4.1"
-source = "git+https://github.com/subspace/rust-libp2p?rev=4ff21ede371f14ea0b90075f676ae21239ef8fbf#4ff21ede371f14ea0b90075f676ae21239ef8fbf"
+version = "0.6.0"
+source = "git+https://github.com/subspace/rust-libp2p?rev=0c2e22fe724e5101bc5ad5763b1c3d7aa452870a#0c2e22fe724e5101bc5ad5763b1c3d7aa452870a"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
@@ -6327,8 +6130,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-core"
-version = "0.42.1"
-source = "git+https://github.com/subspace/rust-libp2p?rev=4ff21ede371f14ea0b90075f676ae21239ef8fbf#4ff21ede371f14ea0b90075f676ae21239ef8fbf"
+version = "0.43.1"
+source = "git+https://github.com/subspace/rust-libp2p?rev=0c2e22fe724e5101bc5ad5763b1c3d7aa452870a#0c2e22fe724e5101bc5ad5763b1c3d7aa452870a"
 dependencies = [
  "either",
  "fnv",
@@ -6338,14 +6141,11 @@ dependencies = [
  "multiaddr 0.18.2",
  "multihash 0.19.1",
  "multistream-select",
- "once_cell",
  "parking_lot 0.12.3",
  "pin-project",
  "quick-protobuf",
  "rand 0.8.5",
  "rw-stream-sink",
- "serde",
- "smallvec",
  "thiserror 2.0.12",
  "tracing",
  "unsigned-varint 0.8.0",
@@ -6354,12 +6154,12 @@ dependencies = [
 
 [[package]]
 name = "libp2p-dns"
-version = "0.42.0"
-source = "git+https://github.com/subspace/rust-libp2p?rev=4ff21ede371f14ea0b90075f676ae21239ef8fbf#4ff21ede371f14ea0b90075f676ae21239ef8fbf"
+version = "0.44.0"
+source = "git+https://github.com/subspace/rust-libp2p?rev=0c2e22fe724e5101bc5ad5763b1c3d7aa452870a#0c2e22fe724e5101bc5ad5763b1c3d7aa452870a"
 dependencies = [
  "async-trait",
  "futures",
- "hickory-resolver 0.24.4",
+ "hickory-resolver",
  "libp2p-core",
  "libp2p-identity",
  "parking_lot 0.12.3",
@@ -6369,8 +6169,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-gossipsub"
-version = "0.48.0"
-source = "git+https://github.com/subspace/rust-libp2p?rev=4ff21ede371f14ea0b90075f676ae21239ef8fbf#4ff21ede371f14ea0b90075f676ae21239ef8fbf"
+version = "0.49.0"
+source = "git+https://github.com/subspace/rust-libp2p?rev=0c2e22fe724e5101bc5ad5763b1c3d7aa452870a#0c2e22fe724e5101bc5ad5763b1c3d7aa452870a"
 dependencies = [
  "async-channel 2.3.1",
  "asynchronous-codec 0.7.0",
@@ -6382,26 +6182,25 @@ dependencies = [
  "futures",
  "futures-timer",
  "getrandom 0.2.15",
+ "hashlink 0.9.1",
  "hex_fmt",
  "libp2p-core",
  "libp2p-identity",
  "libp2p-swarm",
- "prometheus-client",
  "quick-protobuf",
  "quick-protobuf-codec",
  "rand 0.8.5",
  "regex",
  "serde",
  "sha2 0.10.8",
- "smallvec",
  "tracing",
  "web-time",
 ]
 
 [[package]]
 name = "libp2p-identify"
-version = "0.46.0"
-source = "git+https://github.com/subspace/rust-libp2p?rev=4ff21ede371f14ea0b90075f676ae21239ef8fbf#4ff21ede371f14ea0b90075f676ae21239ef8fbf"
+version = "0.47.0"
+source = "git+https://github.com/subspace/rust-libp2p?rev=0c2e22fe724e5101bc5ad5763b1c3d7aa452870a#0c2e22fe724e5101bc5ad5763b1c3d7aa452870a"
 dependencies = [
  "asynchronous-codec 0.7.0",
  "either",
@@ -6411,7 +6210,6 @@ dependencies = [
  "libp2p-core",
  "libp2p-identity",
  "libp2p-swarm",
- "lru",
  "quick-protobuf",
  "quick-protobuf-codec",
  "smallvec",
@@ -6421,8 +6219,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-identity"
-version = "0.2.10"
-source = "git+https://github.com/subspace/rust-libp2p?rev=4ff21ede371f14ea0b90075f676ae21239ef8fbf#4ff21ede371f14ea0b90075f676ae21239ef8fbf"
+version = "0.2.12"
+source = "git+https://github.com/subspace/rust-libp2p?rev=0c2e22fe724e5101bc5ad5763b1c3d7aa452870a#0c2e22fe724e5101bc5ad5763b1c3d7aa452870a"
 dependencies = [
  "bs58",
  "ed25519-dalek",
@@ -6439,10 +6237,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-kad"
-version = "0.47.0"
-source = "git+https://github.com/subspace/rust-libp2p?rev=4ff21ede371f14ea0b90075f676ae21239ef8fbf#4ff21ede371f14ea0b90075f676ae21239ef8fbf"
+version = "0.48.0"
+source = "git+https://github.com/subspace/rust-libp2p?rev=0c2e22fe724e5101bc5ad5763b1c3d7aa452870a#0c2e22fe724e5101bc5ad5763b1c3d7aa452870a"
 dependencies = [
- "arrayvec 0.7.6",
  "asynchronous-codec 0.7.0",
  "bytes",
  "either",
@@ -6461,33 +6258,32 @@ dependencies = [
  "smallvec",
  "thiserror 2.0.12",
  "tracing",
- "uint 0.9.5",
+ "uint",
  "web-time",
 ]
 
 [[package]]
 name = "libp2p-mdns"
-version = "0.46.0"
-source = "git+https://github.com/subspace/rust-libp2p?rev=4ff21ede371f14ea0b90075f676ae21239ef8fbf#4ff21ede371f14ea0b90075f676ae21239ef8fbf"
+version = "0.48.0"
+source = "git+https://github.com/subspace/rust-libp2p?rev=0c2e22fe724e5101bc5ad5763b1c3d7aa452870a#0c2e22fe724e5101bc5ad5763b1c3d7aa452870a"
 dependencies = [
- "data-encoding",
  "futures",
- "hickory-proto 0.24.4",
+ "hickory-proto",
  "if-watch",
  "libp2p-core",
  "libp2p-identity",
  "libp2p-swarm",
  "rand 0.8.5",
  "smallvec",
- "socket2 0.5.9",
+ "socket2",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "libp2p-metrics"
-version = "0.15.0"
-source = "git+https://github.com/subspace/rust-libp2p?rev=4ff21ede371f14ea0b90075f676ae21239ef8fbf#4ff21ede371f14ea0b90075f676ae21239ef8fbf"
+version = "0.17.0"
+source = "git+https://github.com/subspace/rust-libp2p?rev=0c2e22fe724e5101bc5ad5763b1c3d7aa452870a#0c2e22fe724e5101bc5ad5763b1c3d7aa452870a"
 dependencies = [
  "futures",
  "libp2p-core",
@@ -6504,21 +6300,18 @@ dependencies = [
 
 [[package]]
 name = "libp2p-noise"
-version = "0.45.0"
-source = "git+https://github.com/subspace/rust-libp2p?rev=4ff21ede371f14ea0b90075f676ae21239ef8fbf#4ff21ede371f14ea0b90075f676ae21239ef8fbf"
+version = "0.46.1"
+source = "git+https://github.com/subspace/rust-libp2p?rev=0c2e22fe724e5101bc5ad5763b1c3d7aa452870a#0c2e22fe724e5101bc5ad5763b1c3d7aa452870a"
 dependencies = [
  "asynchronous-codec 0.7.0",
  "bytes",
- "curve25519-dalek",
  "futures",
  "libp2p-core",
  "libp2p-identity",
  "multiaddr 0.18.2",
  "multihash 0.19.1",
- "once_cell",
  "quick-protobuf",
  "rand 0.8.5",
- "sha2 0.10.8",
  "snow",
  "static_assertions",
  "thiserror 2.0.12",
@@ -6529,10 +6322,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-ping"
-version = "0.45.1"
-source = "git+https://github.com/subspace/rust-libp2p?rev=4ff21ede371f14ea0b90075f676ae21239ef8fbf#4ff21ede371f14ea0b90075f676ae21239ef8fbf"
+version = "0.47.0"
+source = "git+https://github.com/subspace/rust-libp2p?rev=0c2e22fe724e5101bc5ad5763b1c3d7aa452870a#0c2e22fe724e5101bc5ad5763b1c3d7aa452870a"
 dependencies = [
- "either",
  "futures",
  "futures-timer",
  "libp2p-core",
@@ -6545,8 +6337,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-plaintext"
-version = "0.42.0"
-source = "git+https://github.com/subspace/rust-libp2p?rev=4ff21ede371f14ea0b90075f676ae21239ef8fbf#4ff21ede371f14ea0b90075f676ae21239ef8fbf"
+version = "0.43.0"
+source = "git+https://github.com/subspace/rust-libp2p?rev=0c2e22fe724e5101bc5ad5763b1c3d7aa452870a#0c2e22fe724e5101bc5ad5763b1c3d7aa452870a"
 dependencies = [
  "asynchronous-codec 0.7.0",
  "bytes",
@@ -6560,22 +6352,20 @@ dependencies = [
 
 [[package]]
 name = "libp2p-quic"
-version = "0.11.2"
-source = "git+https://github.com/subspace/rust-libp2p?rev=4ff21ede371f14ea0b90075f676ae21239ef8fbf#4ff21ede371f14ea0b90075f676ae21239ef8fbf"
+version = "0.13.0"
+source = "git+https://github.com/subspace/rust-libp2p?rev=0c2e22fe724e5101bc5ad5763b1c3d7aa452870a#0c2e22fe724e5101bc5ad5763b1c3d7aa452870a"
 dependencies = [
- "bytes",
  "futures",
  "futures-timer",
  "if-watch",
  "libp2p-core",
  "libp2p-identity",
  "libp2p-tls",
- "parking_lot 0.12.3",
  "quinn",
  "rand 0.8.5",
  "ring 0.17.13",
  "rustls 0.23.35",
- "socket2 0.5.9",
+ "socket2",
  "thiserror 2.0.12",
  "tokio",
  "tracing",
@@ -6583,28 +6373,25 @@ dependencies = [
 
 [[package]]
 name = "libp2p-request-response"
-version = "0.28.0"
-source = "git+https://github.com/subspace/rust-libp2p?rev=4ff21ede371f14ea0b90075f676ae21239ef8fbf#4ff21ede371f14ea0b90075f676ae21239ef8fbf"
+version = "0.29.0"
+source = "git+https://github.com/subspace/rust-libp2p?rev=0c2e22fe724e5101bc5ad5763b1c3d7aa452870a#0c2e22fe724e5101bc5ad5763b1c3d7aa452870a"
 dependencies = [
  "async-trait",
  "futures",
  "futures-bounded",
- "futures-timer",
  "libp2p-core",
  "libp2p-identity",
  "libp2p-swarm",
  "rand 0.8.5",
  "smallvec",
  "tracing",
- "web-time",
 ]
 
 [[package]]
 name = "libp2p-swarm"
-version = "0.45.2"
-source = "git+https://github.com/subspace/rust-libp2p?rev=4ff21ede371f14ea0b90075f676ae21239ef8fbf#4ff21ede371f14ea0b90075f676ae21239ef8fbf"
+version = "0.47.0"
+source = "git+https://github.com/subspace/rust-libp2p?rev=0c2e22fe724e5101bc5ad5763b1c3d7aa452870a#0c2e22fe724e5101bc5ad5763b1c3d7aa452870a"
 dependencies = [
- "async-std",
  "either",
  "fnv",
  "futures",
@@ -6614,7 +6401,6 @@ dependencies = [
  "libp2p-swarm-derive",
  "lru",
  "multistream-select",
- "once_cell",
  "rand 0.8.5",
  "smallvec",
  "tokio",
@@ -6624,19 +6410,18 @@ dependencies = [
 
 [[package]]
 name = "libp2p-swarm-derive"
-version = "0.35.0"
-source = "git+https://github.com/subspace/rust-libp2p?rev=4ff21ede371f14ea0b90075f676ae21239ef8fbf#4ff21ede371f14ea0b90075f676ae21239ef8fbf"
+version = "0.35.1"
+source = "git+https://github.com/subspace/rust-libp2p?rev=0c2e22fe724e5101bc5ad5763b1c3d7aa452870a#0c2e22fe724e5101bc5ad5763b1c3d7aa452870a"
 dependencies = [
  "heck 0.5.0",
- "proc-macro2",
  "quote",
  "syn 2.0.111",
 ]
 
 [[package]]
 name = "libp2p-swarm-test"
-version = "0.5.0"
-source = "git+https://github.com/subspace/rust-libp2p?rev=4ff21ede371f14ea0b90075f676ae21239ef8fbf#4ff21ede371f14ea0b90075f676ae21239ef8fbf"
+version = "0.6.0"
+source = "git+https://github.com/subspace/rust-libp2p?rev=0c2e22fe724e5101bc5ad5763b1c3d7aa452870a#0c2e22fe724e5101bc5ad5763b1c3d7aa452870a"
 dependencies = [
  "async-trait",
  "futures",
@@ -6647,31 +6432,28 @@ dependencies = [
  "libp2p-swarm",
  "libp2p-tcp",
  "libp2p-yamux",
- "rand 0.8.5",
  "tracing",
 ]
 
 [[package]]
 name = "libp2p-tcp"
-version = "0.42.0"
-source = "git+https://github.com/subspace/rust-libp2p?rev=4ff21ede371f14ea0b90075f676ae21239ef8fbf#4ff21ede371f14ea0b90075f676ae21239ef8fbf"
+version = "0.44.0"
+source = "git+https://github.com/subspace/rust-libp2p?rev=0c2e22fe724e5101bc5ad5763b1c3d7aa452870a#0c2e22fe724e5101bc5ad5763b1c3d7aa452870a"
 dependencies = [
- "async-io 2.3.4",
  "futures",
  "futures-timer",
  "if-watch",
  "libc",
  "libp2p-core",
- "libp2p-identity",
- "socket2 0.5.9",
+ "socket2",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "libp2p-tls"
-version = "0.5.0"
-source = "git+https://github.com/subspace/rust-libp2p?rev=4ff21ede371f14ea0b90075f676ae21239ef8fbf#4ff21ede371f14ea0b90075f676ae21239ef8fbf"
+version = "0.6.2"
+source = "git+https://github.com/subspace/rust-libp2p?rev=0c2e22fe724e5101bc5ad5763b1c3d7aa452870a#0c2e22fe724e5101bc5ad5763b1c3d7aa452870a"
 dependencies = [
  "futures",
  "futures-rustls",
@@ -6680,16 +6462,16 @@ dependencies = [
  "rcgen",
  "ring 0.17.13",
  "rustls 0.23.35",
- "rustls-webpki 0.101.7",
+ "rustls-webpki 0.103.8",
  "thiserror 2.0.12",
- "x509-parser 0.16.0",
+ "x509-parser 0.17.0",
  "yasna",
 ]
 
 [[package]]
 name = "libp2p-upnp"
-version = "0.3.1"
-source = "git+https://github.com/subspace/rust-libp2p?rev=4ff21ede371f14ea0b90075f676ae21239ef8fbf#4ff21ede371f14ea0b90075f676ae21239ef8fbf"
+version = "0.5.0"
+source = "git+https://github.com/subspace/rust-libp2p?rev=0c2e22fe724e5101bc5ad5763b1c3d7aa452870a#0c2e22fe724e5101bc5ad5763b1c3d7aa452870a"
 dependencies = [
  "futures",
  "futures-timer",
@@ -6702,8 +6484,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-websocket"
-version = "0.44.1"
-source = "git+https://github.com/subspace/rust-libp2p?rev=4ff21ede371f14ea0b90075f676ae21239ef8fbf#4ff21ede371f14ea0b90075f676ae21239ef8fbf"
+version = "0.45.1"
+source = "git+https://github.com/subspace/rust-libp2p?rev=0c2e22fe724e5101bc5ad5763b1c3d7aa452870a#0c2e22fe724e5101bc5ad5763b1c3d7aa452870a"
 dependencies = [
  "either",
  "futures",
@@ -6717,13 +6499,13 @@ dependencies = [
  "thiserror 2.0.12",
  "tracing",
  "url",
- "webpki-roots 0.25.4",
+ "webpki-roots 0.26.6",
 ]
 
 [[package]]
 name = "libp2p-yamux"
-version = "0.46.0"
-source = "git+https://github.com/subspace/rust-libp2p?rev=4ff21ede371f14ea0b90075f676ae21239ef8fbf#4ff21ede371f14ea0b90075f676ae21239ef8fbf"
+version = "0.47.0"
+source = "git+https://github.com/subspace/rust-libp2p?rev=0c2e22fe724e5101bc5ad5763b1c3d7aa452870a#0c2e22fe724e5101bc5ad5763b1c3d7aa452870a"
 dependencies = [
  "either",
  "futures",
@@ -6834,12 +6616,6 @@ checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
-
-[[package]]
-name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
@@ -6875,7 +6651,7 @@ dependencies = [
  "ed25519-dalek",
  "futures",
  "futures-timer",
- "hickory-resolver 0.25.2",
+ "hickory-resolver",
  "indexmap 2.9.0",
  "libc",
  "mockall",
@@ -6892,14 +6668,14 @@ dependencies = [
  "simple-dns",
  "smallvec",
  "snow",
- "socket2 0.5.9",
+ "socket2",
  "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
  "tokio-tungstenite",
  "tokio-util",
  "tracing",
- "uint 0.10.0",
+ "uint",
  "unsigned-varint 0.8.0",
  "url",
  "x25519-dalek",
@@ -6941,9 +6717,6 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
-dependencies = [
- "value-bag",
-]
 
 [[package]]
 name = "loom"
@@ -6968,13 +6741,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "lru-cache"
+name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
-dependencies = [
- "linked-hash-map",
-]
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lz4"
@@ -7196,7 +6966,7 @@ dependencies = [
  "c2-chacha",
  "curve25519-dalek",
  "either",
- "hashlink",
+ "hashlink 0.8.4",
  "lioness",
  "log",
  "parking_lot 0.12.3",
@@ -7211,7 +6981,7 @@ dependencies = [
 [[package]]
 name = "mmr-gadget"
 version = "45.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "futures",
  "log",
@@ -7230,7 +7000,7 @@ dependencies = [
 [[package]]
 name = "mmr-rpc"
 version = "40.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -7394,7 +7164,7 @@ checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
 [[package]]
 name = "multistream-select"
 version = "0.13.0"
-source = "git+https://github.com/subspace/rust-libp2p?rev=4ff21ede371f14ea0b90075f676ae21239ef8fbf#4ff21ede371f14ea0b90075f676ae21239ef8fbf"
+source = "git+https://github.com/subspace/rust-libp2p?rev=0c2e22fe724e5101bc5ad5763b1c3d7aa452870a#0c2e22fe724e5101bc5ad5763b1c3d7aa452870a"
 dependencies = [
  "bytes",
  "futures",
@@ -7448,21 +7218,20 @@ checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
 
 [[package]]
 name = "netlink-packet-core"
-version = "0.4.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "345b8ab5bd4e71a2986663e88c56856699d060e78e152e6e9d7966fcd5491297"
+checksum = "72724faf704479d67b388da142b186f916188505e7e0b26719019c525882eda4"
 dependencies = [
  "anyhow",
  "byteorder",
- "libc",
  "netlink-packet-utils",
 ]
 
 [[package]]
 name = "netlink-packet-route"
-version = "0.12.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9ea4302b9759a7a88242299225ea3688e63c85ea136371bb6cf94fd674efaab"
+checksum = "053998cea5a306971f88580d0829e90f270f940befd7cf928da179d4187a5a66"
 dependencies = [
  "anyhow",
  "bitflags 1.3.2",
@@ -7486,17 +7255,16 @@ dependencies = [
 
 [[package]]
 name = "netlink-proto"
-version = "0.10.0"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65b4b14489ab424703c092062176d52ba55485a89c076b4f9db05092b7223aa6"
+checksum = "72452e012c2f8d612410d89eea01e2d9b56205274abb35d53f60200b2ec41d60"
 dependencies = [
  "bytes",
  "futures",
  "log",
  "netlink-packet-core",
  "netlink-sys",
- "thiserror 1.0.64",
- "tokio",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -7505,7 +7273,6 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "416060d346fbaf1f23f9512963e3e878f1a78e707cb699ba9215761754244307"
 dependencies = [
- "async-io 1.13.0",
  "bytes",
  "futures",
  "libc",
@@ -7527,9 +7294,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.24.3"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa52e972a9a719cecb6864fb88568781eb706bac2cd1d4f04a648542dbf78069"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
 dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
@@ -7922,7 +7689,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "41.1.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -7954,7 +7721,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "40.1.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -7971,7 +7738,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "40.1.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8190,7 +7957,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr"
 version = "40.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -8202,7 +7969,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "40.1.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -8213,7 +7980,7 @@ dependencies = [
 [[package]]
 name = "pallet-preimage"
 version = "40.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8262,7 +8029,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "41.2.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8338,7 +8105,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "40.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8353,7 +8120,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "39.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8383,7 +8150,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "40.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8399,7 +8166,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "43.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -8415,7 +8182,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "40.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -8448,7 +8215,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "40.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8736,7 +8503,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
 dependencies = [
  "atomic-waker",
- "fastrand 2.1.1",
+ "fastrand",
  "futures-io",
 ]
 
@@ -8769,7 +8536,7 @@ dependencies = [
 [[package]]
 name = "polkadot-core-primitives"
 version = "17.1.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -8780,7 +8547,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-metrics"
 version = "23.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "bs58",
  "futures",
@@ -8797,7 +8564,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-network-protocol"
 version = "23.1.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -8822,7 +8589,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-primitives"
 version = "19.1.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "bitvec",
  "bounded-vec",
@@ -8846,7 +8613,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-types"
 version = "23.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "async-trait",
  "derive_more 0.99.18",
@@ -8874,7 +8641,7 @@ dependencies = [
 [[package]]
 name = "polkadot-overseer"
 version = "23.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "async-trait",
  "futures",
@@ -8894,7 +8661,7 @@ dependencies = [
 [[package]]
 name = "polkadot-parachain-primitives"
 version = "16.1.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "bounded-collections",
  "derive_more 0.99.18",
@@ -8910,7 +8677,7 @@ dependencies = [
 [[package]]
 name = "polkadot-primitives"
 version = "18.2.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "bitvec",
  "hex-literal",
@@ -8947,7 +8714,7 @@ dependencies = [
 [[package]]
 name = "polkadot-sdk-frame"
 version = "0.9.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8982,7 +8749,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-table"
 version = "19.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
@@ -9073,22 +8840,6 @@ name = "polkavm-linux-raw"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23eff02c070c70f31878a3d915e88a914ecf3e153741e2fb572dde28cce20fde"
-
-[[package]]
-name = "polling"
-version = "2.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b2d323e8ca7996b3e23126511a523f7e62924d93ecd5ae73b333815b0eb3dce"
-dependencies = [
- "autocfg",
- "bitflags 1.3.2",
- "cfg-if",
- "concurrent-queue",
- "libc",
- "log",
- "pin-project-lite",
- "windows-sys 0.48.0",
-]
 
 [[package]]
 name = "polling"
@@ -9183,7 +8934,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78)",
  "syn 2.0.111",
 ]
 
@@ -9235,7 +8986,7 @@ dependencies = [
  "impl-rlp",
  "impl-serde",
  "scale-info",
- "uint 0.10.0",
+ "uint",
 ]
 
 [[package]]
@@ -9368,9 +9119,9 @@ dependencies = [
 
 [[package]]
 name = "prometheus-client"
-version = "0.22.3"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "504ee9ff529add891127c4827eb481bd69dc0ebc72e9a682e187db4caa60c3ca"
+checksum = "cf41c1a7c32ed72abe5082fb19505b969095c12da9f5732a4bc9878757fd087c"
 dependencies = [
  "dtoa",
  "itoa",
@@ -9535,7 +9286,7 @@ dependencies = [
 [[package]]
 name = "quick-protobuf-codec"
 version = "0.3.1"
-source = "git+https://github.com/subspace/rust-libp2p?rev=4ff21ede371f14ea0b90075f676ae21239ef8fbf#4ff21ede371f14ea0b90075f676ae21239ef8fbf"
+source = "git+https://github.com/subspace/rust-libp2p?rev=0c2e22fe724e5101bc5ad5763b1c3d7aa452870a#0c2e22fe724e5101bc5ad5763b1c3d7aa452870a"
 dependencies = [
  "asynchronous-codec 0.7.0",
  "bytes",
@@ -9546,9 +9297,9 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c7c5fdde3cdae7203427dc4f0a68fe0ed09833edc525a03456b153b79828684"
+checksum = "62e96808277ec6f97351a2380e6c25114bc9e67037775464979f3037c92d05ef"
 dependencies = [
  "bytes",
  "futures-io",
@@ -9557,27 +9308,31 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.0.0",
  "rustls 0.23.35",
- "socket2 0.5.9",
- "thiserror 1.0.64",
+ "socket2",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.8"
+version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fadfaed2cd7f389d0161bb73eeb07b7b78f8691047a6f3e73caaeae55310a4a6"
+checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
 dependencies = [
  "bytes",
- "rand 0.8.5",
+ "getrandom 0.3.2",
+ "lru-slab",
+ "rand 0.9.0",
  "ring 0.17.13",
  "rustc-hash 2.0.0",
  "rustls 0.23.35",
+ "rustls-pki-types",
  "slab",
- "thiserror 1.0.64",
+ "thiserror 2.0.12",
  "tinyvec",
  "tracing",
+ "web-time",
 ]
 
 [[package]]
@@ -9588,7 +9343,7 @@ checksum = "4fe68c2e9e1a1234e218683dbdf9f9dfcb094113c5ac2b938dfcb9bab4c4140b"
 dependencies = [
  "libc",
  "once_cell",
- "socket2 0.5.9",
+ "socket2",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -9739,12 +9494,13 @@ dependencies = [
 
 [[package]]
 name = "rcgen"
-version = "0.11.3"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52c4f3084aa3bc7dfbba4eff4fab2a54db4324965d8872ab933565e6fbd83bc6"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
 dependencies = [
  "pem",
- "ring 0.16.20",
+ "ring 0.17.13",
+ "rustls-pki-types",
  "time",
  "yasna",
 ]
@@ -10008,15 +9764,17 @@ dependencies = [
 
 [[package]]
 name = "rtnetlink"
-version = "0.10.1"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "322c53fd76a18698f1c27381d58091de3a043d356aa5bd0d510608b565f469a0"
+checksum = "7a552eb82d19f38c3beed3f786bd23aa434ceb9ac43ab44419ca6d67a7e186c0"
 dependencies = [
- "async-global-executor",
  "futures",
  "log",
+ "netlink-packet-core",
  "netlink-packet-route",
+ "netlink-packet-utils",
  "netlink-proto",
+ "netlink-sys",
  "nix",
  "thiserror 1.0.64",
  "tokio",
@@ -10101,20 +9859,6 @@ dependencies = [
  "libc",
  "linux-raw-sys 0.1.4",
  "windows-sys 0.45.0",
-]
-
-[[package]]
-name = "rustix"
-version = "0.37.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fea8ca367a3a01fe35e6943c400addf443c0f57670e6ec51196f71a4b8762dd2"
-dependencies = [
- "bitflags 1.3.2",
- "errno",
- "io-lifetimes",
- "libc",
- "linux-raw-sys 0.3.8",
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -10211,6 +9955,7 @@ version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "708c0f9d5f54ba0272468c1d306a52c495b31fa155e91bc25371e6df7996908c"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -10240,16 +9985,6 @@ name = "rustls-platform-verifier-android"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
-
-[[package]]
-name = "rustls-webpki"
-version = "0.101.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
-dependencies = [
- "ring 0.17.13",
- "untrusted 0.9.0",
-]
 
 [[package]]
 name = "rustls-webpki"
@@ -10304,7 +10039,7 @@ dependencies = [
 [[package]]
 name = "rw-stream-sink"
 version = "0.4.0"
-source = "git+https://github.com/subspace/rust-libp2p?rev=4ff21ede371f14ea0b90075f676ae21239ef8fbf#4ff21ede371f14ea0b90075f676ae21239ef8fbf"
+source = "git+https://github.com/subspace/rust-libp2p?rev=0c2e22fe724e5101bc5ad5763b1c3d7aa452870a#0c2e22fe724e5101bc5ad5763b1c3d7aa452870a"
 dependencies = [
  "futures",
  "pin-project",
@@ -10347,7 +10082,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "31.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "log",
  "sp-core",
@@ -10358,7 +10093,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.50.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "async-trait",
  "futures",
@@ -10386,7 +10121,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.49.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "futures",
  "log",
@@ -10407,7 +10142,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.44.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -10422,7 +10157,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "43.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "array-bytes",
  "docify",
@@ -10437,7 +10172,7 @@ dependencies = [
  "serde_json",
  "sp-blockchain",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78)",
  "sp-genesis-builder",
  "sp-io",
  "sp-runtime",
@@ -10448,7 +10183,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "12.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
@@ -10459,7 +10194,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.52.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "array-bytes",
  "chrono",
@@ -10501,7 +10236,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "39.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "fnv",
  "futures",
@@ -10527,7 +10262,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.46.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -10552,7 +10287,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.49.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "async-trait",
  "futures",
@@ -10575,7 +10310,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.49.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "async-trait",
  "futures",
@@ -10705,7 +10440,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.42.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
@@ -10728,7 +10463,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.38.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "polkavm",
  "sc-allocator",
@@ -10741,7 +10476,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-polkavm"
 version = "0.35.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "log",
  "polkavm",
@@ -10752,7 +10487,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.38.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "anyhow",
  "log",
@@ -10768,7 +10503,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.49.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "console",
  "futures",
@@ -10784,7 +10519,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "35.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "array-bytes",
  "parking_lot 0.12.3",
@@ -10798,7 +10533,7 @@ dependencies = [
 [[package]]
 name = "sc-mixnet"
 version = "0.20.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "array-bytes",
  "arrayvec 0.7.6",
@@ -10826,7 +10561,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.50.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -10876,7 +10611,7 @@ dependencies = [
 [[package]]
 name = "sc-network-common"
 version = "0.48.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "bitflags 1.3.2",
  "parity-scale-codec",
@@ -10886,7 +10621,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.50.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "ahash",
  "futures",
@@ -10905,7 +10640,7 @@ dependencies = [
 [[package]]
 name = "sc-network-light"
 version = "0.49.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -10926,7 +10661,7 @@ dependencies = [
 [[package]]
 name = "sc-network-sync"
 version = "0.49.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -10961,7 +10696,7 @@ dependencies = [
 [[package]]
 name = "sc-network-transactions"
 version = "0.49.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "array-bytes",
  "futures",
@@ -10980,7 +10715,7 @@ dependencies = [
 [[package]]
 name = "sc-network-types"
 version = "0.16.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "bs58",
  "bytes",
@@ -10999,7 +10734,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "45.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "bytes",
  "fnv",
@@ -11062,7 +10797,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.20.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -11071,7 +10806,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "45.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -11103,7 +10838,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.49.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -11123,7 +10858,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "22.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "dyn-clone",
  "forwarded-header-value",
@@ -11147,7 +10882,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-spec-v2"
 version = "0.50.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "array-bytes",
  "futures",
@@ -11180,13 +10915,13 @@ dependencies = [
 [[package]]
 name = "sc-runtime-utilities"
 version = "0.2.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "parity-scale-codec",
  "sc-executor",
  "sc-executor-common",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78)",
  "sp-state-machine",
  "sp-wasm-interface",
  "thiserror 1.0.64",
@@ -11195,7 +10930,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.51.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "async-trait",
  "directories",
@@ -11259,7 +10994,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.38.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -11270,7 +11005,7 @@ dependencies = [
 [[package]]
 name = "sc-storage-monitor"
 version = "0.24.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "clap",
  "fs4 0.7.0",
@@ -11328,7 +11063,7 @@ dependencies = [
 [[package]]
 name = "sc-sysinfo"
 version = "42.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "derive_more 0.99.18",
  "futures",
@@ -11341,14 +11076,14 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78)",
  "sp-io",
 ]
 
 [[package]]
 name = "sc-telemetry"
 version = "28.1.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "chrono",
  "futures",
@@ -11367,7 +11102,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "39.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "chrono",
  "console",
@@ -11395,7 +11130,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "11.1.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
@@ -11406,7 +11141,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "39.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "async-trait",
  "futures",
@@ -11424,7 +11159,7 @@ dependencies = [
  "sp-api",
  "sp-blockchain",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78)",
  "sp-runtime",
  "sp-tracing",
  "sp-transaction-pool",
@@ -11438,7 +11173,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "39.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "async-trait",
  "futures",
@@ -11455,7 +11190,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "18.0.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "async-channel 1.9.0",
  "futures",
@@ -12101,36 +11836,19 @@ checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
 name = "smol"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13f2b548cd8447f8de0fdf1c592929f70f4fc7039a05e47404b0d096ec6987a1"
-dependencies = [
- "async-channel 1.9.0",
- "async-executor",
- "async-fs 1.6.0",
- "async-io 1.13.0",
- "async-lock 2.8.0",
- "async-net 1.8.0",
- "async-process 1.8.1",
- "blocking",
- "futures-lite 1.13.0",
-]
-
-[[package]]
-name = "smol"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a33bd3e260892199c3ccfc487c88b2da2265080acb316cd920da72fdfd7c599f"
 dependencies = [
  "async-channel 2.3.1",
  "async-executor",
- "async-fs 2.1.2",
- "async-io 2.3.4",
- "async-lock 3.4.0",
- "async-net 2.0.0",
- "async-process 2.3.0",
+ "async-fs",
+ "async-io",
+ "async-lock",
+ "async-net",
+ "async-process",
  "blocking",
- "futures-lite 2.3.0",
+ "futures-lite",
 ]
 
 [[package]]
@@ -12140,7 +11858,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "966e72d77a3b2171bb7461d0cb91f43670c63558c62d7cf42809cae6c8b6b818"
 dependencies = [
  "arrayvec 0.7.6",
- "async-lock 3.4.0",
+ "async-lock",
  "atomic-take",
  "base64 0.22.1",
  "bip39",
@@ -12153,7 +11871,7 @@ dependencies = [
  "either",
  "event-listener 5.3.1",
  "fnv",
- "futures-lite 2.3.0",
+ "futures-lite",
  "futures-util",
  "hashbrown 0.14.5",
  "hex",
@@ -12194,7 +11912,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a33b06891f687909632ce6a4e3fd7677b24df930365af3d0bcb078310129f3f"
 dependencies = [
  "async-channel 2.3.1",
- "async-lock 3.4.0",
+ "async-lock",
  "base64 0.22.1",
  "blake2-rfc",
  "bs58",
@@ -12203,7 +11921,7 @@ dependencies = [
  "event-listener 5.3.1",
  "fnv",
  "futures-channel",
- "futures-lite 2.3.0",
+ "futures-lite",
  "futures-util",
  "hashbrown 0.14.5",
  "hex",
@@ -12218,7 +11936,7 @@ dependencies = [
  "serde_json",
  "siphasher 1.0.1",
  "slab",
- "smol 2.0.2",
+ "smol",
  "smoldot",
  "zeroize",
 ]
@@ -12244,16 +11962,6 @@ dependencies = [
  "rustc_version",
  "sha2 0.10.8",
  "subtle 2.6.1",
-]
-
-[[package]]
-name = "socket2"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
-dependencies = [
- "libc",
- "winapi",
 ]
 
 [[package]]
@@ -12285,7 +11993,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "36.0.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "docify",
  "hash-db",
@@ -12307,7 +12015,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "22.0.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "Inflector",
  "blake2 0.10.6",
@@ -12321,7 +12029,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "40.1.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12333,7 +12041,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "26.1.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "docify",
  "integer-sqrt",
@@ -12347,7 +12055,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "36.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12372,7 +12080,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "36.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "sp-api",
  "sp-inherents",
@@ -12393,7 +12101,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "39.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -12412,7 +12120,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.42.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "async-trait",
  "futures",
@@ -12426,7 +12134,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.42.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -12442,7 +12150,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.42.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -12460,7 +12168,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-beefy"
 version = "24.1.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12468,7 +12176,7 @@ dependencies = [
  "sp-api",
  "sp-application-crypto",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78)",
  "sp-io",
  "sp-keystore",
  "sp-mmr-primitives",
@@ -12480,7 +12188,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-grandpa"
 version = "23.1.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -12497,7 +12205,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.42.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12536,7 +12244,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "36.1.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "ark-vrf",
  "array-bytes",
@@ -12566,7 +12274,7 @@ dependencies = [
  "secp256k1 0.28.2",
  "secrecy 0.8.0",
  "serde",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78)",
  "sp-debug-derive",
  "sp-externalities",
  "sp-runtime-interface",
@@ -12597,7 +12305,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing"
 version = "0.1.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -12610,17 +12318,17 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "quote",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78)",
  "syn 2.0.111",
 ]
 
 [[package]]
 name = "sp-database"
 version = "10.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.3",
@@ -12629,7 +12337,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "14.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12782,7 +12490,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.30.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -12792,7 +12500,7 @@ dependencies = [
 [[package]]
 name = "sp-genesis-builder"
 version = "0.17.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12804,7 +12512,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "36.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -12817,7 +12525,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "40.0.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "bytes",
  "docify",
@@ -12829,7 +12537,7 @@ dependencies = [
  "rustversion",
  "secp256k1 0.28.2",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78)",
  "sp-externalities",
  "sp-keystore",
  "sp-runtime-interface",
@@ -12843,7 +12551,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "41.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "sp-core",
  "sp-runtime",
@@ -12853,7 +12561,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.42.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
@@ -12864,7 +12572,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "11.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "thiserror 1.0.64",
  "zstd 0.12.4",
@@ -12912,7 +12620,7 @@ dependencies = [
 [[package]]
 name = "sp-metadata-ir"
 version = "0.10.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "frame-metadata 20.0.0",
  "parity-scale-codec",
@@ -12922,7 +12630,7 @@ dependencies = [
 [[package]]
 name = "sp-mixnet"
 version = "0.14.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12933,7 +12641,7 @@ dependencies = [
 [[package]]
 name = "sp-mmr-primitives"
 version = "36.1.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -12958,7 +12666,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "36.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -12968,7 +12676,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "13.0.2"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "backtrace",
  "regex",
@@ -12977,7 +12685,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "34.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "rustc-hash 1.1.0",
  "serde",
@@ -12987,7 +12695,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "41.1.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "binary-merkle-tree",
  "docify",
@@ -13016,7 +12724,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "29.0.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -13035,7 +12743,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "18.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "Inflector",
  "expander",
@@ -13048,7 +12756,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "38.1.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -13062,7 +12770,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "38.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -13075,7 +12783,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.45.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "hash-db",
  "log",
@@ -13095,7 +12803,7 @@ dependencies = [
 [[package]]
 name = "sp-statement-store"
 version = "20.1.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "aes-gcm",
  "curve25519-dalek",
@@ -13108,7 +12816,7 @@ dependencies = [
  "sp-api",
  "sp-application-crypto",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78)",
  "sp-externalities",
  "sp-runtime",
  "sp-runtime-interface",
@@ -13119,12 +12827,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "14.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 
 [[package]]
 name = "sp-storage"
 version = "22.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -13154,7 +12862,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "36.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -13166,7 +12874,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "17.1.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "parity-scale-codec",
  "tracing",
@@ -13177,7 +12885,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "36.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -13186,7 +12894,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "36.1.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -13200,7 +12908,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "39.1.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "ahash",
  "hash-db",
@@ -13222,7 +12930,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "39.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -13239,7 +12947,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "15.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "parity-scale-codec",
  "proc-macro-warning",
@@ -13251,7 +12959,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "21.0.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -13263,7 +12971,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "31.1.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "bounded-collections",
  "parity-scale-codec",
@@ -13341,7 +13049,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 [[package]]
 name = "staging-xcm"
 version = "16.2.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "array-bytes",
  "bounded-collections",
@@ -13500,7 +13208,7 @@ dependencies = [
  "serde",
  "serde-big-array",
  "static_assertions",
- "uint 0.10.0",
+ "uint",
 ]
 
 [[package]]
@@ -13569,7 +13277,7 @@ name = "subspace-farmer"
 version = "0.1.5"
 dependencies = [
  "anyhow",
- "async-lock 3.4.0",
+ "async-lock",
  "async-nats",
  "async-trait",
  "backoff",
@@ -13630,7 +13338,7 @@ name = "subspace-farmer-components"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "async-lock 3.4.0",
+ "async-lock",
  "backoff",
  "bitvec",
  "criterion",
@@ -13681,7 +13389,7 @@ version = "0.1.5"
 dependencies = [
  "actix-web",
  "anyhow",
- "async-lock 3.4.0",
+ "async-lock",
  "async-trait",
  "clap",
  "futures",
@@ -13812,7 +13520,7 @@ dependencies = [
 name = "subspace-networking"
 version = "0.1.0"
 dependencies = [
- "async-lock 3.4.0",
+ "async-lock",
  "async-trait",
  "backoff",
  "bytes",
@@ -14072,7 +13780,7 @@ dependencies = [
  "anyhow",
  "array-bytes",
  "async-channel 1.9.0",
- "async-lock 3.4.0",
+ "async-lock",
  "async-trait",
  "cross-domain-message-gossip",
  "domain-runtime-primitives",
@@ -14355,12 +14063,12 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "11.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "44.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "docify",
  "frame-system-rpc-runtime-api",
@@ -14380,7 +14088,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.17.3"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "http-body-util",
  "hyper",
@@ -14394,7 +14102,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-client"
 version = "2.0.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "array-bytes",
  "async-trait",
@@ -14419,7 +14127,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "26.0.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "build-helper",
  "cargo_metadata",
@@ -14683,20 +14391,20 @@ dependencies = [
 
 [[package]]
 name = "system-configuration"
-version = "0.5.1"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.9.1",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
 
 [[package]]
 name = "system-configuration-sys"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -14738,7 +14446,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f2c9fc62d0beef6951ccffd757e241266a2c833136efbe35af6cd2567dca5b"
 dependencies = [
  "cfg-if",
- "fastrand 2.1.1",
+ "fastrand",
  "once_cell",
  "rustix 0.38.37",
  "windows-sys 0.59.0",
@@ -14957,7 +14665,7 @@ dependencies = [
  "parking_lot 0.12.3",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.5.9",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.52.0",
 ]
@@ -15169,7 +14877,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum"
 version = "19.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "coarsetime",
  "polkadot-primitives",
@@ -15180,7 +14888,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "expander",
  "proc-macro-crate 3.2.0",
@@ -15331,18 +15039,6 @@ name = "ucd-trie"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
-
-[[package]]
-name = "uint"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
-dependencies = [
- "byteorder",
- "crunchy",
- "hex",
- "static_assertions",
-]
 
 [[package]]
 name = "uint"
@@ -15511,12 +15207,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
-name = "value-bag"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba6f5989077681266825251a52748b8c1d8a4ad098cc37e440103d0ea717fc0"
-
-[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15608,12 +15298,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "waker-fn"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317211a0dc0ceedd78fb2ca9a44aed3d7b9b26f81870d485c07122b4350673b7"
-
-[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15658,27 +15342,14 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.93"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
+checksum = "0d759f433fa64a2d763d1340820e46e111a7a5ab75f993d1852d70b03dbb80fd"
 dependencies = [
  "cfg-if",
  "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.93"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
-dependencies = [
- "bumpalo",
- "log",
- "once_cell",
- "proc-macro2",
- "quote",
- "syn 2.0.111",
  "wasm-bindgen-shared",
 ]
 
@@ -15696,9 +15367,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.93"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
+checksum = "48cb0d2638f8baedbc542ed444afc0644a29166f1595371af4fecf8ce1e7eeb3"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -15706,22 +15377,25 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.93"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
+checksum = "cefb59d5cd5f92d9dcf80e4683949f15ca4b511f4ac0a6e14d4e1ac60c6ecd40"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
  "syn 2.0.111",
- "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.93"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
+checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "wasm-instrument"
@@ -16100,12 +15774,6 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.25.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
-
-[[package]]
-name = "webpki-roots"
 version = "0.26.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841c67bff177718f1d4dfefde8d8f0e78f9b6589319ba88312f567fc5841a958"
@@ -16163,7 +15831,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -16665,7 +16333,7 @@ dependencies = [
 [[package]]
 name = "xcm-procedural"
 version = "11.0.2"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=abff7ba7e61b7e55f8b1f90be581cf34526caf25#abff7ba7e61b7e55f8b1f90be581cf34526caf25"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
 dependencies = [
  "Inflector",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ core_affinity = "0.8.1"
 cpufeatures = "0.2.17"
 criterion = { version = "0.5.1", default-features = false }
 cross-domain-message-gossip = { version = "0.1.0", path = "domains/client/cross-domain-message-gossip" }
-cumulus-primitives-proof-size-hostfunction = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25", default-features = false }
+cumulus-primitives-proof-size-hostfunction = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
 derive_more = { version = "1.0.0", default-features = false }
 domain-block-builder = { version = "0.1.0", path = "domains/client/block-builder", default-features = false }
 domain-block-preprocessor = { version = "0.1.0", path = "domains/client/block-preprocessor", default-features = false }
@@ -84,13 +84,13 @@ fp-account = { version = "1.0.0-dev", git = "https://github.com/polkadot-evm/fro
 fp-evm = { version = "3.0.0-dev", git = "https://github.com/polkadot-evm/frontier", rev = "7d1cff7f13828b563752ad8a71458cab1ea42009", default-features = false }
 fp-rpc = { version = "3.0.0-dev", git = "https://github.com/polkadot-evm/frontier", rev = "7d1cff7f13828b563752ad8a71458cab1ea42009", default-features = false }
 fp-self-contained = { version = "1.0.0-dev", git = "https://github.com/polkadot-evm/frontier", rev = "7d1cff7f13828b563752ad8a71458cab1ea42009", default-features = false }
-frame-benchmarking = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25", default-features = false }
-frame-benchmarking-cli = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25", default-features = false }
-frame-executive = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25", default-features = false }
-frame-support = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25", default-features = false }
-frame-system = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25", default-features = false }
-frame-system-benchmarking = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25", default-features = false }
-frame-system-rpc-runtime-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25", default-features = false }
+frame-benchmarking = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
+frame-benchmarking-cli = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
+frame-executive = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
+frame-support = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
+frame-system = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
+frame-system-benchmarking = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
+frame-system-rpc-runtime-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
 fs2 = "0.4.3"
 fs4 = "0.9.1"
 futures = "0.3.31"
@@ -102,15 +102,15 @@ hwlocality = "1.0.0-alpha.6"
 jsonrpsee = "0.24.5"
 kzg = { git = "https://github.com/grandinetech/rust-kzg", rev = "8f5f1a0f73b3c529c77cb880ff8d265830c7d7ac", default-features = false }
 libc = "0.2.159"
-libp2p = { version = "0.54.2", git = "https://github.com/subspace/rust-libp2p", rev = "4ff21ede371f14ea0b90075f676ae21239ef8fbf", default-features = false }
-libp2p-swarm-test = { version = "0.5.0", git = "https://github.com/subspace/rust-libp2p", rev = "4ff21ede371f14ea0b90075f676ae21239ef8fbf" }
+libp2p = { version = "0.56.0", git = "https://github.com/subspace/rust-libp2p", rev = "0c2e22fe724e5101bc5ad5763b1c3d7aa452870a", default-features = false }
+libp2p-swarm-test = { version = "0.6.0", git = "https://github.com/subspace/rust-libp2p", rev = "0c2e22fe724e5101bc5ad5763b1c3d7aa452870a" }
 libsecp256k1 = "0.7.1"
 log = { version = "0.4.22", default-features = false }
 memmap2 = "0.9.5"
 memory-db = { version = "0.32.0", default-features = false }
 mimalloc = "0.1.43"
-mmr-gadget = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25" }
-mmr-rpc = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25" }
+mmr-gadget = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
+mmr-rpc = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
 multihash = "0.19.1"
 nohash-hasher = "0.2.0"
 num-traits = { version = "0.2.18", default-features = false }
@@ -118,10 +118,10 @@ num_cpus = "1.16.0"
 num_enum = { version = "0.5.3", default-features = false }
 ouroboros = "0.18.4"
 pallet-auto-id = { version = "0.1.0", path = "domains/pallets/auto-id", default-features = false }
-pallet-balances = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25", default-features = false }
+pallet-balances = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
 pallet-block-fees = { version = "0.1.0", path = "domains/pallets/block-fees", default-features = false }
-pallet-collective = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25", default-features = false }
-pallet-democracy = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25", default-features = false }
+pallet-collective = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
+pallet-democracy = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
 pallet-domain-id = { version = "0.1.0", path = "domains/pallets/domain-id", default-features = false }
 pallet-domain-sudo = { version = "0.1.0", path = "domains/pallets/domain-sudo", default-features = false }
 pallet-domains = { version = "0.1.0", path = "crates/pallet-domains", default-features = false }
@@ -133,30 +133,30 @@ pallet-evm-precompile-sha3fips = { version = "2.0.0-dev", git = "https://github.
 pallet-evm-precompile-simple = { version = "2.0.0-dev", git = "https://github.com/polkadot-evm/frontier", rev = "7d1cff7f13828b563752ad8a71458cab1ea42009", default-features = false }
 pallet-evm-tracker = { version = "0.1.0", path = "domains/pallets/evm-tracker", default-features = false }
 pallet-messenger = { version = "0.1.0", path = "domains/pallets/messenger", default-features = false }
-pallet-mmr = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25", default-features = false }
-pallet-multisig = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25", default-features = false }
-pallet-preimage = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25", default-features = false }
+pallet-mmr = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
+pallet-multisig = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
+pallet-preimage = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
 pallet-rewards = { version = "0.1.0", path = "crates/pallet-rewards", default-features = false }
 pallet-runtime-configs = { version = "0.1.0", path = "crates/pallet-runtime-configs", default-features = false }
-pallet-scheduler = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25", default-features = false }
+pallet-scheduler = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
 pallet-storage-overlay-checks = { version = "0.1.0", path = "domains/test/pallets/storage_overlay_checks", default-features = false }
 pallet-subspace = { version = "0.1.0", path = "crates/pallet-subspace", default-features = false }
 pallet-subspace-mmr = { version = "0.1.0", path = "crates/pallet-subspace-mmr", default-features = false }
-pallet-sudo = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25", default-features = false }
-pallet-timestamp = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25", default-features = false }
+pallet-sudo = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
+pallet-timestamp = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
 pallet-transaction-fees = { version = "0.1.0", path = "crates/pallet-transaction-fees", default-features = false }
-pallet-transaction-payment = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25", default-features = false }
-pallet-transaction-payment-rpc = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25" }
-pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25", default-features = false }
+pallet-transaction-payment = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
+pallet-transaction-payment-rpc = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
+pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
 pallet-transporter = { version = "0.1.0", path = "domains/pallets/transporter", default-features = false }
-pallet-utility = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25", default-features = false }
+pallet-utility = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
 parity-scale-codec = { version = "3.7.5", default-features = false }
 parking_lot = "0.12.2"
 pem = "3.0.4"
 pin-project = "1.1.5"
 precompile-utils = { version = "0.1.0", git = "https://github.com/polkadot-evm/frontier", rev = "7d1cff7f13828b563752ad8a71458cab1ea42009", default-features = false }
 prometheus = { version = "0.13.0", default-features = false }
-prometheus-client = "0.22.3"
+prometheus-client = "0.23.1"
 prop-test = "0.1.1"
 rand = { version = "0.8.5", default-features = false }
 rand_chacha = { version = "0.3.1", default-features = false }
@@ -167,42 +167,42 @@ ring = "0.17.8"
 rlp = "0.6"
 rs_merkle = { version = "1.4.2", default-features = false }
 rust-kzg-blst = { git = "https://github.com/grandinetech/rust-kzg", rev = "8f5f1a0f73b3c529c77cb880ff8d265830c7d7ac", default-features = false }
-sc-basic-authorship = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25" }
-sc-block-builder = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25" }
-sc-chain-spec = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25" }
-sc-cli = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25", default-features = false }
-sc-client-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25" }
-sc-client-db = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25" }
-sc-consensus = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25" }
-sc-consensus-slots = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25" }
+sc-basic-authorship = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
+sc-block-builder = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
+sc-chain-spec = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
+sc-cli = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
+sc-client-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
+sc-client-db = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
+sc-consensus = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
+sc-consensus-slots = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
 sc-consensus-subspace = { version = "0.1.0", path = "crates/sc-consensus-subspace" }
 sc-consensus-subspace-rpc = { version = "0.1.0", path = "crates/sc-consensus-subspace-rpc" }
 sc-domains = { version = "0.1.0", path = "crates/sc-domains" }
-sc-executor = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25", default-features = false }
-sc-informant = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25" }
-sc-keystore = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25" }
-sc-network = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25" }
-sc-network-common = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25" }
-sc-network-gossip = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25" }
-sc-network-sync = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25", default-features = false }
-sc-network-transactions = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25" }
-sc-offchain = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25" }
+sc-executor = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
+sc-informant = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
+sc-keystore = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
+sc-network = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
+sc-network-common = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
+sc-network-gossip = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
+sc-network-sync = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
+sc-network-transactions = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
+sc-offchain = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
 sc-proof-of-time = { version = "0.1.0", path = "crates/sc-proof-of-time" }
-sc-rpc = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25" }
-sc-rpc-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25" }
-sc-rpc-server = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25" }
-sc-service = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25", default-features = false }
-sc-state-db = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25" }
-sc-storage-monitor = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25", default-features = false }
+sc-rpc = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
+sc-rpc-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
+sc-rpc-server = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
+sc-service = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
+sc-state-db = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
+sc-storage-monitor = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
 sc-subspace-block-relay = { version = "0.1.0", path = "crates/sc-subspace-block-relay" }
 sc-subspace-chain-specs = { version = "0.1.0", path = "crates/sc-subspace-chain-specs" }
 sc-subspace-sync-common = { version = "0.1.0", path = "shared/sc-subspace-sync-common", default-features = false }
-sc-sysinfo = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25", default-features = false }
-sc-telemetry = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25" }
-sc-tracing = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25" }
-sc-transaction-pool = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25" }
-sc-transaction-pool-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25" }
-sc-utils = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25" }
+sc-sysinfo = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
+sc-telemetry = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
+sc-tracing = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
+sc-transaction-pool = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
+sc-transaction-pool-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
+sc-utils = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
 scale-info = { version = "2.11.6", default-features = false }
 schnellru = "0.2.4"
 schnorrkel = { version = "0.11.4", default-features = false }
@@ -211,48 +211,48 @@ serde = { version = "1.0.216", default-features = false }
 serde-big-array = "0.5.1"
 serde_json = "1.0.133"
 sha2 = { version = "0.10.7", default-features = false }
-sp-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25", default-features = false }
-sp-application-crypto = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25", default-features = false }
-sp-arithmetic = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25", default-features = false }
+sp-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
+sp-application-crypto = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
+sp-arithmetic = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
 sp-auto-id = { version = "0.1.0", path = "domains/primitives/auto-id", default-features = false }
-sp-block-builder = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25", default-features = false }
+sp-block-builder = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
 sp-block-fees = { version = "0.1.0", path = "domains/primitives/block-fees", default-features = false }
-sp-blockchain = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25", default-features = false }
-sp-consensus = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25" }
-sp-consensus-slots = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25", default-features = false }
+sp-blockchain = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
+sp-consensus = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
+sp-consensus-slots = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
 sp-consensus-subspace = { version = "0.1.0", path = "crates/sp-consensus-subspace", default-features = false }
-sp-core = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25", default-features = false }
+sp-core = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
 sp-domain-digests = { version = "0.1.0", path = "domains/primitives/digests", default-features = false }
 sp-domain-sudo = { version = "0.1.0", path = "domains/primitives/domain-sudo", default-features = false }
 sp-domains = { version = "0.1.0", path = "crates/sp-domains", default-features = false }
 sp-domains-fraud-proof = { version = "0.1.0", path = "crates/sp-domains-fraud-proof", default-features = false }
 sp-evm-tracker = { version = "0.1.0", path = "domains/primitives/evm-tracker", default-features = false }
 sp-executive = { version = "0.1.0", path = "domains/primitives/executive", default-features = false }
-sp-externalities = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25", default-features = false }
+sp-externalities = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
 sp-evm-precompiles = { version = "0.1.0", path = "domains/primitives/evm-precompiles", default-features = false }
-sp-genesis-builder = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25", default-features = false }
-sp-inherents = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25", default-features = false }
-sp-io = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25", default-features = false }
-sp-keyring = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25" }
-sp-keystore = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25" }
+sp-genesis-builder = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
+sp-inherents = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
+sp-io = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
+sp-keyring = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
+sp-keystore = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
 sp-messenger = { version = "0.1.0", path = "domains/primitives/messenger", default-features = false }
 sp-messenger-host-functions = { version = "0.1.0", path = "domains/primitives/messenger-host-functions", default-features = false }
-sp-mmr-primitives = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25", default-features = false }
+sp-mmr-primitives = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
 sp-objects = { version = "0.1.0", path = "crates/sp-objects", default-features = false }
-sp-offchain = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25", default-features = false }
-sp-runtime = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25", default-features = false }
-sp-runtime-interface = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25", default-features = false }
-sp-session = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25", default-features = false }
-sp-state-machine = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25", default-features = false }
-sp-std = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25", default-features = false }
-sp-storage = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25", default-features = false }
+sp-offchain = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
+sp-runtime = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
+sp-runtime-interface = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
+sp-session = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
+sp-state-machine = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
+sp-std = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
+sp-storage = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
 sp-subspace-mmr = { version = "0.1.0", path = "crates/sp-subspace-mmr", default-features = false }
-sp-timestamp = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25", default-features = false }
-sp-tracing = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25", default-features = false }
-sp-transaction-pool = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25", default-features = false }
-sp-trie = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25", default-features = false }
-sp-version = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25", default-features = false }
-sp-weights = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25", default-features = false }
+sp-timestamp = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
+sp-tracing = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
+sp-transaction-pool = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
+sp-trie = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
+sp-version = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
+sp-weights = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
 spin = "0.9.7"
 sppark = { version = "0.1.8", git = "https://github.com/autonomys/sppark", rev = "b2a181eb99c8200f1a604f04122551ea39fbf63f" }
 ss58-registry = "1.51.0"
@@ -281,11 +281,11 @@ subspace-test-runtime = { version = "0.1.0", path = "test/subspace-test-runtime"
 subspace-test-service = { version = "0.1.0", path = "test/subspace-test-service" }
 subspace-verification = { version = "0.1.0", path = "crates/subspace-verification", default-features = false }
 substrate-bip39 = "0.6.0"
-substrate-build-script-utils = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25" }
-substrate-frame-rpc-system = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25" }
-substrate-prometheus-endpoint = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25" }
-substrate-test-client = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25" }
-substrate-wasm-builder = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25" }
+substrate-build-script-utils = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
+substrate-frame-rpc-system = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
+substrate-prometheus-endpoint = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
+substrate-test-client = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
+substrate-wasm-builder = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
 supports-color = "3.0.1"
 tempfile = "3.13.0"
 thiserror = { version = "2.0.0", default-features = false }
@@ -384,51 +384,51 @@ lto = "fat"
 # Reason: We need to patch substrate dependency of frontier to our fork
 # TODO: Remove if/when we are using upstream substrate instead of fork
 [patch."https://github.com/paritytech/polkadot-sdk.git"]
-cumulus-primitives-storage-weight-reclaim = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25" }
-frame-benchmarking = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25" }
-frame-support = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25" }
-frame-system = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25" }
-sc-block-builder = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25" }
-sc-client-db = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25" }
-sc-consensus = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25" }
-sc-consensus-slots = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25" }
-sc-client-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25" }
-sc-network = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25" }
-sc-network-common = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25" }
-sc-network-sync = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25" }
-sc-rpc = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25" }
-sc-service = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25" }
-sc-telemetry = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25" }
-sc-transaction-pool = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25" }
-sc-transaction-pool-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25" }
-sc-utils = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25" }
-sp-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25" }
-sp-application-crypto = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25" }
-sp-arithmetic = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25" }
-sp-block-builder = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25" }
-sp-blockchain = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25" }
-sp-consensus = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25" }
-sp-consensus-slots = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25" }
-sp-core = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25" }
-sp-crypto-hashing = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25" }
-sp-database = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25" }
-sp-debug-derive = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25" }
-sp-externalities = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25" }
-sp-inherents = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25" }
-sp-io = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25" }
-sp-keystore = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25" }
-sp-runtime = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25" }
-sp-runtime-interface = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25" }
-sp-state-machine = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25" }
-sp-std = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25" }
-sp-storage = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25" }
-sp-timestamp = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25" }
-sp-trie = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25" }
-sp-version = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25" }
-sp-weights = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25" }
-staging-xcm = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25" }
-substrate-prometheus-endpoint = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25" }
-xcm-procedural = { git = "https://github.com/subspace/polkadot-sdk", rev = "abff7ba7e61b7e55f8b1f90be581cf34526caf25" }
+cumulus-primitives-storage-weight-reclaim = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
+frame-benchmarking = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
+frame-support = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
+frame-system = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
+sc-block-builder = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
+sc-client-db = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
+sc-consensus = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
+sc-consensus-slots = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
+sc-client-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
+sc-network = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
+sc-network-common = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
+sc-network-sync = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
+sc-rpc = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
+sc-service = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
+sc-telemetry = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
+sc-transaction-pool = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
+sc-transaction-pool-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
+sc-utils = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
+sp-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
+sp-application-crypto = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
+sp-arithmetic = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
+sp-block-builder = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
+sp-blockchain = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
+sp-consensus = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
+sp-consensus-slots = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
+sp-core = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
+sp-crypto-hashing = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
+sp-database = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
+sp-debug-derive = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
+sp-externalities = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
+sp-inherents = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
+sp-io = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
+sp-keystore = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
+sp-runtime = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
+sp-runtime-interface = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
+sp-state-machine = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
+sp-std = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
+sp-storage = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
+sp-timestamp = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
+sp-trie = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
+sp-version = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
+sp-weights = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
+staging-xcm = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
+substrate-prometheus-endpoint = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
+xcm-procedural = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
 
 [patch."https://github.com/subspace/polkadot-sdk.git"]
 # De-duplicate extra copy that comes from Substrate repo
@@ -441,12 +441,12 @@ substrate-bip39 = "0.6.0"
 # This is a hack: patches to the same repository are rejected by `cargo`. But it considers
 # "subspace/rust-libp2p" and "autonomys/rust-libp2p" to be different repositories, even though
 # they're redirected to the same place by GitHub, so it allows this patch.
-libp2p = { git = "https://github.com/subspace/rust-libp2p", rev = "4ff21ede371f14ea0b90075f676ae21239ef8fbf" }
-libp2p-identity = { git = "https://github.com/subspace/rust-libp2p", rev = "4ff21ede371f14ea0b90075f676ae21239ef8fbf" }
-libp2p-kad = { git = "https://github.com/subspace/rust-libp2p", rev = "4ff21ede371f14ea0b90075f676ae21239ef8fbf" }
-multistream-select = { git = "https://github.com/subspace/rust-libp2p", rev = "4ff21ede371f14ea0b90075f676ae21239ef8fbf" }
+libp2p = { git = "https://github.com/subspace/rust-libp2p", rev = "0c2e22fe724e5101bc5ad5763b1c3d7aa452870a" }
+libp2p-identity = { git = "https://github.com/subspace/rust-libp2p", rev = "0c2e22fe724e5101bc5ad5763b1c3d7aa452870a" }
+libp2p-kad = { git = "https://github.com/subspace/rust-libp2p", rev = "0c2e22fe724e5101bc5ad5763b1c3d7aa452870a" }
+multistream-select = { git = "https://github.com/subspace/rust-libp2p", rev = "0c2e22fe724e5101bc5ad5763b1c3d7aa452870a" }
 
 [patch.crates-io]
 # Patch away `libp2p-identity` in our dependency tree with the git version.
-# For details see: https://github.com/subspace/rust-libp2p/blob/4ff21ede371f14ea0b90075f676ae21239ef8fbf/Cargo.toml#L140-L145
-libp2p-identity = { git = "https://github.com/subspace/rust-libp2p", rev = "4ff21ede371f14ea0b90075f676ae21239ef8fbf" }
+# For details see: https://github.com/subspace/rust-libp2p/blob/0c2e22fe724e5101bc5ad5763b1c3d7aa452870a/Cargo.toml#L140-L145
+libp2p-identity = { git = "https://github.com/subspace/rust-libp2p", rev = "0c2e22fe724e5101bc5ad5763b1c3d7aa452870a" }

--- a/crates/subspace-networking/src/behavior.rs
+++ b/crates/subspace-networking/src/behavior.rs
@@ -104,6 +104,7 @@ impl Behavior {
     }
 }
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, From)]
 pub(crate) enum Event {
     Identify(IdentifyEvent),

--- a/crates/subspace-networking/src/behavior.rs
+++ b/crates/subspace-networking/src/behavior.rs
@@ -104,7 +104,7 @@ impl Behavior {
     }
 }
 
-#[allow(clippy::large_enum_variant)]
+#[expect(clippy::large_enum_variant)]
 #[derive(Debug, From)]
 pub(crate) enum Event {
     Identify(IdentifyEvent),

--- a/crates/subspace-networking/src/protocols/reserved_peers/tests.rs
+++ b/crates/subspace-networking/src/protocols/reserved_peers/tests.rs
@@ -1,5 +1,5 @@
 use crate::protocols::reserved_peers::{Behaviour, Config};
-use futures::{FutureExt, select};
+use futures::{FutureExt, StreamExt, select};
 use libp2p::core::Transport;
 use libp2p::core::transport::MemoryTransport;
 use libp2p::core::upgrade::Version;
@@ -16,7 +16,7 @@ const DIALING_INTERVAL_IN_SECS: Duration = Duration::from_secs(1);
 #[tokio::test]
 async fn test_connection_breaks_after_timeout_without_reservation() {
     let connection_timeout = Duration::from_millis(300);
-    let long_delay = Duration::from_millis(1000);
+    let long_delay = Duration::from_millis(12000);
 
     let identity1 = Keypair::generate_ed25519();
     let mut peer1 = new_ephemeral(
@@ -44,8 +44,8 @@ async fn test_connection_breaks_after_timeout_without_reservation() {
 
     loop {
         select! {
-            _ = peer1.next_swarm_event().fuse() => {},
-            _ = peer2.next_swarm_event().fuse() => {},
+            _ = peer1.select_next_some().fuse() => {},
+            _ = peer2.select_next_some().fuse() => {},
             _ = sleep(long_delay).fuse() => {
                 break;
             }
@@ -60,7 +60,7 @@ async fn test_connection_breaks_after_timeout_without_reservation() {
 #[tokio::test]
 async fn test_connection_reservation() {
     let connection_timeout = Duration::from_millis(300);
-    let long_delay = Duration::from_millis(1000);
+    let long_delay = Duration::from_millis(12000);
 
     let identity1 = Keypair::generate_ed25519();
     let identity2 = Keypair::generate_ed25519();
@@ -92,8 +92,8 @@ async fn test_connection_reservation() {
 
     loop {
         select! {
-            _ = peer1.next_swarm_event().fuse() => {},
-            _ = peer2.next_swarm_event().fuse() => {},
+            _ = peer1.select_next_some().fuse() => {},
+            _ = peer2.select_next_some().fuse() => {},
             _ = sleep(long_delay).fuse() => {
                 break;
             }
@@ -108,7 +108,7 @@ async fn test_connection_reservation() {
 #[tokio::test]
 async fn test_connection_reservation_symmetry() {
     let connection_timeout = Duration::from_millis(300);
-    let long_delay = Duration::from_millis(1000);
+    let long_delay = Duration::from_millis(12000);
 
     let identity1 = Keypair::generate_ed25519();
     let identity2 = Keypair::generate_ed25519();
@@ -138,8 +138,8 @@ async fn test_connection_reservation_symmetry() {
 
     loop {
         select! {
-            _ = peer1.next_swarm_event().fuse() => {},
-            _ = peer2.next_swarm_event().fuse() => {},
+            _ = peer1.select_next_some().fuse() => {},
+            _ = peer2.select_next_some().fuse() => {},
             _ = sleep(long_delay).fuse() => {
                 break;
             }


### PR DESCRIPTION
This PR upgrades our libp2p fork from 0.54.2 to 0.56.0.

## Libp2p fork changes(https://github.com/autonomys/rust-libp2p/commits/subspace-v10/)

### Inbound stream timeouts
We recently patched our fork to have inbound streams to have timeout like outbound. 
Our fork has following patches for this
- https://github.com/autonomys/rust-libp2p/commit/6b251407b29d4ed31dc9d6498cbe243bf7ff018a
- https://github.com/autonomys/rust-libp2p/commit/30f46e6188625c157a22d38407b9c0fe989a5f21

Upstream PR https://github.com/libp2p/rust-libp2p/pull/6009 is still unmerged as we need to confirm if the fix worked. Will handle this to get the PR merged and we dont need to pull our changes in next upgrade hopefully.

### BandwidthSinks
Unfortunately, polkadot-sdk is not yet migrated to 0.56.0 and still at 0.54.1.
Reason being substrate uses `with_bandwidth_logging` to measure the overall bandwidth usage distinct between inbound and outbound. There was deprecation notice and this was mentioned by Nazar in the libp2p upgrade pr https://github.com/paritytech/polkadot-sdk/pull/6248

With 0.56.0, the entire bandwith module is removed. Migrating the same on substrate side would like a bit more changes and felt out of scope for our fork. So I instead reverted the changes into our fork.
Once substrate upgrades to 0.56.0, we would not need this change. Either we upgrade substrate with latest libp2p ourselves or wait for community.


The changes on our end is quiet straight forward. Main change is coming from this https://github.com/libp2p/rust-libp2p/pull/5938

As usual, this PR will be draft until I confirm the changes are compatible with chronos and mainnet.
- [x] Test on Chronos
- [x] Test on mainnet

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
