### PR TITLE
Offline operator detections: Reduce the tau from 1% to 0.5% 

### DIFF
--- a/crates/pallet-domains/src/staking_epoch.rs
+++ b/crates/pallet-domains/src/staking_epoch.rs
@@ -24,7 +24,7 @@ use parity_scale_codec::{Decode, DecodeWithMemTracking, Encode};
 use scale_info::TypeInfo;
 use sp_core::Get;
 use sp_domains::offline_operators::{
-    E_BASE, LN_1_OVER_TAU_1_PERCENT, operator_expected_bundles_in_epoch,
+    E_BASE, LN_1_OVER_TAU_0_5_PERCENT, operator_expected_bundles_in_epoch,
 };
 use sp_domains::{DomainId, EpochIndex, OperatorId, OperatorRewardSource};
 use sp_runtime::traits::{CheckedAdd, CheckedSub, One, Zero};
@@ -271,7 +271,7 @@ pub(crate) fn do_finalize_domain_epoch_staking<T: Config>(
                     (*operator_stake).saturated_into(),
                     epoch_total_stake.saturated_into(),
                     bundle_slot_probability,
-                    LN_1_OVER_TAU_1_PERCENT,
+                    LN_1_OVER_TAU_0_5_PERCENT,
                     E_BASE,
                 );
 

--- a/crates/sp-domains/src/offline_operators.rs
+++ b/crates/sp-domains/src/offline_operators.rs
@@ -34,6 +34,10 @@ use sp_core::{DecodeWithMemTracking, U256};
 /// Represent in FixedU128 by multiplying by 1e18 and rounding.
 pub const LN_1_OVER_TAU_1_PERCENT: FixedU128 = FixedU128::from_inner(4_605_170_185_988_091_904);
 
+// For τ = 0.5%: ln(1/τ) = ln(200) ≈ 5.298317366548036
+// Represent in FixedU128 by multiplying by 1e18 and rounding.
+pub const LN_1_OVER_TAU_0_5_PERCENT: FixedU128 = FixedU128::from_inner(5_298_317_366_548_036_608);
+
 /// Threshold for number of bundles operator can produce based on their stake share.
 /// Operators whose expected bundles from their threshold < E_BASE will not be checked
 /// since they are not throughput relevant.


### PR DESCRIPTION
Further reduce the tau from 1% to 0.5% to be little lenient towards offline operator detection. We initially started with 1% to test out the offline detection mechanism but turns out 1% tau was a bit too strict leading to many false positives on both chronos and mainnet.

Reducing the tau to 0.5% and should Ideally be a much better guage for offline operator detection with reduced false positives.


Tests are updated to use 0.5% tau to ensure no unexpected calculations and some new tests are added to ensure updating tau at a later time without doing same set of changes everytime.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
