### PR TITLE
ensure dst_location does not allow xdm transfers to zero account on substrate as well

### DIFF
--- a/domains/pallets/transporter/src/lib.rs
+++ b/domains/pallets/transporter/src/lib.rs
@@ -49,6 +49,7 @@ pub use weights::WeightInfo;
 /// Zero EVM address.
 /// Used to ensure dst_account is not ZERO address.
 const ZERO_EVM_ADDRESS: MultiAccountId = MultiAccountId::AccountId20([0; 20]);
+const ZERO_SUBSTRATE_ADDRESS: MultiAccountId = MultiAccountId::AccountId32([0; 32]);
 
 /// Location that either sends or receives transfers between chains.
 #[derive(Debug, Encode, Decode, Clone, Eq, PartialEq, TypeInfo, DecodeWithMemTracking)]
@@ -83,7 +84,7 @@ mod pallet {
     use crate::weights::WeightInfo;
     use crate::{
         BalanceOf, Location, MessageIdOf, MultiAccountId, Transfer, TryConvertBack,
-        ZERO_EVM_ADDRESS,
+        ZERO_EVM_ADDRESS, ZERO_SUBSTRATE_ADDRESS,
     };
     #[cfg(not(feature = "std"))]
     use alloc::vec::Vec;
@@ -262,6 +263,11 @@ mod pallet {
 
             ensure!(
                 dst_location.account_id != ZERO_EVM_ADDRESS,
+                Error::<T>::InvalidAccountId
+            );
+
+            ensure!(
+                dst_location.account_id != ZERO_SUBSTRATE_ADDRESS,
                 Error::<T>::InvalidAccountId
             );
 

--- a/domains/pallets/transporter/src/tests.rs
+++ b/domains/pallets/transporter/src/tests.rs
@@ -200,7 +200,7 @@ fn test_transfer_invalid_account_id_substrate() {
     new_test_ext().execute_with(|| {
         let account = USER_ACCOUNT;
         let amount: Balance = 500;
-        // transfer 500 to dst_chain id 100
+        // transfer 500 to dst_chain id 1
         let dst_chain_id: ChainId = 1.into();
         let dst_location = Location {
             chain_id: dst_chain_id,

--- a/domains/pallets/transporter/src/tests.rs
+++ b/domains/pallets/transporter/src/tests.rs
@@ -196,6 +196,23 @@ fn test_transfer_invalid_account_id() {
 }
 
 #[test]
+fn test_transfer_invalid_account_id_substrate() {
+    new_test_ext().execute_with(|| {
+        let account = USER_ACCOUNT;
+        let amount: Balance = 500;
+        // transfer 500 to dst_chain id 100
+        let dst_chain_id: ChainId = 1.into();
+        let dst_location = Location {
+            chain_id: dst_chain_id,
+            account_id: MultiAccountId::AccountId32([0; 32]),
+        };
+
+        let res = Transporter::transfer(RuntimeOrigin::signed(account), dst_location, amount);
+        assert_err!(res, Error::<MockRuntime>::InvalidAccountId)
+    })
+}
+
+#[test]
 fn test_transfer_response_revert() {
     new_test_ext().execute_with(|| {
         let account = USER_ACCOUNT;


### PR DESCRIPTION
This PR disallows transferring value to zero accounts on substrate accounts

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
