### PR TITLE
update yamux 0.13.8 → 0.13.9 and stop downgrading to 0.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6513,7 +6513,7 @@ dependencies = [
  "thiserror 2.0.12",
  "tracing",
  "yamux 0.12.1",
- "yamux 0.13.8",
+ "yamux 0.13.9",
 ]
 
 [[package]]
@@ -6680,7 +6680,7 @@ dependencies = [
  "url",
  "x25519-dalek",
  "x509-parser 0.17.0",
- "yamux 0.13.8",
+ "yamux 0.13.9",
  "yasna",
  "zeroize",
 ]
@@ -16373,9 +16373,9 @@ dependencies = [
 
 [[package]]
 name = "yamux"
-version = "0.13.8"
+version = "0.13.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deab71f2e20691b4728b349c6cee8fc7223880fa67b6b4f92225ec32225447e5"
+checksum = "c650efd29044140aa63caaf80129996a9e2659a2ab7045a7e061807d02fc8549"
 dependencies = [
  "futures",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1558,9 +1558,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 dependencies = [
  "serde",
 ]
@@ -2666,12 +2666,12 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.3.11"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -7411,9 +7411,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
 
 [[package]]
 name = "num-derive"
@@ -14579,30 +14579,30 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.36"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
  "num-conv",
  "powerfmt",
- "serde",
+ "serde_core",
  "time-core",
  "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.2"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.18"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ bitvec = "1.0.1"
 blake2 = { version = "0.10.6", default-features = false }
 blake3 = { version = "1.8.2", default-features = false }
 blst = "0.3.13"
-bytes = { version = "1.7.2", default-features = false }
+bytes = { version = "1.11.1", default-features = false }
 bytesize = "1.3.0"
 cc = "1.1.23"
 chacha20 = { version = "0.9.1", default-features = false }

--- a/crates/subspace-networking/src/constructor.rs
+++ b/crates/subspace-networking/src/constructor.rs
@@ -77,13 +77,6 @@ const TEMPORARY_BANS_DEFAULT_MAX_INTERVAL: Duration = Duration::from_secs(30 * 6
 /// wasting resources and producing a ton of log records.
 const DIALING_INTERVAL_IN_SECS: Duration = Duration::from_secs(1);
 
-/// Specific YAMUX settings for Subspace applications: additional buffer space for pieces and
-/// substream's limit.
-///
-/// Defines a replication factor for Kademlia on get_record operation.
-/// "Good citizen" supports the network health.
-const YAMUX_MAX_STREAMS: usize = 256;
-
 /// Max confidence for autonat protocol. Could affect Kademlia mode change.
 pub(crate) const AUTONAT_MAX_CONFIDENCE: usize = 3;
 /// We set a very long pause before autonat initialization (Duration::Max panics).
@@ -279,8 +272,9 @@ impl Config {
             .set_record_ttl(None)
             .set_replication_interval(None);
 
-        let mut yamux_config = YamuxConfig::default();
-        yamux_config.set_max_num_streams(YAMUX_MAX_STREAMS);
+        // NOTE: Do not call deprecated setters like `set_max_num_streams()` on this config.
+        // They silently downgrade from yamux 0.13 to 0.12, which has a remote DoS vulnerability.
+        let yamux_config = YamuxConfig::default();
 
         let gossipsub = ENABLE_GOSSIP_PROTOCOL.then(|| {
             GossipsubConfigBuilder::default()


### PR DESCRIPTION
The call to `set_max_num_streams()` was silently switching from yamux 0.13 to 0.12 at runtime (the deprecated setter triggers a fallback in libp2p-yamux). Remove the call and the unused YAMUX_MAX_STREAMS constant so connections stay on the patched 0.13 path.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
