### PR TITLE
Libp2p backport changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1249,7 +1249,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 [[package]]
 name = "binary-merkle-tree"
 version = "16.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "hash-db",
  "log",
@@ -2374,7 +2374,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-parachain-inherent"
 version = "0.17.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2383,7 +2383,7 @@ dependencies = [
  "cumulus-test-relay-sproof-builder",
  "parity-scale-codec",
  "sc-client-api",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d)",
  "sp-inherents",
  "sp-runtime",
  "sp-state-machine",
@@ -2394,7 +2394,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-core"
 version = "0.18.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "parity-scale-codec",
  "polkadot-core-primitives",
@@ -2410,7 +2410,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-parachain-inherent"
 version = "0.18.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2424,7 +2424,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-proof-size-hostfunction"
 version = "0.12.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "sp-externalities",
  "sp-runtime-interface",
@@ -2434,7 +2434,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-storage-weight-reclaim"
 version = "11.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-proof-size-hostfunction",
@@ -2451,7 +2451,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-interface"
 version = "0.23.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2470,7 +2470,7 @@ dependencies = [
 [[package]]
 name = "cumulus-test-relay-sproof-builder"
 version = "0.19.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
@@ -3973,7 +3973,7 @@ dependencies = [
  "rustc-hex",
  "serde",
  "serde_json",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d)",
 ]
 
 [[package]]
@@ -4104,7 +4104,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 [[package]]
 name = "fork-tree"
 version = "13.0.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -4232,7 +4232,7 @@ checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 [[package]]
 name = "frame-benchmarking"
 version = "40.2.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -4256,7 +4256,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "48.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "Inflector",
  "array-bytes",
@@ -4330,7 +4330,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "40.0.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "aquamarine",
  "frame-support",
@@ -4372,7 +4372,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "40.1.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "aquamarine",
  "array-bytes",
@@ -4413,7 +4413,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "33.0.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -4426,14 +4426,14 @@ dependencies = [
  "proc-macro-warning",
  "proc-macro2",
  "quote",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d)",
  "syn 2.0.111",
 ]
 
 [[package]]
 name = "frame-support-procedural-tools"
 version = "13.0.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate 3.2.0",
@@ -4445,7 +4445,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "12.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4455,7 +4455,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "40.2.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "cfg-if",
  "docify",
@@ -4474,7 +4474,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "40.0.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4488,7 +4488,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "36.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "docify",
  "parity-scale-codec",
@@ -4498,7 +4498,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.46.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -6050,7 +6050,7 @@ dependencies = [
 [[package]]
 name = "libp2p"
 version = "0.56.0"
-source = "git+https://github.com/subspace/rust-libp2p?rev=0c2e22fe724e5101bc5ad5763b1c3d7aa452870a#0c2e22fe724e5101bc5ad5763b1c3d7aa452870a"
+source = "git+https://github.com/subspace/rust-libp2p?rev=7e9532d65530ebd0cf92c53fc326948ee8467fea#7e9532d65530ebd0cf92c53fc326948ee8467fea"
 dependencies = [
  "bytes",
  "either",
@@ -6087,7 +6087,7 @@ dependencies = [
 [[package]]
 name = "libp2p-allow-block-list"
 version = "0.6.0"
-source = "git+https://github.com/subspace/rust-libp2p?rev=0c2e22fe724e5101bc5ad5763b1c3d7aa452870a#0c2e22fe724e5101bc5ad5763b1c3d7aa452870a"
+source = "git+https://github.com/subspace/rust-libp2p?rev=7e9532d65530ebd0cf92c53fc326948ee8467fea#7e9532d65530ebd0cf92c53fc326948ee8467fea"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
@@ -6097,7 +6097,7 @@ dependencies = [
 [[package]]
 name = "libp2p-autonat"
 version = "0.15.0"
-source = "git+https://github.com/subspace/rust-libp2p?rev=0c2e22fe724e5101bc5ad5763b1c3d7aa452870a#0c2e22fe724e5101bc5ad5763b1c3d7aa452870a"
+source = "git+https://github.com/subspace/rust-libp2p?rev=7e9532d65530ebd0cf92c53fc326948ee8467fea#7e9532d65530ebd0cf92c53fc326948ee8467fea"
 dependencies = [
  "async-trait",
  "asynchronous-codec 0.7.0",
@@ -6121,7 +6121,7 @@ dependencies = [
 [[package]]
 name = "libp2p-connection-limits"
 version = "0.6.0"
-source = "git+https://github.com/subspace/rust-libp2p?rev=0c2e22fe724e5101bc5ad5763b1c3d7aa452870a#0c2e22fe724e5101bc5ad5763b1c3d7aa452870a"
+source = "git+https://github.com/subspace/rust-libp2p?rev=7e9532d65530ebd0cf92c53fc326948ee8467fea#7e9532d65530ebd0cf92c53fc326948ee8467fea"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
@@ -6131,7 +6131,7 @@ dependencies = [
 [[package]]
 name = "libp2p-core"
 version = "0.43.1"
-source = "git+https://github.com/subspace/rust-libp2p?rev=0c2e22fe724e5101bc5ad5763b1c3d7aa452870a#0c2e22fe724e5101bc5ad5763b1c3d7aa452870a"
+source = "git+https://github.com/subspace/rust-libp2p?rev=7e9532d65530ebd0cf92c53fc326948ee8467fea#7e9532d65530ebd0cf92c53fc326948ee8467fea"
 dependencies = [
  "either",
  "fnv",
@@ -6155,7 +6155,7 @@ dependencies = [
 [[package]]
 name = "libp2p-dns"
 version = "0.44.0"
-source = "git+https://github.com/subspace/rust-libp2p?rev=0c2e22fe724e5101bc5ad5763b1c3d7aa452870a#0c2e22fe724e5101bc5ad5763b1c3d7aa452870a"
+source = "git+https://github.com/subspace/rust-libp2p?rev=7e9532d65530ebd0cf92c53fc326948ee8467fea#7e9532d65530ebd0cf92c53fc326948ee8467fea"
 dependencies = [
  "async-trait",
  "futures",
@@ -6170,7 +6170,7 @@ dependencies = [
 [[package]]
 name = "libp2p-gossipsub"
 version = "0.49.0"
-source = "git+https://github.com/subspace/rust-libp2p?rev=0c2e22fe724e5101bc5ad5763b1c3d7aa452870a#0c2e22fe724e5101bc5ad5763b1c3d7aa452870a"
+source = "git+https://github.com/subspace/rust-libp2p?rev=7e9532d65530ebd0cf92c53fc326948ee8467fea#7e9532d65530ebd0cf92c53fc326948ee8467fea"
 dependencies = [
  "async-channel 2.3.1",
  "asynchronous-codec 0.7.0",
@@ -6200,7 +6200,7 @@ dependencies = [
 [[package]]
 name = "libp2p-identify"
 version = "0.47.0"
-source = "git+https://github.com/subspace/rust-libp2p?rev=0c2e22fe724e5101bc5ad5763b1c3d7aa452870a#0c2e22fe724e5101bc5ad5763b1c3d7aa452870a"
+source = "git+https://github.com/subspace/rust-libp2p?rev=7e9532d65530ebd0cf92c53fc326948ee8467fea#7e9532d65530ebd0cf92c53fc326948ee8467fea"
 dependencies = [
  "asynchronous-codec 0.7.0",
  "either",
@@ -6220,7 +6220,7 @@ dependencies = [
 [[package]]
 name = "libp2p-identity"
 version = "0.2.12"
-source = "git+https://github.com/subspace/rust-libp2p?rev=0c2e22fe724e5101bc5ad5763b1c3d7aa452870a#0c2e22fe724e5101bc5ad5763b1c3d7aa452870a"
+source = "git+https://github.com/subspace/rust-libp2p?rev=7e9532d65530ebd0cf92c53fc326948ee8467fea#7e9532d65530ebd0cf92c53fc326948ee8467fea"
 dependencies = [
  "bs58",
  "ed25519-dalek",
@@ -6238,7 +6238,7 @@ dependencies = [
 [[package]]
 name = "libp2p-kad"
 version = "0.48.0"
-source = "git+https://github.com/subspace/rust-libp2p?rev=0c2e22fe724e5101bc5ad5763b1c3d7aa452870a#0c2e22fe724e5101bc5ad5763b1c3d7aa452870a"
+source = "git+https://github.com/subspace/rust-libp2p?rev=7e9532d65530ebd0cf92c53fc326948ee8467fea#7e9532d65530ebd0cf92c53fc326948ee8467fea"
 dependencies = [
  "asynchronous-codec 0.7.0",
  "bytes",
@@ -6265,7 +6265,7 @@ dependencies = [
 [[package]]
 name = "libp2p-mdns"
 version = "0.48.0"
-source = "git+https://github.com/subspace/rust-libp2p?rev=0c2e22fe724e5101bc5ad5763b1c3d7aa452870a#0c2e22fe724e5101bc5ad5763b1c3d7aa452870a"
+source = "git+https://github.com/subspace/rust-libp2p?rev=7e9532d65530ebd0cf92c53fc326948ee8467fea#7e9532d65530ebd0cf92c53fc326948ee8467fea"
 dependencies = [
  "futures",
  "hickory-proto",
@@ -6283,7 +6283,7 @@ dependencies = [
 [[package]]
 name = "libp2p-metrics"
 version = "0.17.0"
-source = "git+https://github.com/subspace/rust-libp2p?rev=0c2e22fe724e5101bc5ad5763b1c3d7aa452870a#0c2e22fe724e5101bc5ad5763b1c3d7aa452870a"
+source = "git+https://github.com/subspace/rust-libp2p?rev=7e9532d65530ebd0cf92c53fc326948ee8467fea#7e9532d65530ebd0cf92c53fc326948ee8467fea"
 dependencies = [
  "futures",
  "libp2p-core",
@@ -6301,7 +6301,7 @@ dependencies = [
 [[package]]
 name = "libp2p-noise"
 version = "0.46.1"
-source = "git+https://github.com/subspace/rust-libp2p?rev=0c2e22fe724e5101bc5ad5763b1c3d7aa452870a#0c2e22fe724e5101bc5ad5763b1c3d7aa452870a"
+source = "git+https://github.com/subspace/rust-libp2p?rev=7e9532d65530ebd0cf92c53fc326948ee8467fea#7e9532d65530ebd0cf92c53fc326948ee8467fea"
 dependencies = [
  "asynchronous-codec 0.7.0",
  "bytes",
@@ -6323,7 +6323,7 @@ dependencies = [
 [[package]]
 name = "libp2p-ping"
 version = "0.47.0"
-source = "git+https://github.com/subspace/rust-libp2p?rev=0c2e22fe724e5101bc5ad5763b1c3d7aa452870a#0c2e22fe724e5101bc5ad5763b1c3d7aa452870a"
+source = "git+https://github.com/subspace/rust-libp2p?rev=7e9532d65530ebd0cf92c53fc326948ee8467fea#7e9532d65530ebd0cf92c53fc326948ee8467fea"
 dependencies = [
  "futures",
  "futures-timer",
@@ -6338,7 +6338,7 @@ dependencies = [
 [[package]]
 name = "libp2p-plaintext"
 version = "0.43.0"
-source = "git+https://github.com/subspace/rust-libp2p?rev=0c2e22fe724e5101bc5ad5763b1c3d7aa452870a#0c2e22fe724e5101bc5ad5763b1c3d7aa452870a"
+source = "git+https://github.com/subspace/rust-libp2p?rev=7e9532d65530ebd0cf92c53fc326948ee8467fea#7e9532d65530ebd0cf92c53fc326948ee8467fea"
 dependencies = [
  "asynchronous-codec 0.7.0",
  "bytes",
@@ -6353,7 +6353,7 @@ dependencies = [
 [[package]]
 name = "libp2p-quic"
 version = "0.13.0"
-source = "git+https://github.com/subspace/rust-libp2p?rev=0c2e22fe724e5101bc5ad5763b1c3d7aa452870a#0c2e22fe724e5101bc5ad5763b1c3d7aa452870a"
+source = "git+https://github.com/subspace/rust-libp2p?rev=7e9532d65530ebd0cf92c53fc326948ee8467fea#7e9532d65530ebd0cf92c53fc326948ee8467fea"
 dependencies = [
  "futures",
  "futures-timer",
@@ -6374,7 +6374,7 @@ dependencies = [
 [[package]]
 name = "libp2p-request-response"
 version = "0.29.0"
-source = "git+https://github.com/subspace/rust-libp2p?rev=0c2e22fe724e5101bc5ad5763b1c3d7aa452870a#0c2e22fe724e5101bc5ad5763b1c3d7aa452870a"
+source = "git+https://github.com/subspace/rust-libp2p?rev=7e9532d65530ebd0cf92c53fc326948ee8467fea#7e9532d65530ebd0cf92c53fc326948ee8467fea"
 dependencies = [
  "async-trait",
  "futures",
@@ -6390,16 +6390,16 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm"
 version = "0.47.0"
-source = "git+https://github.com/subspace/rust-libp2p?rev=0c2e22fe724e5101bc5ad5763b1c3d7aa452870a#0c2e22fe724e5101bc5ad5763b1c3d7aa452870a"
+source = "git+https://github.com/subspace/rust-libp2p?rev=7e9532d65530ebd0cf92c53fc326948ee8467fea#7e9532d65530ebd0cf92c53fc326948ee8467fea"
 dependencies = [
  "either",
  "fnv",
  "futures",
  "futures-timer",
+ "hashlink 0.9.1",
  "libp2p-core",
  "libp2p-identity",
  "libp2p-swarm-derive",
- "lru",
  "multistream-select",
  "rand 0.8.5",
  "smallvec",
@@ -6411,7 +6411,7 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm-derive"
 version = "0.35.1"
-source = "git+https://github.com/subspace/rust-libp2p?rev=0c2e22fe724e5101bc5ad5763b1c3d7aa452870a#0c2e22fe724e5101bc5ad5763b1c3d7aa452870a"
+source = "git+https://github.com/subspace/rust-libp2p?rev=7e9532d65530ebd0cf92c53fc326948ee8467fea#7e9532d65530ebd0cf92c53fc326948ee8467fea"
 dependencies = [
  "heck 0.5.0",
  "quote",
@@ -6421,7 +6421,7 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm-test"
 version = "0.6.0"
-source = "git+https://github.com/subspace/rust-libp2p?rev=0c2e22fe724e5101bc5ad5763b1c3d7aa452870a#0c2e22fe724e5101bc5ad5763b1c3d7aa452870a"
+source = "git+https://github.com/subspace/rust-libp2p?rev=7e9532d65530ebd0cf92c53fc326948ee8467fea#7e9532d65530ebd0cf92c53fc326948ee8467fea"
 dependencies = [
  "async-trait",
  "futures",
@@ -6438,7 +6438,7 @@ dependencies = [
 [[package]]
 name = "libp2p-tcp"
 version = "0.44.0"
-source = "git+https://github.com/subspace/rust-libp2p?rev=0c2e22fe724e5101bc5ad5763b1c3d7aa452870a#0c2e22fe724e5101bc5ad5763b1c3d7aa452870a"
+source = "git+https://github.com/subspace/rust-libp2p?rev=7e9532d65530ebd0cf92c53fc326948ee8467fea#7e9532d65530ebd0cf92c53fc326948ee8467fea"
 dependencies = [
  "futures",
  "futures-timer",
@@ -6453,7 +6453,7 @@ dependencies = [
 [[package]]
 name = "libp2p-tls"
 version = "0.6.2"
-source = "git+https://github.com/subspace/rust-libp2p?rev=0c2e22fe724e5101bc5ad5763b1c3d7aa452870a#0c2e22fe724e5101bc5ad5763b1c3d7aa452870a"
+source = "git+https://github.com/subspace/rust-libp2p?rev=7e9532d65530ebd0cf92c53fc326948ee8467fea#7e9532d65530ebd0cf92c53fc326948ee8467fea"
 dependencies = [
  "futures",
  "futures-rustls",
@@ -6471,7 +6471,7 @@ dependencies = [
 [[package]]
 name = "libp2p-upnp"
 version = "0.5.0"
-source = "git+https://github.com/subspace/rust-libp2p?rev=0c2e22fe724e5101bc5ad5763b1c3d7aa452870a#0c2e22fe724e5101bc5ad5763b1c3d7aa452870a"
+source = "git+https://github.com/subspace/rust-libp2p?rev=7e9532d65530ebd0cf92c53fc326948ee8467fea#7e9532d65530ebd0cf92c53fc326948ee8467fea"
 dependencies = [
  "futures",
  "futures-timer",
@@ -6485,7 +6485,7 @@ dependencies = [
 [[package]]
 name = "libp2p-websocket"
 version = "0.45.1"
-source = "git+https://github.com/subspace/rust-libp2p?rev=0c2e22fe724e5101bc5ad5763b1c3d7aa452870a#0c2e22fe724e5101bc5ad5763b1c3d7aa452870a"
+source = "git+https://github.com/subspace/rust-libp2p?rev=7e9532d65530ebd0cf92c53fc326948ee8467fea#7e9532d65530ebd0cf92c53fc326948ee8467fea"
 dependencies = [
  "either",
  "futures",
@@ -6505,7 +6505,7 @@ dependencies = [
 [[package]]
 name = "libp2p-yamux"
 version = "0.47.0"
-source = "git+https://github.com/subspace/rust-libp2p?rev=0c2e22fe724e5101bc5ad5763b1c3d7aa452870a#0c2e22fe724e5101bc5ad5763b1c3d7aa452870a"
+source = "git+https://github.com/subspace/rust-libp2p?rev=7e9532d65530ebd0cf92c53fc326948ee8467fea#7e9532d65530ebd0cf92c53fc326948ee8467fea"
 dependencies = [
  "either",
  "futures",
@@ -6981,7 +6981,7 @@ dependencies = [
 [[package]]
 name = "mmr-gadget"
 version = "45.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "futures",
  "log",
@@ -7000,7 +7000,7 @@ dependencies = [
 [[package]]
 name = "mmr-rpc"
 version = "40.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -7164,7 +7164,7 @@ checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
 [[package]]
 name = "multistream-select"
 version = "0.13.0"
-source = "git+https://github.com/subspace/rust-libp2p?rev=0c2e22fe724e5101bc5ad5763b1c3d7aa452870a#0c2e22fe724e5101bc5ad5763b1c3d7aa452870a"
+source = "git+https://github.com/subspace/rust-libp2p?rev=7e9532d65530ebd0cf92c53fc326948ee8467fea#7e9532d65530ebd0cf92c53fc326948ee8467fea"
 dependencies = [
  "bytes",
  "futures",
@@ -7689,7 +7689,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "41.1.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -7721,7 +7721,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "40.1.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -7738,7 +7738,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "40.1.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7957,7 +7957,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr"
 version = "40.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -7969,7 +7969,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "40.1.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -7980,7 +7980,7 @@ dependencies = [
 [[package]]
 name = "pallet-preimage"
 version = "40.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8029,7 +8029,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "41.2.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8105,7 +8105,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "40.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8120,7 +8120,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "39.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8150,7 +8150,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "40.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8166,7 +8166,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "43.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -8182,7 +8182,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "40.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -8215,7 +8215,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "40.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8536,7 +8536,7 @@ dependencies = [
 [[package]]
 name = "polkadot-core-primitives"
 version = "17.1.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -8547,7 +8547,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-metrics"
 version = "23.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "bs58",
  "futures",
@@ -8564,7 +8564,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-network-protocol"
 version = "23.1.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -8589,7 +8589,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-primitives"
 version = "19.1.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "bitvec",
  "bounded-vec",
@@ -8613,7 +8613,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-types"
 version = "23.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "async-trait",
  "derive_more 0.99.18",
@@ -8641,7 +8641,7 @@ dependencies = [
 [[package]]
 name = "polkadot-overseer"
 version = "23.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "async-trait",
  "futures",
@@ -8661,7 +8661,7 @@ dependencies = [
 [[package]]
 name = "polkadot-parachain-primitives"
 version = "16.1.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "bounded-collections",
  "derive_more 0.99.18",
@@ -8677,7 +8677,7 @@ dependencies = [
 [[package]]
 name = "polkadot-primitives"
 version = "18.2.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "bitvec",
  "hex-literal",
@@ -8714,7 +8714,7 @@ dependencies = [
 [[package]]
 name = "polkadot-sdk-frame"
 version = "0.9.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8749,7 +8749,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-table"
 version = "19.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
@@ -8934,7 +8934,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d)",
  "syn 2.0.111",
 ]
 
@@ -9286,7 +9286,7 @@ dependencies = [
 [[package]]
 name = "quick-protobuf-codec"
 version = "0.3.1"
-source = "git+https://github.com/subspace/rust-libp2p?rev=0c2e22fe724e5101bc5ad5763b1c3d7aa452870a#0c2e22fe724e5101bc5ad5763b1c3d7aa452870a"
+source = "git+https://github.com/subspace/rust-libp2p?rev=7e9532d65530ebd0cf92c53fc326948ee8467fea#7e9532d65530ebd0cf92c53fc326948ee8467fea"
 dependencies = [
  "asynchronous-codec 0.7.0",
  "bytes",
@@ -10039,7 +10039,7 @@ dependencies = [
 [[package]]
 name = "rw-stream-sink"
 version = "0.4.0"
-source = "git+https://github.com/subspace/rust-libp2p?rev=0c2e22fe724e5101bc5ad5763b1c3d7aa452870a#0c2e22fe724e5101bc5ad5763b1c3d7aa452870a"
+source = "git+https://github.com/subspace/rust-libp2p?rev=7e9532d65530ebd0cf92c53fc326948ee8467fea#7e9532d65530ebd0cf92c53fc326948ee8467fea"
 dependencies = [
  "futures",
  "pin-project",
@@ -10082,7 +10082,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "31.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "log",
  "sp-core",
@@ -10093,7 +10093,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.50.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "async-trait",
  "futures",
@@ -10121,7 +10121,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.49.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "futures",
  "log",
@@ -10142,7 +10142,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.44.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -10157,7 +10157,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "43.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "array-bytes",
  "docify",
@@ -10172,7 +10172,7 @@ dependencies = [
  "serde_json",
  "sp-blockchain",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d)",
  "sp-genesis-builder",
  "sp-io",
  "sp-runtime",
@@ -10183,7 +10183,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "12.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
@@ -10194,7 +10194,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.52.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "array-bytes",
  "chrono",
@@ -10236,7 +10236,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "39.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "fnv",
  "futures",
@@ -10262,7 +10262,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.46.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -10287,7 +10287,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.49.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "async-trait",
  "futures",
@@ -10310,7 +10310,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.49.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "async-trait",
  "futures",
@@ -10440,7 +10440,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.42.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
@@ -10463,7 +10463,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.38.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "polkavm",
  "sc-allocator",
@@ -10476,7 +10476,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-polkavm"
 version = "0.35.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "log",
  "polkavm",
@@ -10487,7 +10487,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.38.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "anyhow",
  "log",
@@ -10503,7 +10503,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.49.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "console",
  "futures",
@@ -10519,7 +10519,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "35.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "array-bytes",
  "parking_lot 0.12.3",
@@ -10533,7 +10533,7 @@ dependencies = [
 [[package]]
 name = "sc-mixnet"
 version = "0.20.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "array-bytes",
  "arrayvec 0.7.6",
@@ -10561,7 +10561,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.50.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -10611,7 +10611,7 @@ dependencies = [
 [[package]]
 name = "sc-network-common"
 version = "0.48.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "bitflags 1.3.2",
  "parity-scale-codec",
@@ -10621,7 +10621,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.50.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "ahash",
  "futures",
@@ -10640,7 +10640,7 @@ dependencies = [
 [[package]]
 name = "sc-network-light"
 version = "0.49.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -10661,7 +10661,7 @@ dependencies = [
 [[package]]
 name = "sc-network-sync"
 version = "0.49.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -10696,7 +10696,7 @@ dependencies = [
 [[package]]
 name = "sc-network-transactions"
 version = "0.49.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "array-bytes",
  "futures",
@@ -10715,7 +10715,7 @@ dependencies = [
 [[package]]
 name = "sc-network-types"
 version = "0.16.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "bs58",
  "bytes",
@@ -10734,7 +10734,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "45.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "bytes",
  "fnv",
@@ -10797,7 +10797,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.20.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -10806,7 +10806,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "45.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -10838,7 +10838,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.49.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -10858,7 +10858,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "22.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "dyn-clone",
  "forwarded-header-value",
@@ -10882,7 +10882,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-spec-v2"
 version = "0.50.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "array-bytes",
  "futures",
@@ -10915,13 +10915,13 @@ dependencies = [
 [[package]]
 name = "sc-runtime-utilities"
 version = "0.2.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "parity-scale-codec",
  "sc-executor",
  "sc-executor-common",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d)",
  "sp-state-machine",
  "sp-wasm-interface",
  "thiserror 1.0.64",
@@ -10930,7 +10930,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.51.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "async-trait",
  "directories",
@@ -10994,7 +10994,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.38.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -11005,7 +11005,7 @@ dependencies = [
 [[package]]
 name = "sc-storage-monitor"
 version = "0.24.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "clap",
  "fs4 0.7.0",
@@ -11063,7 +11063,7 @@ dependencies = [
 [[package]]
 name = "sc-sysinfo"
 version = "42.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "derive_more 0.99.18",
  "futures",
@@ -11076,14 +11076,14 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d)",
  "sp-io",
 ]
 
 [[package]]
 name = "sc-telemetry"
 version = "28.1.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "chrono",
  "futures",
@@ -11102,7 +11102,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "39.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "chrono",
  "console",
@@ -11130,7 +11130,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "11.1.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
@@ -11141,7 +11141,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "39.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "async-trait",
  "futures",
@@ -11159,7 +11159,7 @@ dependencies = [
  "sp-api",
  "sp-blockchain",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d)",
  "sp-runtime",
  "sp-tracing",
  "sp-transaction-pool",
@@ -11173,7 +11173,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "39.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "async-trait",
  "futures",
@@ -11190,7 +11190,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "18.0.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "async-channel 1.9.0",
  "futures",
@@ -11993,7 +11993,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "36.0.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "docify",
  "hash-db",
@@ -12015,7 +12015,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "22.0.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "Inflector",
  "blake2 0.10.6",
@@ -12029,7 +12029,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "40.1.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12041,7 +12041,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "26.1.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "docify",
  "integer-sqrt",
@@ -12055,7 +12055,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "36.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12080,7 +12080,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "36.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "sp-api",
  "sp-inherents",
@@ -12101,7 +12101,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "39.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -12120,7 +12120,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.42.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "async-trait",
  "futures",
@@ -12134,7 +12134,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.42.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -12150,7 +12150,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.42.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -12168,7 +12168,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-beefy"
 version = "24.1.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12176,7 +12176,7 @@ dependencies = [
  "sp-api",
  "sp-application-crypto",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d)",
  "sp-io",
  "sp-keystore",
  "sp-mmr-primitives",
@@ -12188,7 +12188,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-grandpa"
 version = "23.1.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -12205,7 +12205,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.42.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12244,7 +12244,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "36.1.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "ark-vrf",
  "array-bytes",
@@ -12274,7 +12274,7 @@ dependencies = [
  "secp256k1 0.28.2",
  "secrecy 0.8.0",
  "serde",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d)",
  "sp-debug-derive",
  "sp-externalities",
  "sp-runtime-interface",
@@ -12305,7 +12305,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing"
 version = "0.1.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -12318,17 +12318,17 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "quote",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d)",
  "syn 2.0.111",
 ]
 
 [[package]]
 name = "sp-database"
 version = "10.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.3",
@@ -12337,7 +12337,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "14.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12490,7 +12490,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.30.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -12500,7 +12500,7 @@ dependencies = [
 [[package]]
 name = "sp-genesis-builder"
 version = "0.17.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12512,7 +12512,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "36.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -12525,7 +12525,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "40.0.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "bytes",
  "docify",
@@ -12537,7 +12537,7 @@ dependencies = [
  "rustversion",
  "secp256k1 0.28.2",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d)",
  "sp-externalities",
  "sp-keystore",
  "sp-runtime-interface",
@@ -12551,7 +12551,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "41.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "sp-core",
  "sp-runtime",
@@ -12561,7 +12561,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.42.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
@@ -12572,7 +12572,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "11.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "thiserror 1.0.64",
  "zstd 0.12.4",
@@ -12620,7 +12620,7 @@ dependencies = [
 [[package]]
 name = "sp-metadata-ir"
 version = "0.10.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "frame-metadata 20.0.0",
  "parity-scale-codec",
@@ -12630,7 +12630,7 @@ dependencies = [
 [[package]]
 name = "sp-mixnet"
 version = "0.14.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12641,7 +12641,7 @@ dependencies = [
 [[package]]
 name = "sp-mmr-primitives"
 version = "36.1.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -12666,7 +12666,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "36.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -12676,7 +12676,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "13.0.2"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "backtrace",
  "regex",
@@ -12685,7 +12685,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "34.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "rustc-hash 1.1.0",
  "serde",
@@ -12695,7 +12695,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "41.1.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "binary-merkle-tree",
  "docify",
@@ -12724,7 +12724,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "29.0.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -12743,7 +12743,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "18.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "Inflector",
  "expander",
@@ -12756,7 +12756,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "38.1.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12770,7 +12770,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "38.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -12783,7 +12783,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.45.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "hash-db",
  "log",
@@ -12803,7 +12803,7 @@ dependencies = [
 [[package]]
 name = "sp-statement-store"
 version = "20.1.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "aes-gcm",
  "curve25519-dalek",
@@ -12816,7 +12816,7 @@ dependencies = [
  "sp-api",
  "sp-application-crypto",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d)",
  "sp-externalities",
  "sp-runtime",
  "sp-runtime-interface",
@@ -12827,12 +12827,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "14.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 
 [[package]]
 name = "sp-storage"
 version = "22.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -12862,7 +12862,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "36.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -12874,7 +12874,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "17.1.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "parity-scale-codec",
  "tracing",
@@ -12885,7 +12885,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "36.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -12894,7 +12894,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "36.1.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -12908,7 +12908,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "39.1.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "ahash",
  "hash-db",
@@ -12930,7 +12930,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "39.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -12947,7 +12947,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "15.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "parity-scale-codec",
  "proc-macro-warning",
@@ -12959,7 +12959,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "21.0.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -12971,7 +12971,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "31.1.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "bounded-collections",
  "parity-scale-codec",
@@ -13049,7 +13049,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 [[package]]
 name = "staging-xcm"
 version = "16.2.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "array-bytes",
  "bounded-collections",
@@ -14063,12 +14063,12 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "11.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "44.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "docify",
  "frame-system-rpc-runtime-api",
@@ -14088,7 +14088,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.17.3"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "http-body-util",
  "hyper",
@@ -14102,7 +14102,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-client"
 version = "2.0.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "array-bytes",
  "async-trait",
@@ -14127,7 +14127,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "26.0.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "build-helper",
  "cargo_metadata",
@@ -14877,7 +14877,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum"
 version = "19.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "coarsetime",
  "polkadot-primitives",
@@ -14888,7 +14888,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "expander",
  "proc-macro-crate 3.2.0",
@@ -16333,7 +16333,7 @@ dependencies = [
 [[package]]
 name = "xcm-procedural"
 version = "11.0.2"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=ea14677c8fb2a987b659b7ede504cb37b97c1f78#ea14677c8fb2a987b659b7ede504cb37b97c1f78"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d#2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d"
 dependencies = [
  "Inflector",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ core_affinity = "0.8.1"
 cpufeatures = "0.2.17"
 criterion = { version = "0.5.1", default-features = false }
 cross-domain-message-gossip = { version = "0.1.0", path = "domains/client/cross-domain-message-gossip" }
-cumulus-primitives-proof-size-hostfunction = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
+cumulus-primitives-proof-size-hostfunction = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d", default-features = false }
 derive_more = { version = "1.0.0", default-features = false }
 domain-block-builder = { version = "0.1.0", path = "domains/client/block-builder", default-features = false }
 domain-block-preprocessor = { version = "0.1.0", path = "domains/client/block-preprocessor", default-features = false }
@@ -84,13 +84,13 @@ fp-account = { version = "1.0.0-dev", git = "https://github.com/polkadot-evm/fro
 fp-evm = { version = "3.0.0-dev", git = "https://github.com/polkadot-evm/frontier", rev = "7d1cff7f13828b563752ad8a71458cab1ea42009", default-features = false }
 fp-rpc = { version = "3.0.0-dev", git = "https://github.com/polkadot-evm/frontier", rev = "7d1cff7f13828b563752ad8a71458cab1ea42009", default-features = false }
 fp-self-contained = { version = "1.0.0-dev", git = "https://github.com/polkadot-evm/frontier", rev = "7d1cff7f13828b563752ad8a71458cab1ea42009", default-features = false }
-frame-benchmarking = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
-frame-benchmarking-cli = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
-frame-executive = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
-frame-support = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
-frame-system = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
-frame-system-benchmarking = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
-frame-system-rpc-runtime-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
+frame-benchmarking = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d", default-features = false }
+frame-benchmarking-cli = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d", default-features = false }
+frame-executive = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d", default-features = false }
+frame-support = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d", default-features = false }
+frame-system = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d", default-features = false }
+frame-system-benchmarking = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d", default-features = false }
+frame-system-rpc-runtime-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d", default-features = false }
 fs2 = "0.4.3"
 fs4 = "0.9.1"
 futures = "0.3.31"
@@ -102,15 +102,15 @@ hwlocality = "1.0.0-alpha.6"
 jsonrpsee = "0.24.5"
 kzg = { git = "https://github.com/grandinetech/rust-kzg", rev = "8f5f1a0f73b3c529c77cb880ff8d265830c7d7ac", default-features = false }
 libc = "0.2.159"
-libp2p = { version = "0.56.0", git = "https://github.com/subspace/rust-libp2p", rev = "0c2e22fe724e5101bc5ad5763b1c3d7aa452870a", default-features = false }
-libp2p-swarm-test = { version = "0.6.0", git = "https://github.com/subspace/rust-libp2p", rev = "0c2e22fe724e5101bc5ad5763b1c3d7aa452870a" }
+libp2p = { version = "0.56.0", git = "https://github.com/subspace/rust-libp2p", rev = "7e9532d65530ebd0cf92c53fc326948ee8467fea", default-features = false }
+libp2p-swarm-test = { version = "0.6.0", git = "https://github.com/subspace/rust-libp2p", rev = "7e9532d65530ebd0cf92c53fc326948ee8467fea" }
 libsecp256k1 = "0.7.1"
 log = { version = "0.4.22", default-features = false }
 memmap2 = "0.9.5"
 memory-db = { version = "0.32.0", default-features = false }
 mimalloc = "0.1.43"
-mmr-gadget = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
-mmr-rpc = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
+mmr-gadget = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d" }
+mmr-rpc = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d" }
 multihash = "0.19.1"
 nohash-hasher = "0.2.0"
 num-traits = { version = "0.2.18", default-features = false }
@@ -118,10 +118,10 @@ num_cpus = "1.16.0"
 num_enum = { version = "0.5.3", default-features = false }
 ouroboros = "0.18.4"
 pallet-auto-id = { version = "0.1.0", path = "domains/pallets/auto-id", default-features = false }
-pallet-balances = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
+pallet-balances = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d", default-features = false }
 pallet-block-fees = { version = "0.1.0", path = "domains/pallets/block-fees", default-features = false }
-pallet-collective = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
-pallet-democracy = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
+pallet-collective = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d", default-features = false }
+pallet-democracy = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d", default-features = false }
 pallet-domain-id = { version = "0.1.0", path = "domains/pallets/domain-id", default-features = false }
 pallet-domain-sudo = { version = "0.1.0", path = "domains/pallets/domain-sudo", default-features = false }
 pallet-domains = { version = "0.1.0", path = "crates/pallet-domains", default-features = false }
@@ -133,23 +133,23 @@ pallet-evm-precompile-sha3fips = { version = "2.0.0-dev", git = "https://github.
 pallet-evm-precompile-simple = { version = "2.0.0-dev", git = "https://github.com/polkadot-evm/frontier", rev = "7d1cff7f13828b563752ad8a71458cab1ea42009", default-features = false }
 pallet-evm-tracker = { version = "0.1.0", path = "domains/pallets/evm-tracker", default-features = false }
 pallet-messenger = { version = "0.1.0", path = "domains/pallets/messenger", default-features = false }
-pallet-mmr = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
-pallet-multisig = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
-pallet-preimage = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
+pallet-mmr = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d", default-features = false }
+pallet-multisig = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d", default-features = false }
+pallet-preimage = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d", default-features = false }
 pallet-rewards = { version = "0.1.0", path = "crates/pallet-rewards", default-features = false }
 pallet-runtime-configs = { version = "0.1.0", path = "crates/pallet-runtime-configs", default-features = false }
-pallet-scheduler = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
+pallet-scheduler = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d", default-features = false }
 pallet-storage-overlay-checks = { version = "0.1.0", path = "domains/test/pallets/storage_overlay_checks", default-features = false }
 pallet-subspace = { version = "0.1.0", path = "crates/pallet-subspace", default-features = false }
 pallet-subspace-mmr = { version = "0.1.0", path = "crates/pallet-subspace-mmr", default-features = false }
-pallet-sudo = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
-pallet-timestamp = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
+pallet-sudo = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d", default-features = false }
+pallet-timestamp = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d", default-features = false }
 pallet-transaction-fees = { version = "0.1.0", path = "crates/pallet-transaction-fees", default-features = false }
-pallet-transaction-payment = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
-pallet-transaction-payment-rpc = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
-pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
+pallet-transaction-payment = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d", default-features = false }
+pallet-transaction-payment-rpc = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d" }
+pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d", default-features = false }
 pallet-transporter = { version = "0.1.0", path = "domains/pallets/transporter", default-features = false }
-pallet-utility = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
+pallet-utility = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d", default-features = false }
 parity-scale-codec = { version = "3.7.5", default-features = false }
 parking_lot = "0.12.2"
 pem = "3.0.4"
@@ -167,42 +167,42 @@ ring = "0.17.8"
 rlp = "0.6"
 rs_merkle = { version = "1.4.2", default-features = false }
 rust-kzg-blst = { git = "https://github.com/grandinetech/rust-kzg", rev = "8f5f1a0f73b3c529c77cb880ff8d265830c7d7ac", default-features = false }
-sc-basic-authorship = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
-sc-block-builder = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
-sc-chain-spec = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
-sc-cli = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
-sc-client-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
-sc-client-db = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
-sc-consensus = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
-sc-consensus-slots = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
+sc-basic-authorship = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d" }
+sc-block-builder = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d" }
+sc-chain-spec = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d" }
+sc-cli = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d", default-features = false }
+sc-client-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d" }
+sc-client-db = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d" }
+sc-consensus = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d" }
+sc-consensus-slots = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d" }
 sc-consensus-subspace = { version = "0.1.0", path = "crates/sc-consensus-subspace" }
 sc-consensus-subspace-rpc = { version = "0.1.0", path = "crates/sc-consensus-subspace-rpc" }
 sc-domains = { version = "0.1.0", path = "crates/sc-domains" }
-sc-executor = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
-sc-informant = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
-sc-keystore = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
-sc-network = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
-sc-network-common = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
-sc-network-gossip = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
-sc-network-sync = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
-sc-network-transactions = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
-sc-offchain = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
+sc-executor = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d", default-features = false }
+sc-informant = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d" }
+sc-keystore = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d" }
+sc-network = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d" }
+sc-network-common = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d" }
+sc-network-gossip = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d" }
+sc-network-sync = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d", default-features = false }
+sc-network-transactions = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d" }
+sc-offchain = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d" }
 sc-proof-of-time = { version = "0.1.0", path = "crates/sc-proof-of-time" }
-sc-rpc = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
-sc-rpc-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
-sc-rpc-server = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
-sc-service = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
-sc-state-db = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
-sc-storage-monitor = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
+sc-rpc = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d" }
+sc-rpc-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d" }
+sc-rpc-server = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d" }
+sc-service = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d", default-features = false }
+sc-state-db = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d" }
+sc-storage-monitor = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d", default-features = false }
 sc-subspace-block-relay = { version = "0.1.0", path = "crates/sc-subspace-block-relay" }
 sc-subspace-chain-specs = { version = "0.1.0", path = "crates/sc-subspace-chain-specs" }
 sc-subspace-sync-common = { version = "0.1.0", path = "shared/sc-subspace-sync-common", default-features = false }
-sc-sysinfo = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
-sc-telemetry = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
-sc-tracing = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
-sc-transaction-pool = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
-sc-transaction-pool-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
-sc-utils = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
+sc-sysinfo = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d", default-features = false }
+sc-telemetry = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d" }
+sc-tracing = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d" }
+sc-transaction-pool = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d" }
+sc-transaction-pool-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d" }
+sc-utils = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d" }
 scale-info = { version = "2.11.6", default-features = false }
 schnellru = "0.2.4"
 schnorrkel = { version = "0.11.4", default-features = false }
@@ -211,48 +211,48 @@ serde = { version = "1.0.216", default-features = false }
 serde-big-array = "0.5.1"
 serde_json = "1.0.133"
 sha2 = { version = "0.10.7", default-features = false }
-sp-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
-sp-application-crypto = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
-sp-arithmetic = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
+sp-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d", default-features = false }
+sp-application-crypto = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d", default-features = false }
+sp-arithmetic = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d", default-features = false }
 sp-auto-id = { version = "0.1.0", path = "domains/primitives/auto-id", default-features = false }
-sp-block-builder = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
+sp-block-builder = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d", default-features = false }
 sp-block-fees = { version = "0.1.0", path = "domains/primitives/block-fees", default-features = false }
-sp-blockchain = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
-sp-consensus = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
-sp-consensus-slots = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
+sp-blockchain = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d", default-features = false }
+sp-consensus = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d" }
+sp-consensus-slots = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d", default-features = false }
 sp-consensus-subspace = { version = "0.1.0", path = "crates/sp-consensus-subspace", default-features = false }
-sp-core = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
+sp-core = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d", default-features = false }
 sp-domain-digests = { version = "0.1.0", path = "domains/primitives/digests", default-features = false }
 sp-domain-sudo = { version = "0.1.0", path = "domains/primitives/domain-sudo", default-features = false }
 sp-domains = { version = "0.1.0", path = "crates/sp-domains", default-features = false }
 sp-domains-fraud-proof = { version = "0.1.0", path = "crates/sp-domains-fraud-proof", default-features = false }
 sp-evm-tracker = { version = "0.1.0", path = "domains/primitives/evm-tracker", default-features = false }
 sp-executive = { version = "0.1.0", path = "domains/primitives/executive", default-features = false }
-sp-externalities = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
+sp-externalities = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d", default-features = false }
 sp-evm-precompiles = { version = "0.1.0", path = "domains/primitives/evm-precompiles", default-features = false }
-sp-genesis-builder = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
-sp-inherents = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
-sp-io = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
-sp-keyring = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
-sp-keystore = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
+sp-genesis-builder = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d", default-features = false }
+sp-inherents = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d", default-features = false }
+sp-io = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d", default-features = false }
+sp-keyring = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d" }
+sp-keystore = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d" }
 sp-messenger = { version = "0.1.0", path = "domains/primitives/messenger", default-features = false }
 sp-messenger-host-functions = { version = "0.1.0", path = "domains/primitives/messenger-host-functions", default-features = false }
-sp-mmr-primitives = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
+sp-mmr-primitives = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d", default-features = false }
 sp-objects = { version = "0.1.0", path = "crates/sp-objects", default-features = false }
-sp-offchain = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
-sp-runtime = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
-sp-runtime-interface = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
-sp-session = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
-sp-state-machine = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
-sp-std = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
-sp-storage = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
+sp-offchain = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d", default-features = false }
+sp-runtime = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d", default-features = false }
+sp-runtime-interface = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d", default-features = false }
+sp-session = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d", default-features = false }
+sp-state-machine = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d", default-features = false }
+sp-std = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d", default-features = false }
+sp-storage = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d", default-features = false }
 sp-subspace-mmr = { version = "0.1.0", path = "crates/sp-subspace-mmr", default-features = false }
-sp-timestamp = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
-sp-tracing = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
-sp-transaction-pool = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
-sp-trie = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
-sp-version = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
-sp-weights = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78", default-features = false }
+sp-timestamp = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d", default-features = false }
+sp-tracing = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d", default-features = false }
+sp-transaction-pool = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d", default-features = false }
+sp-trie = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d", default-features = false }
+sp-version = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d", default-features = false }
+sp-weights = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d", default-features = false }
 spin = "0.9.7"
 sppark = { version = "0.1.8", git = "https://github.com/autonomys/sppark", rev = "b2a181eb99c8200f1a604f04122551ea39fbf63f" }
 ss58-registry = "1.51.0"
@@ -281,11 +281,11 @@ subspace-test-runtime = { version = "0.1.0", path = "test/subspace-test-runtime"
 subspace-test-service = { version = "0.1.0", path = "test/subspace-test-service" }
 subspace-verification = { version = "0.1.0", path = "crates/subspace-verification", default-features = false }
 substrate-bip39 = "0.6.0"
-substrate-build-script-utils = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
-substrate-frame-rpc-system = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
-substrate-prometheus-endpoint = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
-substrate-test-client = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
-substrate-wasm-builder = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
+substrate-build-script-utils = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d" }
+substrate-frame-rpc-system = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d" }
+substrate-prometheus-endpoint = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d" }
+substrate-test-client = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d" }
+substrate-wasm-builder = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d" }
 supports-color = "3.0.1"
 tempfile = "3.13.0"
 thiserror = { version = "2.0.0", default-features = false }
@@ -384,51 +384,51 @@ lto = "fat"
 # Reason: We need to patch substrate dependency of frontier to our fork
 # TODO: Remove if/when we are using upstream substrate instead of fork
 [patch."https://github.com/paritytech/polkadot-sdk.git"]
-cumulus-primitives-storage-weight-reclaim = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
-frame-benchmarking = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
-frame-support = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
-frame-system = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
-sc-block-builder = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
-sc-client-db = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
-sc-consensus = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
-sc-consensus-slots = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
-sc-client-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
-sc-network = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
-sc-network-common = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
-sc-network-sync = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
-sc-rpc = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
-sc-service = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
-sc-telemetry = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
-sc-transaction-pool = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
-sc-transaction-pool-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
-sc-utils = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
-sp-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
-sp-application-crypto = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
-sp-arithmetic = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
-sp-block-builder = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
-sp-blockchain = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
-sp-consensus = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
-sp-consensus-slots = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
-sp-core = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
-sp-crypto-hashing = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
-sp-database = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
-sp-debug-derive = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
-sp-externalities = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
-sp-inherents = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
-sp-io = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
-sp-keystore = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
-sp-runtime = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
-sp-runtime-interface = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
-sp-state-machine = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
-sp-std = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
-sp-storage = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
-sp-timestamp = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
-sp-trie = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
-sp-version = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
-sp-weights = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
-staging-xcm = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
-substrate-prometheus-endpoint = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
-xcm-procedural = { git = "https://github.com/subspace/polkadot-sdk", rev = "ea14677c8fb2a987b659b7ede504cb37b97c1f78" }
+cumulus-primitives-storage-weight-reclaim = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d" }
+frame-benchmarking = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d" }
+frame-support = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d" }
+frame-system = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d" }
+sc-block-builder = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d" }
+sc-client-db = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d" }
+sc-consensus = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d" }
+sc-consensus-slots = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d" }
+sc-client-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d" }
+sc-network = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d" }
+sc-network-common = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d" }
+sc-network-sync = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d" }
+sc-rpc = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d" }
+sc-service = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d" }
+sc-telemetry = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d" }
+sc-transaction-pool = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d" }
+sc-transaction-pool-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d" }
+sc-utils = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d" }
+sp-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d" }
+sp-application-crypto = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d" }
+sp-arithmetic = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d" }
+sp-block-builder = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d" }
+sp-blockchain = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d" }
+sp-consensus = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d" }
+sp-consensus-slots = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d" }
+sp-core = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d" }
+sp-crypto-hashing = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d" }
+sp-database = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d" }
+sp-debug-derive = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d" }
+sp-externalities = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d" }
+sp-inherents = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d" }
+sp-io = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d" }
+sp-keystore = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d" }
+sp-runtime = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d" }
+sp-runtime-interface = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d" }
+sp-state-machine = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d" }
+sp-std = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d" }
+sp-storage = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d" }
+sp-timestamp = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d" }
+sp-trie = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d" }
+sp-version = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d" }
+sp-weights = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d" }
+staging-xcm = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d" }
+substrate-prometheus-endpoint = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d" }
+xcm-procedural = { git = "https://github.com/subspace/polkadot-sdk", rev = "2aaf0d6b675cf3b176abbb0e4f91efaa7b61d78d" }
 
 [patch."https://github.com/subspace/polkadot-sdk.git"]
 # De-duplicate extra copy that comes from Substrate repo
@@ -441,12 +441,12 @@ substrate-bip39 = "0.6.0"
 # This is a hack: patches to the same repository are rejected by `cargo`. But it considers
 # "subspace/rust-libp2p" and "autonomys/rust-libp2p" to be different repositories, even though
 # they're redirected to the same place by GitHub, so it allows this patch.
-libp2p = { git = "https://github.com/subspace/rust-libp2p", rev = "0c2e22fe724e5101bc5ad5763b1c3d7aa452870a" }
-libp2p-identity = { git = "https://github.com/subspace/rust-libp2p", rev = "0c2e22fe724e5101bc5ad5763b1c3d7aa452870a" }
-libp2p-kad = { git = "https://github.com/subspace/rust-libp2p", rev = "0c2e22fe724e5101bc5ad5763b1c3d7aa452870a" }
-multistream-select = { git = "https://github.com/subspace/rust-libp2p", rev = "0c2e22fe724e5101bc5ad5763b1c3d7aa452870a" }
+libp2p = { git = "https://github.com/subspace/rust-libp2p", rev = "7e9532d65530ebd0cf92c53fc326948ee8467fea" }
+libp2p-identity = { git = "https://github.com/subspace/rust-libp2p", rev = "7e9532d65530ebd0cf92c53fc326948ee8467fea" }
+libp2p-kad = { git = "https://github.com/subspace/rust-libp2p", rev = "7e9532d65530ebd0cf92c53fc326948ee8467fea" }
+multistream-select = { git = "https://github.com/subspace/rust-libp2p", rev = "7e9532d65530ebd0cf92c53fc326948ee8467fea" }
 
 [patch.crates-io]
 # Patch away `libp2p-identity` in our dependency tree with the git version.
-# For details see: https://github.com/subspace/rust-libp2p/blob/0c2e22fe724e5101bc5ad5763b1c3d7aa452870a/Cargo.toml#L140-L145
-libp2p-identity = { git = "https://github.com/subspace/rust-libp2p", rev = "0c2e22fe724e5101bc5ad5763b1c3d7aa452870a" }
+# For details see: https://github.com/subspace/rust-libp2p/blob/7e9532d65530ebd0cf92c53fc326948ee8467fea/Cargo.toml#L140-L145
+libp2p-identity = { git = "https://github.com/subspace/rust-libp2p", rev = "7e9532d65530ebd0cf92c53fc326948ee8467fea" }


### PR DESCRIPTION
Backported https://github.com/libp2p/rust-libp2p/pull/6138#issuecomment-3746931640 into our libp2p fork.
While this remove `lru` from libp2p completely, substrate's `frame-benchmarking-cli` still pulls `lru 0.12.4` through `smoldot-light`. This is only used when we are benchmarking runtimes.

There is a recent patch for smoldot here https://github.com/smol-dot/smoldot/commit/c10714d86dd71bd115715942517122197f4ae051 but this has not been made into latest release.

For now, leaving them as is in our fork. Will most likely pick up myself with updating upstream once release has been made
### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
