### PR TITLE
Backport PoS table optimizations from Abundance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,6 +13,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "ab-chacha8"
+version = "0.1.0"
+dependencies = [
+ "chacha20",
+ "no-panic",
+]
+
+[[package]]
 name = "actix-codec"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1448,15 +1456,6 @@ name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
-dependencies = [
- "generic-array 0.14.7",
-]
-
-[[package]]
-name = "block-padding"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
 dependencies = [
  "generic-array 0.14.7",
 ]
@@ -5640,7 +5639,6 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
 dependencies = [
- "block-padding",
  "generic-array 0.14.7",
 ]
 
@@ -7316,6 +7314,17 @@ dependencies = [
  "log",
  "rand 0.8.5",
  "signatory",
+]
+
+[[package]]
+name = "no-panic"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "113d1abd5bb3dc25a75d9b3a973f40e31eb03e0bae23c172b32cca4bcb9cfad2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -13639,16 +13648,15 @@ dependencies = [
 name = "subspace-proof-of-space"
 version = "0.1.0"
 dependencies = [
- "bitvec",
+ "ab-chacha8",
  "blake3",
  "chacha20",
  "criterion",
  "derive_more 1.0.0",
- "parking_lot 0.12.3",
+ "hex",
  "rayon",
  "seq-macro",
  "sha2 0.10.8",
- "spin 0.9.8",
  "subspace-core-primitives",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ members = [
 ]
 
 [workspace.dependencies]
+ab-chacha8 = { version = "0.1.0", path = "shared/ab-chacha8" }
 actix-web = { version = "4.9.0", default-features = false }
 aes = "0.9.0-pre.2"
 anyhow = "1.0.89"
@@ -113,6 +114,7 @@ mmr-gadget = { git = "https://github.com/subspace/polkadot-sdk", rev = "1a4f8929
 mmr-rpc = { git = "https://github.com/subspace/polkadot-sdk", rev = "1a4f892900ab0eba51f729cca4caeaab0627efed" }
 multihash = "0.19.1"
 nohash-hasher = "0.2.0"
+no-panic = "0.1.35"
 num-traits = { version = "0.2.18", default-features = false }
 num_cpus = "1.16.0"
 num_enum = { version = "0.5.3", default-features = false }

--- a/crates/sp-consensus-subspace/Cargo.toml
+++ b/crates/sp-consensus-subspace/Cargo.toml
@@ -58,7 +58,7 @@ std = [
     "sp-weights/std",
     "subspace-core-primitives/std",
     "subspace-kzg/std",
-    "subspace-proof-of-space/std",
+    "subspace-proof-of-space/alloc",
     "subspace-verification/kzg",
     "subspace-verification/std",
     "thiserror/std",

--- a/crates/subspace-core-primitives/src/solutions.rs
+++ b/crates/subspace-core-primitives/src/solutions.rs
@@ -1,7 +1,7 @@
 //! Solutions-related data structures and functions.
 
 use crate::pieces::{PieceOffset, Record, RecordCommitment, RecordWitness};
-use crate::pos::PosProof;
+use crate::pos::{PosProof, PosSeed};
 use crate::sectors::SectorIndex;
 use crate::segments::{HistorySize, SegmentIndex};
 use crate::{PublicKey, ScalarBytes};
@@ -239,6 +239,12 @@ impl AsMut<[u8]> for ChunkWitness {
 impl ChunkWitness {
     /// Size of chunk witness in bytes.
     pub const SIZE: usize = 48;
+}
+
+/// Proof-of-time verifier trait, used in abundance backports.
+pub trait SolutionPotVerifier {
+    /// Check whether proof created earlier is valid
+    fn is_proof_valid(seed: &PosSeed, challenge_index: u32, proof: &PosProof) -> bool;
 }
 
 /// Farmer solution for slot challenge.

--- a/crates/subspace-proof-of-space/Cargo.toml
+++ b/crates/subspace-proof-of-space/Cargo.toml
@@ -6,52 +6,51 @@ version = "0.1.0"
 authors = ["Nazar Mokrynskyi <nazar@mokrynskyi.com>"]
 edition.workspace = true
 include = [
-    "/benches",
     "/src",
     "/Cargo.toml",
 ]
+
+[package.metadata.docs.rs]
+all-features = true
 
 [lib]
 # Necessary for CLI options to work on benches
 bench = false
 
 [dependencies]
+ab-chacha8.workspace = true
 blake3 = { workspace = true, default-features = false }
-chacha20.workspace = true
+chacha20 = { workspace = true, optional = true }
 derive_more = { workspace = true, features = ["full"] }
-parking_lot = { workspace = true, optional = true }
 rayon = { workspace = true, optional = true }
-seq-macro.workspace = true
-sha2.workspace = true
-spin.workspace = true
+seq-macro = { workspace = true, optional = true }
+sha2 = { workspace = true, optional = true }
 subspace-core-primitives.workspace = true
 
 [dev-dependencies]
-bitvec.workspace = true
+chacha20.workspace = true
 criterion.workspace = true
+hex.workspace = true
 rayon.workspace = true
+seq-macro.workspace = true
+sha2.workspace = true
 
 [[bench]]
 name = "pos"
 harness = false
 
 [features]
-default = ["std"]
-std = [
-    # TODO: `std` will not be necessary once 1.8.3+ is released with https://github.com/BLAKE3-team/BLAKE3/pull/469
-    "blake3/std",
-    "chacha20/std",
-    "derive_more/std",
-    # In no-std environment we use `spin`
-    "parking_lot",
-    "sha2/std",
-    "subspace-core-primitives/std",
+default = []
+alloc = [
+    "dep:chacha20",
+    "dep:seq-macro",
+]
+# Enabling this feature exposes quality search on `chiapos` module as well as enables support for K=15..=25 (by default
+# only K=20 is exposed)
+full-chiapos = [
+    "dep:sha2",
 ]
 parallel = [
+    "alloc",
     "dep:rayon",
 ]
-
-# The std and no_std features are mutually exclusive, so when checking for unused dependencies,
-# ignore the `spin` dependency, which is only used in no_std.
-[package.metadata.cargo-udeps.ignore]
-normal = ["spin"]

--- a/crates/subspace-proof-of-space/benches/pos.rs
+++ b/crates/subspace-proof-of-space/benches/pos.rs
@@ -1,11 +1,42 @@
+//! Proof of space benchmarks
+
 #![feature(const_trait_impl)]
 
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+#[cfg(feature = "alloc")]
+use criterion::Throughput;
+use criterion::{Criterion, criterion_group, criterion_main};
 #[cfg(feature = "parallel")]
 use rayon::ThreadPoolBuilder;
+#[cfg(feature = "alloc")]
+use std::hint::black_box;
+#[cfg(feature = "alloc")]
+use subspace_core_primitives::pieces::Record;
+#[cfg(feature = "alloc")]
 use subspace_core_primitives::pos::PosSeed;
-use subspace_proof_of_space::{Table, TableGenerator};
+use subspace_proof_of_space::Table;
+#[cfg(feature = "alloc")]
+use subspace_proof_of_space::TableGenerator;
 
+#[cfg(not(feature = "alloc"))]
+#[expect(
+    clippy::extra_unused_type_parameters,
+    reason = "Needs to match the normal version of the function"
+)]
+fn pos_bench<PosTable>(
+    _c: &mut Criterion,
+    _name: &'static str,
+    _challenge_index_without_solution: u32,
+    _challenge_index_with_solution: u32,
+) where
+    PosTable: Table,
+{
+    panic!(
+        "`alloc` feature needs to be enabled to run benchmarks (`parallel` for benchmarking \
+        parallel version)"
+    )
+}
+
+#[cfg(feature = "alloc")]
 fn pos_bench<PosTable>(
     c: &mut Criterion,
     name: &'static str,
@@ -30,38 +61,132 @@ fn pos_bench<PosTable>(
 
     let mut group = c.benchmark_group(name);
 
-    let mut generator_instance = PosTable::generator();
-    group.bench_function("table/single", |b| {
+    let generator = PosTable::generator();
+    group.throughput(Throughput::Elements(1));
+    group.bench_function("table/single/1x", |b| {
         b.iter(|| {
-            generator_instance.generate(black_box(&seed));
+            generator.generate(black_box(&seed));
         });
     });
 
     #[cfg(feature = "parallel")]
     {
-        let mut generator_instance = PosTable::generator();
+        {
+            group.throughput(Throughput::Elements(2));
+            group.bench_function("table/single/2x", |b| {
+                b.iter(|| {
+                    rayon::scope(|scope| {
+                        for _ in 0..2 {
+                            scope.spawn(|_scope| {
+                                generator.generate(black_box(&seed));
+                            });
+                        }
+                    });
+                });
+            });
+        }
+
+        {
+            group.throughput(Throughput::Elements(4));
+            group.bench_function("table/single/4x", |b| {
+                b.iter(|| {
+                    rayon::scope(|scope| {
+                        for _ in 0..4 {
+                            scope.spawn(|_scope| {
+                                generator.generate(black_box(&seed));
+                            });
+                        }
+                    });
+                });
+            });
+        }
+
+        {
+            group.throughput(Throughput::Elements(8));
+            group.bench_function("table/single/8x", |b| {
+                b.iter(|| {
+                    rayon::scope(|scope| {
+                        for _ in 0..8 {
+                            scope.spawn(|_scope| {
+                                generator.generate(black_box(&seed));
+                            });
+                        }
+                    });
+                });
+            });
+        }
+
+        {
+            group.throughput(Throughput::Elements(16));
+            group.bench_function("table/single/16x", |b| {
+                b.iter(|| {
+                    rayon::scope(|scope| {
+                        for _ in 0..16 {
+                            scope.spawn(|_scope| {
+                                generator.generate(black_box(&seed));
+                            });
+                        }
+                    });
+                });
+            });
+        }
+    }
+
+    #[cfg(feature = "parallel")]
+    {
+        group.throughput(Throughput::Elements(1));
         group.bench_function("table/parallel/1x", |b| {
             b.iter(|| {
-                generator_instance.generate_parallel(black_box(&seed));
+                generator.generate_parallel(black_box(&seed));
             });
         });
 
-        let mut generator_instances = [
-            PosTable::generator(),
-            PosTable::generator(),
-            PosTable::generator(),
-            PosTable::generator(),
-            PosTable::generator(),
-            PosTable::generator(),
-            PosTable::generator(),
-            PosTable::generator(),
-        ];
+        group.throughput(Throughput::Elements(2));
+        group.bench_function("table/parallel/2x", |b| {
+            b.iter(|| {
+                rayon::scope(|scope| {
+                    for _ in 0..2 {
+                        scope.spawn(|_scope| {
+                            generator.generate_parallel(black_box(&seed));
+                        });
+                    }
+                });
+            });
+        });
+
+        group.throughput(Throughput::Elements(4));
+        group.bench_function("table/parallel/4x", |b| {
+            b.iter(|| {
+                rayon::scope(|scope| {
+                    for _ in 0..4 {
+                        scope.spawn(|_scope| {
+                            generator.generate_parallel(black_box(&seed));
+                        });
+                    }
+                });
+            });
+        });
+
+        group.throughput(Throughput::Elements(8));
         group.bench_function("table/parallel/8x", |b| {
             b.iter(|| {
                 rayon::scope(|scope| {
-                    for g in &mut generator_instances {
+                    for _ in 0..8 {
                         scope.spawn(|_scope| {
-                            g.generate_parallel(black_box(&seed));
+                            generator.generate_parallel(black_box(&seed));
+                        });
+                    }
+                });
+            });
+        });
+
+        group.throughput(Throughput::Elements(16));
+        group.bench_function("table/parallel/16x", |b| {
+            b.iter(|| {
+                rayon::scope(|scope| {
+                    for _ in 0..16 {
+                        scope.spawn(|_scope| {
+                            generator.generate_parallel(black_box(&seed));
                         });
                     }
                 });
@@ -69,8 +194,9 @@ fn pos_bench<PosTable>(
         });
     }
 
-    let table = generator_instance.generate(&seed);
+    let table = generator.generate(&seed);
 
+    group.throughput(Throughput::Elements(1));
     group.bench_function("proof/missing", |b| {
         b.iter(|| {
             assert!(
@@ -81,6 +207,7 @@ fn pos_bench<PosTable>(
         });
     });
 
+    group.throughput(Throughput::Elements(1));
     group.bench_function("proof/present", |b| {
         b.iter(|| {
             assert!(
@@ -91,11 +218,28 @@ fn pos_bench<PosTable>(
         });
     });
 
+    group.throughput(Throughput::Elements(1));
+    group.bench_function("proof/for-record", |b| {
+        b.iter(|| {
+            let mut found_proofs = 0_usize;
+            for challenge_index in 0..Record::NUM_S_BUCKETS as u32 {
+                if table.find_proof(black_box(challenge_index)).is_some() {
+                    found_proofs += 1;
+
+                    if found_proofs == Record::NUM_CHUNKS {
+                        break;
+                    }
+                }
+            }
+        });
+    });
+
     let proof = table.find_proof(challenge_index_with_solution).unwrap();
 
+    group.throughput(Throughput::Elements(1));
     group.bench_function("verification", |b| {
         b.iter(|| {
-            assert!(PosTable::is_proof_valid(
+            assert!(<PosTable as Table>::is_proof_valid(
                 &seed,
                 challenge_index_with_solution,
                 &proof
@@ -121,9 +265,9 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     }
     {
         // This challenge index with above seed is known to not have a solution
-        let challenge_index_without_solution = 0;
+        let challenge_index_without_solution = 1;
         // This challenge index with above seed is known to have a solution
-        let challenge_index_with_solution = 2;
+        let challenge_index_with_solution = 0;
 
         pos_bench::<subspace_proof_of_space::shim::ShimTable>(
             c,

--- a/crates/subspace-proof-of-space/benches/pos.rs
+++ b/crates/subspace-proof-of-space/benches/pos.rs
@@ -265,9 +265,9 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     }
     {
         // This challenge index with above seed is known to not have a solution
-        let challenge_index_without_solution = 1;
+        let challenge_index_without_solution = 0;
         // This challenge index with above seed is known to have a solution
-        let challenge_index_with_solution = 0;
+        let challenge_index_with_solution = 1;
 
         pos_bench::<subspace_proof_of_space::shim::ShimTable>(
             c,

--- a/crates/subspace-proof-of-space/src/chia.rs
+++ b/crates/subspace-proof-of-space/src/chia.rs
@@ -1,77 +1,80 @@
 //! Chia proof of space implementation
-use crate::chiapos::{Tables, TablesCache};
-use crate::{PosTableType, Table, TableGenerator};
-use core::mem;
+#[cfg(feature = "alloc")]
+use crate::TableGenerator;
+use crate::chiapos::Tables;
+#[cfg(feature = "alloc")]
+use crate::chiapos::TablesCache;
+use crate::{PosTableType, Table};
 use subspace_core_primitives::pos::{PosProof, PosSeed};
 
 const K: u8 = PosProof::K;
 
-/// Subspace proof of space table generator.
+/// Proof of space table generator.
 ///
 /// Chia implementation.
 #[derive(Debug, Default, Clone)]
+#[cfg(feature = "alloc")]
 pub struct ChiaTableGenerator {
-    tables_cache: TablesCache<K>,
+    tables_cache: TablesCache,
 }
 
+#[cfg(feature = "alloc")]
 impl TableGenerator<ChiaTable> for ChiaTableGenerator {
-    fn generate(&mut self, seed: &PosSeed) -> ChiaTable {
+    fn generate(&self, seed: &PosSeed) -> ChiaTable {
         ChiaTable {
-            tables: Tables::<K>::create((*seed).into(), &mut self.tables_cache),
+            tables: Tables::<K>::create((*seed).into(), &self.tables_cache),
         }
     }
 
-    #[cfg(any(feature = "parallel", test))]
-    fn generate_parallel(&mut self, seed: &PosSeed) -> ChiaTable {
+    #[cfg(feature = "parallel")]
+    fn generate_parallel(&self, seed: &PosSeed) -> ChiaTable {
         ChiaTable {
-            tables: Tables::<K>::create_parallel((*seed).into(), &mut self.tables_cache),
+            tables: Tables::<K>::create_parallel((*seed).into(), &self.tables_cache),
         }
     }
 }
 
-/// Subspace proof of space table.
+/// Proof of space table.
 ///
 /// Chia implementation.
 #[derive(Debug)]
 pub struct ChiaTable {
+    #[cfg(feature = "alloc")]
     tables: Tables<K>,
+}
+
+impl subspace_core_primitives::solutions::SolutionPotVerifier for ChiaTable {
+    fn is_proof_valid(seed: &PosSeed, challenge_index: u32, proof: &PosProof) -> bool {
+        Tables::<K>::verify_only(seed, challenge_index.to_le_bytes(), proof)
+    }
 }
 
 impl Table for ChiaTable {
     const TABLE_TYPE: PosTableType = PosTableType::Chia;
+    #[cfg(feature = "alloc")]
     type Generator = ChiaTableGenerator;
 
-    fn generate(seed: &PosSeed) -> ChiaTable {
-        Self {
-            tables: Tables::<K>::create_simple((*seed).into()),
-        }
-    }
-
-    #[cfg(any(feature = "parallel", test))]
-    fn generate_parallel(seed: &PosSeed) -> ChiaTable {
-        Self {
-            tables: Tables::<K>::create_parallel((*seed).into(), &mut TablesCache::default()),
-        }
-    }
-
+    #[cfg(feature = "alloc")]
     fn find_proof(&self, challenge_index: u32) -> Option<PosProof> {
-        let mut challenge = [0; 32];
-        challenge[..mem::size_of::<u32>()].copy_from_slice(&challenge_index.to_le_bytes());
+        let first_challenge_bytes = challenge_index.to_le_bytes();
 
         self.tables
-            .find_proof(&challenge)
+            .find_proof(first_challenge_bytes)
             .next()
             .map(PosProof::from)
     }
 
     fn is_proof_valid(seed: &PosSeed, challenge_index: u32, proof: &PosProof) -> bool {
-        let mut challenge = [0; 32];
-        challenge[..mem::size_of::<u32>()].copy_from_slice(&challenge_index.to_le_bytes());
-        Tables::<K>::verify(**seed, &challenge, proof).is_some()
+        <Self as subspace_core_primitives::solutions::SolutionPotVerifier>::is_proof_valid(
+            seed,
+            challenge_index,
+            proof,
+        )
     }
 }
 
-#[cfg(test)]
+#[cfg(all(feature = "alloc", test))]
+#[cfg(not(miri))]
 mod tests {
     use super::*;
 
@@ -82,15 +85,19 @@ mod tests {
             198, 204, 10, 9, 10, 11, 129, 139, 171, 15, 23,
         ]);
 
-        let table = ChiaTable::generate(&seed);
-        let table_parallel = ChiaTable::generate_parallel(&seed);
+        let generator = ChiaTableGenerator::default();
+        let table = generator.generate(&seed);
+        #[cfg(feature = "parallel")]
+        let table_parallel = generator.generate_parallel(&seed);
 
         assert!(table.find_proof(1232460437).is_none());
+        #[cfg(feature = "parallel")]
         assert!(table_parallel.find_proof(1232460437).is_none());
 
         {
             let challenge_index = 600426542;
             let proof = table.find_proof(challenge_index).unwrap();
+            #[cfg(feature = "parallel")]
             assert_eq!(proof, table_parallel.find_proof(challenge_index).unwrap());
             assert!(ChiaTable::is_proof_valid(&seed, challenge_index, &proof));
         }

--- a/crates/subspace-proof-of-space/src/chiapos.rs
+++ b/crates/subspace-proof-of-space/src/chiapos.rs
@@ -5,59 +5,51 @@ mod table;
 mod tables;
 mod utils;
 
+#[cfg(feature = "alloc")]
 pub use crate::chiapos::table::TablesCache;
-use crate::chiapos::table::metadata_size_bytes;
+use crate::chiapos::table::{metadata_size_bytes, num_buckets};
 use crate::chiapos::tables::TablesGeneric;
 use crate::chiapos::utils::EvaluatableUsize;
 
 type Seed = [u8; 32];
+#[cfg(any(feature = "full-chiapos", test))]
 type Challenge = [u8; 32];
+#[cfg(any(feature = "full-chiapos", test))]
 type Quality = [u8; 32];
 
 /// Collection of Chia tables
 #[derive(Debug)]
 pub struct Tables<const K: u8>(TablesGeneric<K>)
 where
-    EvaluatableUsize<{ metadata_size_bytes(K, 1) }>: Sized,
-    EvaluatableUsize<{ metadata_size_bytes(K, 2) }>: Sized,
-    EvaluatableUsize<{ metadata_size_bytes(K, 3) }>: Sized,
-    EvaluatableUsize<{ metadata_size_bytes(K, 4) }>: Sized,
-    EvaluatableUsize<{ metadata_size_bytes(K, 5) }>: Sized,
-    EvaluatableUsize<{ metadata_size_bytes(K, 6) }>: Sized,
-    EvaluatableUsize<{ metadata_size_bytes(K, 7) }>: Sized;
+    EvaluatableUsize<{ metadata_size_bytes(K, 7) }>: Sized,
+    [(); 1 << K]:,
+    [(); num_buckets(K)]:,
+    [(); num_buckets(K) - 1]:;
 
 macro_rules! impl_any {
     ($($k: expr$(,)? )*) => {
         $(
 impl Tables<$k> {
     /// Create Chia proof of space tables. There also exists [`Self::create_parallel()`] that trades
-    /// CPU efficiency and memory usage for lower latency.
-    ///
-    /// Advanced version of [`Self::create_simple`] that allows to reuse cache.
-    pub fn create(seed: Seed, cache: &mut TablesCache<$k>) -> Self {
+    /// memory usage for lower latency and higher CPU efficiency.
+    #[cfg(feature = "alloc")]
+    pub fn create(seed: Seed, cache: &TablesCache) -> Self {
         Self(TablesGeneric::<$k>::create(
             seed, cache,
         ))
     }
 
     /// Almost the same as [`Self::create()`], but uses parallelism internally for better
-    /// performance (though not efficiency of CPU and memory usage), if you create multiple tables
-    /// in parallel, prefer [`Self::create()`] for better overall performance.
-    #[cfg(any(feature = "parallel", test))]
-    pub fn create_parallel(seed: Seed, cache: &mut TablesCache<$k>) -> Self {
+    /// latency and performance (though higher memory usage).
+    #[cfg(feature = "parallel")]
+    pub fn create_parallel(seed: Seed, cache: &TablesCache) -> Self {
         Self(TablesGeneric::<$k>::create_parallel(
             seed, cache,
         ))
     }
 
-    /// Create Chia proof of space tables.
-    ///
-    /// Simpler version of [`Self::create`].
-    pub fn create_simple(seed: Seed) -> Self {
-        Self::create(seed, &mut TablesCache::default())
-    }
-
-    /// Find proof of space quality for given challenge.
+    /// Find proof of space quality for a given challenge.
+    #[cfg(all(feature = "alloc", any(feature = "full-chiapos", test)))]
     pub fn find_quality<'a>(
         &'a self,
         challenge: &'a Challenge,
@@ -65,17 +57,30 @@ impl Tables<$k> {
         self.0.find_quality(challenge)
     }
 
-    /// Find proof of space for given challenge.
+    /// Find proof of space for a given challenge.
+    #[cfg(feature = "alloc")]
     pub fn find_proof<'a>(
         &'a self,
-        challenge: &'a Challenge,
+        first_challenge_bytes: [u8; 4],
     ) -> impl Iterator<Item = [u8; 64 * $k / 8]> + 'a {
-        self.0.find_proof(challenge)
+        self.0.find_proof(first_challenge_bytes)
     }
 
-    /// Verify proof of space for given seed and challenge.
+    /// Verify proof of space for a given seed and challenge
+    pub fn verify_only(
+        seed: &Seed,
+        first_challenge_bytes: [u8; 4],
+        proof_of_space: &[u8; 64 * $k as usize / 8],
+    ) -> bool {
+        TablesGeneric::<$k>::verify_only(seed, first_challenge_bytes, proof_of_space)
+    }
+
+    /// Verify proof of space for a given seed and challenge.
+    ///
+    /// Similar to [`Self::verify_only()`], but also returns quality on successful verification.
+    #[cfg(any(feature = "full-chiapos", test))]
     pub fn verify(
-        seed: Seed,
+        seed: &Seed,
         challenge: &Challenge,
         proof_of_space: &[u8; 64 * $k as usize / 8],
     ) -> Option<Quality> {
@@ -86,5 +91,9 @@ impl Tables<$k> {
     }
 }
 
-// Only these k values are supported by current implementation
-impl_any!(15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25);
+// Only these k values are supported by the current implementation
+#[cfg(feature = "full-chiapos")]
+impl_any!(15, 16, 18, 19, 21, 22, 23, 24, 25);
+#[cfg(any(feature = "full-chiapos", test))]
+impl_any!(17);
+impl_any!(20);

--- a/crates/subspace-proof-of-space/src/chiapos/constants.rs
+++ b/crates/subspace-proof-of-space/src/chiapos/constants.rs
@@ -1,3 +1,5 @@
+//! `chiapos` constants.
+
 /// PRNG extension parameter to avoid collisions
 pub(super) const PARAM_EXT: u8 = 6;
 pub(super) const PARAM_M: u16 = 1 << PARAM_EXT;

--- a/crates/subspace-proof-of-space/src/chiapos/table.rs
+++ b/crates/subspace-proof-of-space/src/chiapos/table.rs
@@ -52,20 +52,20 @@ const COMPUTE_FN_SIMD_FACTOR: usize = 16;
 const MAX_BUCKET_SIZE: usize = 512;
 #[cfg(feature = "alloc")]
 const BUCKET_SIZE_UPPER_BOUND_SECURITY_BITS: u8 = 128;
-/// Reducing bucket size for better performance.
+/// Bucket size used for fixed-size bucketed arrays.
 ///
-/// The number should be sufficient to produce enough proofs for sector encoding with high
-/// probability.
-// TODO: Statistical analysis if possible, confirming there will be enough proofs
+/// Must be `MAX_BUCKET_SIZE` to avoid silently dropping entries when a bucket's Y values exceed
+/// the limit. With `PARAM_BC / 2^PARAM_EXT ≈ 236` expected entries per bucket and std dev ≈ 15.4,
+/// the original value of 272 (~2.3 sigma) caused overflow in production (K=20), dropping hundreds
+/// of proofs and causing "Missing PoS proof" farming errors.
 #[allow(dead_code, reason = "unused when crate is compiled separately")]
-const REDUCED_BUCKET_SIZE: usize = 272;
-/// Reducing matches count for better performance.
+pub(crate) const REDUCED_BUCKET_SIZE: usize = MAX_BUCKET_SIZE;
+/// Matches count limit per bucket pair.
 ///
-/// The number should be sufficient to produce enough proofs for sector encoding with high
-/// probability.
-// TODO: Statistical analysis if possible, confirming there will be enough proofs
+/// Must be `MAX_BUCKET_SIZE` to avoid silently dropping matches. The original value of 288 could
+/// cause early termination in `find_matches_in_buckets`, losing valid proof paths.
 #[allow(dead_code, reason = "unused when crate is compiled separately")]
-const REDUCED_MATCHES_COUNT: usize = 288;
+const REDUCED_MATCHES_COUNT: usize = MAX_BUCKET_SIZE;
 #[cfg(feature = "parallel")]
 const CACHE_LINE_SIZE: usize = 64;
 
@@ -256,6 +256,22 @@ where
 
     // SAFETY: All entries are initialized
     unsafe { Box::from_raw(Box::into_raw(buckets).cast()) }
+}
+
+/// Sort entries within each bucket by Y value to ensure deterministic proof ordering.
+/// This matches the old code's behavior where entries were globally Y-sorted before bucketing.
+#[cfg(feature = "alloc")]
+fn sort_buckets<const K: u8>(buckets: &mut [[(Position, Y); REDUCED_BUCKET_SIZE]; num_buckets(K)])
+where
+    [(); num_buckets(K)]:,
+{
+    for bucket in buckets.iter_mut() {
+        let len = bucket
+            .iter()
+            .take_while(|&&(pos, _)| pos != Position::SENTINEL)
+            .count();
+        bucket[..len].sort_unstable_by_key(|&(pos, y)| (u32::from(y), u32::from(pos)));
+    }
 }
 
 #[cfg(feature = "alloc")]
@@ -1032,7 +1048,8 @@ where
         };
 
         // TODO: Try to group buckets in the process of collecting `y`s
-        let buckets = group_by_buckets::<K>(&ys);
+        let mut buckets = group_by_buckets::<K>(&ys);
+        sort_buckets::<K>(&mut buckets);
 
         Self::First { buckets }
     }
@@ -1083,7 +1100,8 @@ where
         };
 
         // TODO: Try to group buckets in the process of collecting `y`s
-        let buckets = group_by_buckets::<K>(&ys);
+        let mut buckets = group_by_buckets::<K>(&ys);
+        sort_buckets::<K>(&mut buckets);
 
         Self::First { buckets }
     }
@@ -1293,7 +1311,8 @@ where
         };
 
         // TODO: Try to group buckets in the process of collecting `y`s
-        let buckets = group_by_buckets::<K>(&ys);
+        let mut buckets = group_by_buckets::<K>(&ys);
+        sort_buckets::<K>(&mut buckets);
 
         let table = Self::Other {
             positions,
@@ -1410,7 +1429,7 @@ where
 
         // TODO: Try to group buckets in the process of collecting `y`s
         // SAFETY: `global_results_counts` corresponds to the number of initialized `ys`
-        let buckets = unsafe {
+        let mut buckets = unsafe {
             group_by_buckets_from_buckets::<K, _>(
                 ys.iter().zip(
                     global_results_counts
@@ -1419,6 +1438,7 @@ where
                 ),
             )
         };
+        sort_buckets::<K>(&mut buckets);
 
         let table = Self::OtherBuckets {
             positions,

--- a/crates/subspace-proof-of-space/src/chiapos/table.rs
+++ b/crates/subspace-proof-of-space/src/chiapos/table.rs
@@ -1,33 +1,78 @@
+//! `chiapos` table implementation.
+
+#[cfg(any(feature = "alloc", test))]
+mod rmap;
 #[cfg(test)]
 mod tests;
 pub(super) mod types;
 
-#[cfg(not(feature = "std"))]
-extern crate alloc;
-
 use crate::chiapos::Seed;
 use crate::chiapos::constants::{PARAM_B, PARAM_BC, PARAM_C, PARAM_EXT, PARAM_M};
-use crate::chiapos::table::types::{Metadata, Position, X, Y};
+#[cfg(feature = "alloc")]
+use crate::chiapos::table::rmap::Rmap;
+use crate::chiapos::table::types::{Metadata, X, Y};
+#[cfg(feature = "alloc")]
+use crate::chiapos::table::types::{Position, R};
 use crate::chiapos::utils::EvaluatableUsize;
-#[cfg(not(feature = "std"))]
+use ab_chacha8::{ChaCha8Block, ChaCha8State};
+#[cfg(feature = "alloc")]
+use alloc::boxed::Box;
+#[cfg(feature = "alloc")]
 use alloc::vec;
-#[cfg(not(feature = "std"))]
+#[cfg(feature = "alloc")]
 use alloc::vec::Vec;
-use chacha20::cipher::{KeyIvInit, StreamCipher, StreamCipherSeek};
-use chacha20::{ChaCha8, Key, Nonce};
+#[cfg(feature = "alloc")]
+use chacha20::cipher::{Iv, KeyIvInit, StreamCipher};
+#[cfg(feature = "alloc")]
+use chacha20::{ChaCha8, Key};
 use core::array;
-use core::simd::Simd;
-use core::simd::num::SimdUint;
-#[cfg(all(feature = "std", any(feature = "parallel", test)))]
-use parking_lot::Mutex;
-#[cfg(any(feature = "parallel", test))]
-use rayon::prelude::*;
+#[cfg(feature = "parallel")]
+use core::cell::SyncUnsafeCell;
+#[cfg(feature = "alloc")]
+use core::mem;
+#[cfg(feature = "alloc")]
+use core::mem::MaybeUninit;
+#[cfg(any(feature = "alloc", test))]
+use core::simd::prelude::*;
+#[cfg(feature = "parallel")]
+use core::sync::atomic::{AtomicUsize, Ordering};
+#[cfg(feature = "alloc")]
+use derive_more::Deref;
+#[cfg(any(feature = "alloc", test))]
 use seq_macro::seq;
-#[cfg(all(not(feature = "std"), any(feature = "parallel", test)))]
-use spin::Mutex;
+// TODO: Switch to `rclite` once https://github.com/fereidani/rclite/issues/11 is resolved
+#[cfg(feature = "alloc")]
+use alloc::sync::Arc;
+use subspace_core_primitives::hashes::blake3_hash;
 
 pub(super) const COMPUTE_F1_SIMD_FACTOR: usize = 8;
-pub(super) const FIND_MATCHES_AND_COMPUTE_UNROLL_FACTOR: usize = 8;
+#[cfg(any(feature = "alloc", test))]
+const COMPUTE_FN_SIMD_FACTOR: usize = 16;
+#[allow(dead_code, reason = "unused when crate is compiled separately")]
+const MAX_BUCKET_SIZE: usize = 512;
+#[cfg(feature = "alloc")]
+const BUCKET_SIZE_UPPER_BOUND_SECURITY_BITS: u8 = 128;
+/// Reducing bucket size for better performance.
+///
+/// The number should be sufficient to produce enough proofs for sector encoding with high
+/// probability.
+// TODO: Statistical analysis if possible, confirming there will be enough proofs
+#[allow(dead_code, reason = "unused when crate is compiled separately")]
+const REDUCED_BUCKET_SIZE: usize = 272;
+/// Reducing matches count for better performance.
+///
+/// The number should be sufficient to produce enough proofs for sector encoding with high
+/// probability.
+// TODO: Statistical analysis if possible, confirming there will be enough proofs
+#[allow(dead_code, reason = "unused when crate is compiled separately")]
+const REDUCED_MATCHES_COUNT: usize = 288;
+#[cfg(feature = "parallel")]
+const CACHE_LINE_SIZE: usize = 64;
+
+const _: () = {
+    debug_assert!(REDUCED_BUCKET_SIZE <= MAX_BUCKET_SIZE);
+    debug_assert!(REDUCED_MATCHES_COUNT <= MAX_BUCKET_SIZE);
+};
 
 /// Compute the size of `y` in bits
 pub(super) const fn y_size_bits(k: u8) -> usize {
@@ -53,152 +98,281 @@ pub(super) const fn metadata_size_bits(k: u8, table_number: u8) -> usize {
         }
 }
 
+/// Number of buckets for a given `k`
+pub const fn num_buckets(k: u8) -> usize {
+    2_usize
+        .pow(y_size_bits(k) as u32)
+        .div_ceil(PARAM_BC as usize)
+}
+
+#[cfg(feature = "parallel")]
+#[inline(always)]
+fn strip_sync_unsafe_cell<const N: usize, T>(value: Box<[SyncUnsafeCell<T>; N]>) -> Box<[T; N]> {
+    // SAFETY: `SyncUnsafeCell` has the same layout as `T`
+    unsafe { Box::from_raw(Box::into_raw(value).cast()) }
+}
+
 /// ChaCha8 [`Vec`] sufficient for the whole first table for [`K`].
 /// Prefer [`partial_y`] if you need partial y just for a single `x`.
+#[cfg(feature = "alloc")]
 fn partial_ys<const K: u8>(seed: Seed) -> Vec<u8> {
     let output_len_bits = usize::from(K) * (1 << K);
     let mut output = vec![0; output_len_bits.div_ceil(u8::BITS as usize)];
 
     let key = Key::from(seed);
-    let nonce = Nonce::default();
+    let iv = Iv::<ChaCha8>::default();
 
-    let mut cipher = ChaCha8::new(&key, &nonce);
+    let mut cipher = ChaCha8::new(&key, &iv);
 
     cipher.apply_keystream(&mut output);
 
     output
 }
 
-/// ChaCha8 byte for a single `y` at `x` in the first table for [`K`], returns bytes and offset (in
-/// bits) within those bytes at which data start.
-/// Prefer [`partial_ys`] if you process the whole first table.
-pub(super) fn partial_y<const K: u8>(
-    seed: Seed,
-    x: X,
-) -> ([u8; (K as usize * 2).div_ceil(u8::BITS as usize)], usize) {
-    let skip_bits = usize::from(K) * usize::from(x);
-    let skip_bytes = skip_bits / u8::BITS as usize;
-    let skip_bits = skip_bits % u8::BITS as usize;
+/// Calculate a probabilistic upper bound on the Chia bucket size for a given `k` and
+/// `security_bits` (security level).
+///
+/// This is based on a Chernoff bound for the Poisson distribution with mean
+/// `lambda = PARAM_BC / 2^PARAM_EXT`, ensuring the probability that any bucket exceeds the bound is
+/// less than `2^{-security_bits}`.
+/// The bound is lambda + ceil(sqrt(3 * lambda * (k + security_bits) * ln(2))).
+#[cfg(feature = "alloc")]
+const fn bucket_size_upper_bound(k: u8, security_bits: u8) -> usize {
+    // Lambda is the expected number of entries in a bucket, approximated as
+    // `PARAM_BC / 2^PARAM_EXT`. It is independent of `k`.
+    const LAMBDA: u64 = PARAM_BC as u64 / 2u64.pow(PARAM_EXT as u32);
+    // Approximation of ln(2) as a fraction: ln(2) ≈ LN2_NUM / LN2_DEN.
+    // This allows integer-only computation of the square root term involving ln(2).
+    const LN2_NUM: u128 = 693147;
+    const LN2_DEN: u128 = 1000000;
 
-    let mut output = [0; (K as usize * 2).div_ceil(u8::BITS as usize)];
+    // `k + security_bits` for the union bound over ~2^k intervals
+    let ks = k as u128 + security_bits as u128;
+    // Compute numerator for the expression under the square root:
+    // `3 * lambda * (k + security_bits) * LN2_NUM`
+    let num = 3u128 * LAMBDA as u128 * ks * LN2_NUM;
+    // Denominator for ln(2): `LN2_DEN`
+    let den = LN2_DEN;
 
-    let key = Key::from(seed);
-    let nonce = Nonce::default();
+    let ceil_div: u128 = num.div_ceil(den);
 
-    let mut cipher = ChaCha8::new(&key, &nonce);
+    // Binary search to find the smallest `x` such that `x * x * den >= num`,
+    // which computes `ceil(sqrt(num / den))` without floating-point.
+    // We use a custom binary search over `u64` range because binary search in the standard library
+    // operates on sorted slices, not directly on integer ranges for solving inequalities like this.
+    let mut low = 0u64;
+    let mut high = u64::MAX;
+    while low < high {
+        let mid = low + (high - low) / 2;
+        let left = (mid as u128) * (mid as u128);
+        if left >= ceil_div {
+            high = mid;
+        } else {
+            low = mid + 1;
+        }
+    }
+    let add_term = low;
 
-    cipher.seek(skip_bytes);
-    cipher.apply_keystream(&mut output);
-
-    (output, skip_bits)
+    (LAMBDA + add_term) as usize
 }
 
-#[derive(Debug, Clone)]
-struct LeftTargets {
-    left_targets: Vec<Position>,
+#[cfg(feature = "alloc")]
+fn group_by_buckets<const K: u8>(
+    ys: &[Y],
+) -> Box<[[(Position, Y); REDUCED_BUCKET_SIZE]; num_buckets(K)]>
+where
+    [(); num_buckets(K)]:,
+{
+    let mut bucket_offsets = [0_u16; num_buckets(K)];
+    // SAFETY: Contents is `MaybeUninit`
+    let mut buckets = unsafe {
+        Box::<[[MaybeUninit<(Position, Y)>; REDUCED_BUCKET_SIZE]; num_buckets(K)]>::new_uninit()
+            .assume_init()
+    };
+
+    for (&y, position) in ys.iter().zip(Position::ZERO..) {
+        let bucket_index = (u32::from(y) / u32::from(PARAM_BC)) as usize;
+
+        // SAFETY: Bucket is obtained using division by `PARAM_BC` and fits by definition
+        let bucket_offset = unsafe { bucket_offsets.get_unchecked_mut(bucket_index) };
+        // SAFETY: Bucket is obtained using division by `PARAM_BC` and fits by definition
+        let bucket = unsafe { buckets.get_unchecked_mut(bucket_index) };
+
+        if *bucket_offset < REDUCED_BUCKET_SIZE as u16 {
+            bucket[*bucket_offset as usize].write((position, y));
+            *bucket_offset += 1;
+        }
+    }
+
+    for (bucket, initialized) in buckets.iter_mut().zip(bucket_offsets) {
+        bucket[usize::from(initialized)..].write_filled((Position::SENTINEL, Y::SENTINEL));
+    }
+
+    // SAFETY: All entries are initialized
+    unsafe { Box::from_raw(Box::into_raw(buckets).cast()) }
 }
 
-fn calculate_left_targets() -> LeftTargets {
-    let mut left_targets = Vec::with_capacity(2 * usize::from(PARAM_BC) * usize::from(PARAM_M));
+/// Similar to [`group_by_buckets()`], but processes buckets instead of a flat list of `y`s.
+///
+/// # Safety
+/// Iterator item is a list of potentially uninitialized `y`s and a number of initialized `y`s. The
+/// number of initialized `y`s must be correct.
+#[cfg(feature = "parallel")]
+unsafe fn group_by_buckets_from_buckets<'a, const K: u8, I>(
+    iter: I,
+) -> Box<[[(Position, Y); REDUCED_BUCKET_SIZE]; num_buckets(K)]>
+where
+    I: Iterator<Item = (&'a [MaybeUninit<Y>; REDUCED_MATCHES_COUNT], usize)> + 'a,
+    [(); num_buckets(K)]:,
+{
+    let mut bucket_offsets = [0_u16; num_buckets(K)];
+    // SAFETY: Contents is `MaybeUninit`
+    let mut buckets = unsafe {
+        Box::<[[MaybeUninit<(Position, Y)>; REDUCED_BUCKET_SIZE]; num_buckets(K)]>::new_uninit()
+            .assume_init()
+    };
 
-    let param_b = u32::from(PARAM_B);
-    let param_c = u32::from(PARAM_C);
+    for ((ys, count), batch_start) in iter.zip((Position::ZERO..).step_by(REDUCED_MATCHES_COUNT)) {
+        // SAFETY: Function contract guarantees that `y`s are initialized
+        let ys = unsafe { ys[..count].assume_init_ref() };
+        for (&y, position) in ys.iter().zip(batch_start..) {
+            let bucket_index = (u32::from(y) / u32::from(PARAM_BC)) as usize;
 
-    for parity in 0..=1u32 {
-        for r in 0..u32::from(PARAM_BC) {
-            let c = r / param_c;
+            // SAFETY: Bucket is obtained using division by `PARAM_BC` and fits by definition
+            let bucket_offset = unsafe { bucket_offsets.get_unchecked_mut(bucket_index) };
+            // SAFETY: Bucket is obtained using division by `PARAM_BC` and fits by definition
+            let bucket = unsafe { buckets.get_unchecked_mut(bucket_index) };
 
-            for m in 0..u32::from(PARAM_M) {
-                let target = ((c + m) % param_b) * param_c
-                    + (((2 * m + parity) * (2 * m + parity) + r) % param_c);
-                left_targets.push(Position::from(target));
+            if *bucket_offset < REDUCED_BUCKET_SIZE as u16 {
+                bucket[*bucket_offset as usize].write((position, y));
+                *bucket_offset += 1;
             }
         }
     }
 
-    LeftTargets { left_targets }
+    for (bucket, initialized) in buckets.iter_mut().zip(bucket_offsets) {
+        bucket[usize::from(initialized)..].write_filled((Position::SENTINEL, Y::SENTINEL));
+    }
+
+    // SAFETY: All entries are initialized
+    unsafe { Box::from_raw(Box::into_raw(buckets).cast()) }
+}
+
+#[cfg(feature = "alloc")]
+#[derive(Debug, Copy, Clone, Deref)]
+#[repr(align(64))]
+struct CacheLineAligned<T>(T);
+
+/// Mapping from `parity` to `r` to `m`
+#[cfg(feature = "alloc")]
+type LeftTargets = [[CacheLineAligned<[R; PARAM_M as usize]>; PARAM_BC as usize]; 2];
+
+#[cfg(feature = "alloc")]
+fn calculate_left_targets() -> Arc<LeftTargets> {
+    let mut left_targets = Arc::<LeftTargets>::new_uninit();
+    // SAFETY: Same layout and uninitialized in both cases
+    let left_targets_slice = unsafe {
+        mem::transmute::<
+            &mut MaybeUninit<[[CacheLineAligned<[R; PARAM_M as usize]>; PARAM_BC as usize]; 2]>,
+            &mut [[MaybeUninit<CacheLineAligned<[R; PARAM_M as usize]>>; PARAM_BC as usize]; 2],
+        >(Arc::get_mut_unchecked(&mut left_targets))
+    };
+
+    for parity in 0..=1 {
+        for r in 0..PARAM_BC {
+            let c = r / PARAM_C;
+
+            let mut arr = array::from_fn(|m| {
+                let m = m as u16;
+                R::from(
+                    ((c + m) % PARAM_B) * PARAM_C
+                        + (((2 * m + parity) * (2 * m + parity) + r) % PARAM_C),
+                )
+            });
+            arr.sort_unstable();
+            left_targets_slice[parity as usize][r as usize].write(CacheLineAligned(arr));
+        }
+    }
+
+    // SAFETY: Initialized all entries
+    unsafe { left_targets.assume_init() }
 }
 
 fn calculate_left_target_on_demand(parity: u32, r: u32, m: u32) -> u32 {
     let param_b = u32::from(PARAM_B);
     let param_c = u32::from(PARAM_C);
 
-    let c = r / param_c;
-
-    ((c + m) % param_b) * param_c + (((2 * m + parity) * (2 * m + parity) + r) % param_c)
+    ((r / param_c + m) % param_b) * param_c + (((2 * m + parity) * (2 * m + parity) + r) % param_c)
 }
 
-/// Caches that can be used to optimize creation of multiple [`Tables`](super::Tables).
+/// Caches that can be used to optimize the creation of multiple [`Tables`](super::Tables).
+#[cfg(feature = "alloc")]
 #[derive(Debug, Clone)]
-pub struct TablesCache<const K: u8> {
-    buckets: Vec<Bucket>,
-    rmap_scratch: Vec<RmapItem>,
-    left_targets: LeftTargets,
+pub struct TablesCache {
+    left_targets: Arc<LeftTargets>,
 }
 
-impl<const K: u8> Default for TablesCache<K> {
-    /// Create new instance
+#[cfg(feature = "alloc")]
+impl Default for TablesCache {
+    /// Create a new instance
     fn default() -> Self {
         Self {
-            buckets: Vec::new(),
-            rmap_scratch: Vec::new(),
             left_targets: calculate_left_targets(),
         }
     }
 }
 
-#[derive(Debug)]
+#[cfg(feature = "alloc")]
+#[derive(Debug, Copy, Clone)]
 struct Match {
     left_position: Position,
     left_y: Y,
     right_position: Position,
 }
 
-#[derive(Debug, Default, Copy, Clone, Eq, PartialEq)]
-struct Bucket {
-    /// Bucket index
-    bucket_index: u32,
-    /// Start position of this bucket in the table
-    start_position: Position,
-    /// Size of this bucket
-    size: Position,
-}
+/// `partial_y_offset` is in bits within `partial_y`
+pub(super) fn compute_f1<const K: u8>(x: X, seed: &Seed) -> Y {
+    let skip_bits = u32::from(K) * u32::from(x);
+    let skip_u32s = skip_bits / u32::BITS;
+    let partial_y_offset = skip_bits % u32::BITS;
 
-#[derive(Debug, Default, Copy, Clone)]
-pub(super) struct RmapItem {
-    count: Position,
-    start_position: Position,
-}
+    const U32S_PER_BLOCK: usize = size_of::<ChaCha8Block>() / size_of::<u32>();
 
-/// `partial_y_offset` is in bits
-pub(super) fn compute_f1<const K: u8>(x: X, partial_y: &[u8], partial_y_offset: usize) -> Y {
-    let partial_y_length =
-        (partial_y_offset % u8::BITS as usize + usize::from(K)).div_ceil(u8::BITS as usize);
-    let mut pre_y_bytes = 0u64.to_be_bytes();
-    pre_y_bytes[..partial_y_length]
-        .copy_from_slice(&partial_y[partial_y_offset / u8::BITS as usize..][..partial_y_length]);
-    // Contains `K` desired bits of `partial_y` in the final offset of eventual `y` with the rest
-    // of bits being in undefined state
-    let pre_y = u64::from_be_bytes(pre_y_bytes)
-        >> (u64::BITS as usize - usize::from(K + PARAM_EXT) - partial_y_offset % u8::BITS as usize);
+    let initial_state = ChaCha8State::init(seed, &[0; _]);
+    let first_block_counter = skip_u32s / U32S_PER_BLOCK as u32;
+    let u32_in_first_block = skip_u32s as usize % U32S_PER_BLOCK;
+
+    let first_block = initial_state.compute_block(first_block_counter);
+    let hi = first_block[u32_in_first_block].to_be();
+
+    // TODO: Is SIMD version of `compute_block()` that produces two blocks at once possible?
+    let lo = if u32_in_first_block + 1 == U32S_PER_BLOCK {
+        // Spilled over into the second block
+        let second_block = initial_state.compute_block(first_block_counter + 1);
+        second_block[0].to_be()
+    } else {
+        first_block[u32_in_first_block + 1].to_be()
+    };
+
+    let partial_y = (u64::from(hi) << u32::BITS) | u64::from(lo);
+
+    let pre_y = partial_y >> (u64::BITS - u32::from(K + PARAM_EXT) - partial_y_offset);
     let pre_y = pre_y as u32;
     // Mask for clearing the rest of bits of `pre_y`.
-    let pre_y_mask = (u32::MAX << usize::from(PARAM_EXT))
-        & (u32::MAX >> (u32::BITS as usize - usize::from(K + PARAM_EXT)));
+    let pre_y_mask = (u32::MAX << PARAM_EXT) & (u32::MAX >> (u32::BITS - u32::from(K + PARAM_EXT)));
 
     // Extract `PARAM_EXT` most significant bits from `x` and store in the final offset of
-    // eventual `y` with the rest of bits being in undefined state.
-    let pre_ext = u32::from(x) >> (usize::from(K - PARAM_EXT));
-    // Mask for clearing the rest of bits of `pre_ext`.
-    let pre_ext_mask = u32::MAX >> (u32::BITS as usize - usize::from(PARAM_EXT));
+    // eventual `y` with the rest of bits being zero (`x` is `0..2^K`)
+    let pre_ext = u32::from(x) >> (K - PARAM_EXT);
 
     // Combine all of the bits together:
     // [padding zero bits][`K` bits rom `partial_y`][`PARAM_EXT` bits from `x`]
-    Y::from((pre_y & pre_y_mask) | (pre_ext & pre_ext_mask))
+    Y::from((pre_y & pre_y_mask) | pre_ext)
 }
 
+#[cfg(any(feature = "alloc", test))]
 pub(super) fn compute_f1_simd<const K: u8>(
-    xs: [u32; COMPUTE_F1_SIMD_FACTOR],
+    xs: Simd<u32, COMPUTE_F1_SIMD_FACTOR>,
     partial_ys: &[u8; K as usize * COMPUTE_F1_SIMD_FACTOR / u8::BITS as usize],
 ) -> [Y; COMPUTE_F1_SIMD_FACTOR] {
     // Each element contains `K` desired bits of `partial_ys` in the final offset of eventual `ys`
@@ -228,7 +402,7 @@ pub(super) fn compute_f1_simd<const K: u8>(
 
     // Extract `PARAM_EXT` most significant bits from `xs` and store in the final offset of
     // eventual `ys` with the rest of bits being in undefined state.
-    let pre_exts = Simd::from_array(xs) >> Simd::splat(u32::from(K - PARAM_EXT));
+    let pre_exts = xs >> Simd::splat(u32::from(K - PARAM_EXT));
 
     // Combine all of the bits together:
     // [padding zero bits][`K` bits rom `partial_y`][`PARAM_EXT` bits from `x`]
@@ -237,106 +411,89 @@ pub(super) fn compute_f1_simd<const K: u8>(
     Y::array_from_repr(ys.to_array())
 }
 
-/// `rmap_scratch` is just an optimization to reuse allocations between calls.
+/// For verification use [`has_match`] instead.
 ///
-/// For verification purposes use [`has_match`] instead.
-///
-/// Returns `None` if either of buckets is empty.
-#[allow(clippy::too_many_arguments)]
-fn find_matches<T, Map>(
-    left_bucket_ys: &[Y],
-    left_bucket_start_position: Position,
-    right_bucket_ys: &[Y],
-    right_bucket_start_position: Position,
-    rmap_scratch: &mut Vec<RmapItem>,
+/// # Safety
+/// Left and right bucket positions must correspond to the parent table.
+// TODO: Try to reduce the `matches` size further by processing `left_bucket` in chunks (like halves
+//  for example)
+#[cfg(feature = "alloc")]
+unsafe fn find_matches_in_buckets<'a>(
+    left_bucket_index: u32,
+    left_bucket: &[(Position, Y); REDUCED_BUCKET_SIZE],
+    right_bucket: &[(Position, Y); REDUCED_BUCKET_SIZE],
+    // `PARAM_M as usize * 2` corresponds to the upper bound number of matches a single `y` in the
+    // left bucket might have here
+    matches: &'a mut [MaybeUninit<Match>; REDUCED_MATCHES_COUNT + PARAM_M as usize * 2],
     left_targets: &LeftTargets,
-    map: Map,
-    output: &mut Vec<T>,
-) where
-    Map: Fn(Match) -> T,
-{
-    // Clear and set to correct size with zero values
-    rmap_scratch.clear();
-    rmap_scratch.resize_with(usize::from(PARAM_BC), RmapItem::default);
-    let rmap = rmap_scratch;
+) -> &'a [Match] {
+    let left_base = left_bucket_index * u32::from(PARAM_BC);
+    let right_base = left_base + u32::from(PARAM_BC);
 
-    // Both left and right buckets can be empty
-    let Some(&first_left_bucket_y) = left_bucket_ys.first() else {
-        return;
-    };
-    let Some(&first_right_bucket_y) = right_bucket_ys.first() else {
-        return;
-    };
-    // Since all entries in a bucket are obtained after division by `PARAM_BC`, we can compute
-    // quotient more efficiently by subtracting base value rather than computing remainder of
-    // division
-    let base = (usize::from(first_right_bucket_y) / usize::from(PARAM_BC)) * usize::from(PARAM_BC);
-    for (&y, right_position) in right_bucket_ys.iter().zip(right_bucket_start_position..) {
-        let r = usize::from(y) - base;
-
-        // Same `y` and as the result `r` can appear in the table multiple times, in which case
-        // they'll all occupy consecutive slots in `right_bucket` and all we need to store is just
-        // the first position and number of elements.
-        if rmap[r].count == Position::ZERO {
-            rmap[r].start_position = right_position;
+    let mut rmap = Rmap::new();
+    for &(right_position, y) in right_bucket {
+        if right_position == Position::SENTINEL {
+            break;
         }
-        rmap[r].count += Position::ONE;
-    }
-    let rmap = rmap.as_slice();
-
-    // Same idea as above, but avoids division by leveraging the fact that each bucket is exactly
-    // `PARAM_BC` away from the previous one in terms of divisor by `PARAM_BC`
-    let base = base - usize::from(PARAM_BC);
-    let parity = (usize::from(first_left_bucket_y) / usize::from(PARAM_BC)) % 2;
-    let left_targets_parity = {
-        let (a, b) = left_targets
-            .left_targets
-            .split_at(left_targets.left_targets.len() / 2);
-        if parity == 0 { a } else { b }
-    };
-
-    for (&y, left_position) in left_bucket_ys.iter().zip(left_bucket_start_position..) {
-        let r = usize::from(y) - base;
-        let left_targets_r = left_targets_parity
-            .chunks_exact(left_targets_parity.len() / usize::from(PARAM_BC))
-            .nth(r)
-            .expect("r is valid");
-
-        const _: () = {
-            assert!((PARAM_M as usize).is_multiple_of(FIND_MATCHES_AND_COMPUTE_UNROLL_FACTOR));
-        };
-
-        for r_targets in left_targets_r
-            .as_chunks::<{ FIND_MATCHES_AND_COMPUTE_UNROLL_FACTOR }>()
-            .0
-            .iter()
-            .take(usize::from(PARAM_M) / FIND_MATCHES_AND_COMPUTE_UNROLL_FACTOR)
-        {
-            let _: [(); FIND_MATCHES_AND_COMPUTE_UNROLL_FACTOR] = seq!(N in 0..8 {
-                [
-                #(
-                {
-                    let rmap_item = rmap[usize::from(r_targets[N])];
-
-                    for right_position in
-                        rmap_item.start_position..rmap_item.start_position + rmap_item.count
-                    {
-                        let m = Match {
-                            left_position,
-                            left_y: y,
-                            right_position,
-                        };
-                        output.push(map(m));
-                    }
-                },
-                )*
-                ]
-            });
+        let r = R::from((u32::from(y) - right_base) as u16);
+        // SAFETY: `r` is within `0..PARAM_BC` range by definition, the right bucket is limited to
+        // `REDUCED_BUCKETS_SIZE`
+        unsafe {
+            rmap.add(r, right_position);
         }
     }
+
+    let parity = left_base % 2;
+    let left_targets_parity = &left_targets[parity as usize];
+    let mut next_match_index = 0;
+
+    // TODO: Simd read for left bucket? It might be more efficient in terms of memory access to
+    //  process chunks of the left bucket against one right value for each at a time
+    for &(left_position, y) in left_bucket {
+        // `next_match_index >= REDUCED_MATCHES_COUNT` is crucial to make sure
+        if left_position == Position::SENTINEL || next_match_index >= REDUCED_MATCHES_COUNT {
+            // Sentinel values are padded to the end of the bucket
+            break;
+        }
+
+        let r = R::from((u32::from(y) - left_base) as u16);
+        // SAFETY: `r` is within a bucket and exists by definition
+        let left_targets_r = unsafe { left_targets_parity.get_unchecked(usize::from(r)) };
+
+        for &r_target in left_targets_r.iter() {
+            // SAFETY: Targets are always limited to `PARAM_BC`
+            let [right_position_a, right_position_b] = unsafe { rmap.get(r_target) };
+
+            // The right bucket position is never zero
+            if right_position_a != Position::ZERO {
+                // SAFETY: Iteration will stop before `REDUCED_MATCHES_COUNT + PARAM_M * 2`
+                // elements is inserted
+                unsafe { matches.get_unchecked_mut(next_match_index) }.write(Match {
+                    left_position,
+                    left_y: y,
+                    right_position: right_position_a,
+                });
+                next_match_index += 1;
+
+                if right_position_b != Position::ZERO {
+                    // SAFETY: Iteration will stop before
+                    // `REDUCED_MATCHES_COUNT + PARAM_M * 2` elements is inserted
+                    unsafe { matches.get_unchecked_mut(next_match_index) }.write(Match {
+                        left_position,
+                        left_y: y,
+                        right_position: right_position_b,
+                    });
+                    next_match_index += 1;
+                }
+            }
+        }
+    }
+
+    // SAFETY: Initialized this many matches
+    unsafe { matches[..next_match_index].assume_init_ref() }
 }
 
-/// Simplified version of [`find_matches`] for verification purposes.
+/// Simplified version of [`find_matches_in_buckets`] for verification purposes.
 pub(super) fn has_match(left_y: Y, right_y: Y) -> bool {
     let right_r = u32::from(right_y) % u32::from(PARAM_BC);
     let parity = (u32::from(left_y) / u32::from(PARAM_BC)) % 2;
@@ -349,6 +506,7 @@ pub(super) fn has_match(left_y: Y, right_y: Y) -> bool {
     r_targets.contains(&right_r)
 }
 
+#[inline(always)]
 pub(super) fn compute_fn<const K: u8, const TABLE_NUMBER: u8, const PARENT_TABLE_NUMBER: u8>(
     y: Y,
     left_metadata: Metadata<K, PARENT_TABLE_NUMBER>,
@@ -363,23 +521,23 @@ where
 
     let parent_metadata_bits = metadata_size_bits(K, PARENT_TABLE_NUMBER);
 
+    // Part of the `right_bits` at the final offset of eventual `input_a`
+    let y_and_left_bits = y_size_bits(K) + parent_metadata_bits;
+    let right_bits_start_offset = u128::BITS as usize - parent_metadata_bits;
+
+    // Take only bytes where bits were set
+    let num_bytes_with_data =
+        (y_size_bits(K) + parent_metadata_bits * 2).div_ceil(u8::BITS as usize);
+
     // Only supports `K` from 15 to 25 (otherwise math will not be correct when concatenating y,
     // left metadata and right metadata)
     let hash = {
-        // Take only bytes where bits were set
-        let num_bytes_with_data = (y_size_bits(K) + metadata_size_bits(K, PARENT_TABLE_NUMBER) * 2)
-            .div_ceil(u8::BITS as usize);
-
         // Collect `K` most significant bits of `y` at the final offset of eventual `input_a`
         let y_bits = u128::from(y) << (u128::BITS as usize - y_size_bits(K));
 
         // Move bits of `left_metadata` at the final offset of eventual `input_a`
         let left_metadata_bits =
             left_metadata << (u128::BITS as usize - parent_metadata_bits - y_size_bits(K));
-
-        // Part of the `right_bits` at the final offset of eventual `input_a`
-        let y_and_left_bits = y_size_bits(K) + parent_metadata_bits;
-        let right_bits_start_offset = u128::BITS as usize - parent_metadata_bits;
 
         // If `right_metadata` bits start to the left of the desired position in `input_a` move
         // bits right, else move left
@@ -395,15 +553,14 @@ where
             let input = [input_a.to_be_bytes(), input_b.to_be_bytes()];
             let input_len =
                 size_of::<u128>() + right_bits_pushed_into_input_b.div_ceil(u8::BITS as usize);
-            blake3::hash(&input.as_flattened()[..input_len])
+            blake3_hash(&input.as_flattened()[..input_len])
         } else {
             let right_bits_a = right_metadata << (right_bits_start_offset - y_and_left_bits);
             let input_a = y_bits | left_metadata_bits | right_bits_a;
 
-            blake3::hash(&input_a.to_be_bytes()[..num_bytes_with_data])
+            blake3_hash(&input_a.to_be_bytes()[..num_bytes_with_data])
         }
     };
-    let hash = <[u8; 32]>::from(hash);
 
     let y_output = Y::from(
         u32::from_be_bytes([hash[0], hash[1], hash[2], hash[3]])
@@ -415,9 +572,9 @@ where
     let metadata = if TABLE_NUMBER < 4 {
         (left_metadata << parent_metadata_bits) | right_metadata
     } else if metadata_size_bits > 0 {
-        // For K under 25 it is guaranteed that metadata + bit offset will always fit into u128.
-        // We collect bytes necessary, potentially with extra bits at the start and end of the bytes
-        // that will be taken care of later.
+        // For K up to 25 it is guaranteed that metadata + bit offset will always fit into u128.
+        // We collect the bytes necessary, potentially with extra bits at the start and end of the
+        // bytes that will be taken care of later.
         let metadata = u128::from_be_bytes(
             hash[y_size_bits(K) / u8::BITS as usize..][..size_of::<u128>()]
                 .try_into()
@@ -425,7 +582,7 @@ where
         );
         // Remove extra bits at the beginning
         let metadata = metadata << (y_size_bits(K) % u8::BITS as usize);
-        // Move bits into correct location
+        // Move bits into the correct location
         metadata >> (u128::BITS as usize - metadata_size_bits)
     } else {
         0
@@ -434,20 +591,156 @@ where
     (y_output, Metadata::from(metadata))
 }
 
-fn match_to_result<const K: u8, const TABLE_NUMBER: u8, const PARENT_TABLE_NUMBER: u8>(
-    last_table: &Table<K, PARENT_TABLE_NUMBER>,
-    m: Match,
-) -> (Y, [Position; 2], Metadata<K, TABLE_NUMBER>)
+// TODO: This is actually using only pipelining rather than real SIMD (at least explicitly) due to:
+//  * https://github.com/rust-lang/portable-simd/issues/108
+//  * https://github.com/BLAKE3-team/BLAKE3/issues/478#issuecomment-3200106103
+#[cfg(any(feature = "alloc", test))]
+fn compute_fn_simd<const K: u8, const TABLE_NUMBER: u8, const PARENT_TABLE_NUMBER: u8>(
+    left_ys: [Y; COMPUTE_FN_SIMD_FACTOR],
+    left_metadatas: [Metadata<K, PARENT_TABLE_NUMBER>; COMPUTE_FN_SIMD_FACTOR],
+    right_metadatas: [Metadata<K, PARENT_TABLE_NUMBER>; COMPUTE_FN_SIMD_FACTOR],
+) -> (
+    [Y; COMPUTE_FN_SIMD_FACTOR],
+    [Metadata<K, TABLE_NUMBER>; COMPUTE_FN_SIMD_FACTOR],
+)
 where
     EvaluatableUsize<{ metadata_size_bytes(K, PARENT_TABLE_NUMBER) }>: Sized,
     EvaluatableUsize<{ metadata_size_bytes(K, TABLE_NUMBER) }>: Sized,
 {
-    let left_metadata = last_table
-        .metadata(m.left_position)
-        .expect("Position resulted from matching is correct; qed");
-    let right_metadata = last_table
-        .metadata(m.right_position)
-        .expect("Position resulted from matching is correct; qed");
+    let parent_metadata_bits = metadata_size_bits(K, PARENT_TABLE_NUMBER);
+    let metadata_size_bits = metadata_size_bits(K, TABLE_NUMBER);
+
+    // TODO: `u128` is not supported as SIMD element yet, see
+    //  https://github.com/rust-lang/portable-simd/issues/108
+    let left_metadatas: [u128; COMPUTE_FN_SIMD_FACTOR] = seq!(N in 0..16 {
+        [
+        #(
+            u128::from(left_metadatas[N]),
+        )*
+        ]
+    });
+    let right_metadatas: [u128; COMPUTE_FN_SIMD_FACTOR] = seq!(N in 0..16 {
+        [
+        #(
+            u128::from(right_metadatas[N]),
+        )*
+        ]
+    });
+
+    // Part of the `right_bits` at the final offset of eventual `input_a`
+    let y_and_left_bits = y_size_bits(K) + parent_metadata_bits;
+    let right_bits_start_offset = u128::BITS as usize - parent_metadata_bits;
+
+    // Take only bytes where bits were set
+    let num_bytes_with_data =
+        (y_size_bits(K) + parent_metadata_bits * 2).div_ceil(u8::BITS as usize);
+
+    // Only supports `K` from 15 to 25 (otherwise math will not be correct when concatenating y,
+    // left metadata and right metadata)
+    // TODO: SIMD hashing once this is possible:
+    //  https://github.com/BLAKE3-team/BLAKE3/issues/478#issuecomment-3200106103
+    let hashes: [_; COMPUTE_FN_SIMD_FACTOR] = seq!(N in 0..16 {
+        [
+        #(
+        {
+            let y = left_ys[N];
+            let left_metadata = left_metadatas[N];
+            let right_metadata = right_metadatas[N];
+
+            // Collect `K` most significant bits of `y` at the final offset of eventual
+            // `input_a`
+            let y_bits = u128::from(y) << (u128::BITS as usize - y_size_bits(K));
+
+            // Move bits of `left_metadata` at the final offset of eventual `input_a`
+            let left_metadata_bits =
+                left_metadata << (u128::BITS as usize - parent_metadata_bits - y_size_bits(K));
+
+            // If `right_metadata` bits start to the left of the desired position in `input_a` move
+            // bits right, else move left
+            if right_bits_start_offset < y_and_left_bits {
+                let right_bits_pushed_into_input_b = y_and_left_bits - right_bits_start_offset;
+                // Collect bits of `right_metadata` that will fit into `input_a` at the final offset
+                // in eventual `input_a`
+                let right_bits_a = right_metadata >> right_bits_pushed_into_input_b;
+                let input_a = y_bits | left_metadata_bits | right_bits_a;
+                // Collect bits of `right_metadata` that will spill over into `input_b`
+                let input_b = right_metadata << (u128::BITS as usize - right_bits_pushed_into_input_b);
+
+                let input = [input_a.to_be_bytes(), input_b.to_be_bytes()];
+                let input_len =
+                    size_of::<u128>() + right_bits_pushed_into_input_b.div_ceil(u8::BITS as usize);
+                blake3_hash(&input.as_flattened()[..input_len])
+            } else {
+                let right_bits_a = right_metadata << (right_bits_start_offset - y_and_left_bits);
+                let input_a = y_bits | left_metadata_bits | right_bits_a;
+
+                blake3_hash(&input_a.to_be_bytes()[..num_bytes_with_data])
+            }
+        },
+        )*
+        ]
+    });
+
+    let y_outputs = Simd::from_array(
+        hashes.map(|hash| u32::from_be_bytes([hash[0], hash[1], hash[2], hash[3]])),
+    ) >> (u32::BITS - y_size_bits(K) as u32);
+    let y_outputs = Y::array_from_repr(y_outputs.to_array());
+
+    let metadatas = if TABLE_NUMBER < 4 {
+        seq!(N in 0..16 {
+            [
+            #(
+                Metadata::from((left_metadatas[N] << parent_metadata_bits) | right_metadatas[N]),
+            )*
+            ]
+        })
+    } else if metadata_size_bits > 0 {
+        // For K up to 25 it is guaranteed that metadata + bit offset will always fit into u128.
+        // We collect the bytes necessary, potentially with extra bits at the start and end of the
+        // bytes that will be taken care of later.
+        seq!(N in 0..16 {
+            [
+            #(
+            {
+                let metadata = u128::from_be_bytes(
+                    hashes[N][y_size_bits(K) / u8::BITS as usize..][..size_of::<u128>()]
+                        .try_into()
+                        .expect("Always enough bits for any K; qed"),
+                );
+                // Remove extra bits at the beginning
+                let metadata = metadata << (y_size_bits(K) % u8::BITS as usize);
+                // Move bits into the correct location
+                Metadata::from(metadata >> (u128::BITS as usize - metadata_size_bits))
+            },
+            )*
+            ]
+        })
+    } else {
+        [Metadata::default(); _]
+    };
+
+    (y_outputs, metadatas)
+}
+
+/// # Safety
+/// `m` must contain positions that correspond to the parent table
+#[cfg(feature = "alloc")]
+unsafe fn match_to_result<const K: u8, const TABLE_NUMBER: u8, const PARENT_TABLE_NUMBER: u8>(
+    parent_table: &Table<K, PARENT_TABLE_NUMBER>,
+    m: &Match,
+) -> (Y, [Position; 2], Metadata<K, TABLE_NUMBER>)
+where
+    Table<K, PARENT_TABLE_NUMBER>: private::NotLastTable,
+    EvaluatableUsize<{ metadata_size_bytes(K, PARENT_TABLE_NUMBER) }>: Sized,
+    EvaluatableUsize<{ metadata_size_bytes(K, TABLE_NUMBER) }>: Sized,
+    [(); 1 << K]:,
+    [(); num_buckets(K)]:,
+    [(); num_buckets(K) - 1]:,
+{
+    // SAFETY: Guaranteed by function contract
+    let left_metadata = unsafe { parent_table.metadata(m.left_position) };
+    // SAFETY: Guaranteed by function contract
+    let right_metadata = unsafe { parent_table.metadata(m.right_position) };
 
     let (y, metadata) =
         compute_fn::<K, TABLE_NUMBER, PARENT_TABLE_NUMBER>(m.left_y, left_metadata, right_metadata);
@@ -455,391 +748,791 @@ where
     (y, [m.left_position, m.right_position], metadata)
 }
 
-fn match_and_compute_fn<'a, const K: u8, const TABLE_NUMBER: u8, const PARENT_TABLE_NUMBER: u8>(
-    last_table: &'a Table<K, PARENT_TABLE_NUMBER>,
-    left_bucket: Bucket,
-    right_bucket: Bucket,
-    rmap_scratch: &'a mut Vec<RmapItem>,
-    left_targets: &'a LeftTargets,
-    results_table: &mut Vec<(Y, [Position; 2], Metadata<K, TABLE_NUMBER>)>,
-) where
+/// # Safety
+/// `matches` must contain positions that correspond to the parent table
+#[cfg(feature = "alloc")]
+#[inline(always)]
+unsafe fn match_to_result_simd<const K: u8, const TABLE_NUMBER: u8, const PARENT_TABLE_NUMBER: u8>(
+    parent_table: &Table<K, PARENT_TABLE_NUMBER>,
+    matches: &[Match; COMPUTE_FN_SIMD_FACTOR],
+) -> (
+    [Y; COMPUTE_FN_SIMD_FACTOR],
+    [[Position; 2]; COMPUTE_FN_SIMD_FACTOR],
+    [Metadata<K, TABLE_NUMBER>; COMPUTE_FN_SIMD_FACTOR],
+)
+where
+    Table<K, PARENT_TABLE_NUMBER>: private::NotLastTable,
     EvaluatableUsize<{ metadata_size_bytes(K, PARENT_TABLE_NUMBER) }>: Sized,
     EvaluatableUsize<{ metadata_size_bytes(K, TABLE_NUMBER) }>: Sized,
+    [(); 1 << K]:,
+    [(); num_buckets(K)]:,
+    [(); num_buckets(K) - 1]:,
 {
-    find_matches(
-        &last_table.ys()[usize::from(left_bucket.start_position)..]
-            [..usize::from(left_bucket.size)],
-        left_bucket.start_position,
-        &last_table.ys()[usize::from(right_bucket.start_position)..]
-            [..usize::from(right_bucket.size)],
-        right_bucket.start_position,
-        rmap_scratch,
-        left_targets,
-        |m| match_to_result(last_table, m),
-        results_table,
-    )
+    let left_ys: [_; COMPUTE_FN_SIMD_FACTOR] = seq!(N in 0..16 {
+        [
+        #(
+            matches[N].left_y,
+        )*
+        ]
+    });
+    // SAFETY: Guaranteed by function contract
+    let left_metadatas: [_; COMPUTE_FN_SIMD_FACTOR] = unsafe {
+        seq!(N in 0..16 {
+            [
+            #(
+                parent_table.metadata(matches[N].left_position),
+            )*
+            ]
+        })
+    };
+    // SAFETY: Guaranteed by function contract
+    let right_metadatas: [_; COMPUTE_FN_SIMD_FACTOR] = unsafe {
+        seq!(N in 0..16 {
+            [
+            #(
+                parent_table.metadata(matches[N].right_position),
+            )*
+            ]
+        })
+    };
+
+    let (y_outputs, metadatas) = compute_fn_simd::<K, TABLE_NUMBER, PARENT_TABLE_NUMBER>(
+        left_ys,
+        left_metadatas,
+        right_metadatas,
+    );
+
+    let positions = seq!(N in 0..16 {
+        [
+        #(
+            [
+                matches[N].left_position,
+                matches[N].right_position,
+            ],
+        )*
+        ]
+    });
+
+    (y_outputs, positions, metadatas)
 }
 
+/// # Safety
+/// `matches` must contain positions that correspond to the parent table. `ys`, `position` and
+/// `metadatas` length must be at least the length of `matches`
+#[cfg(feature = "alloc")]
+#[inline(always)]
+unsafe fn matches_to_results<const K: u8, const TABLE_NUMBER: u8, const PARENT_TABLE_NUMBER: u8>(
+    parent_table: &Table<K, PARENT_TABLE_NUMBER>,
+    matches: &[Match],
+    ys: &mut [MaybeUninit<Y>],
+    positions: &mut [MaybeUninit<[Position; 2]>],
+    metadatas: &mut [MaybeUninit<Metadata<K, TABLE_NUMBER>>],
+) where
+    Table<K, PARENT_TABLE_NUMBER>: private::NotLastTable,
+    EvaluatableUsize<{ metadata_size_bytes(K, PARENT_TABLE_NUMBER) }>: Sized,
+    EvaluatableUsize<{ metadata_size_bytes(K, TABLE_NUMBER) }>: Sized,
+    [(); 1 << K]:,
+    [(); num_buckets(K)]:,
+    [(); num_buckets(K) - 1]:,
+{
+    let (grouped_matches, other_matches) = matches.as_chunks::<COMPUTE_FN_SIMD_FACTOR>();
+    let (grouped_ys, other_ys) = ys.split_at_mut(grouped_matches.as_flattened().len());
+    let grouped_ys = grouped_ys.as_chunks_mut::<COMPUTE_FN_SIMD_FACTOR>().0;
+    let (grouped_positions, other_positions) =
+        positions.split_at_mut(grouped_matches.as_flattened().len());
+    let grouped_positions = grouped_positions
+        .as_chunks_mut::<COMPUTE_FN_SIMD_FACTOR>()
+        .0;
+    let (grouped_metadatas, other_metadatas) =
+        metadatas.split_at_mut(grouped_matches.as_flattened().len());
+    let grouped_metadatas = grouped_metadatas
+        .as_chunks_mut::<COMPUTE_FN_SIMD_FACTOR>()
+        .0;
+
+    for (((grouped_matches, grouped_ys), grouped_positions), grouped_metadatas) in grouped_matches
+        .iter()
+        .zip(grouped_ys)
+        .zip(grouped_positions)
+        .zip(grouped_metadatas)
+    {
+        // SAFETY: Guaranteed by function contract
+        let (ys_group, positions_group, metadatas_group) =
+            unsafe { match_to_result_simd(parent_table, grouped_matches) };
+        grouped_ys.write_copy_of_slice(&ys_group);
+        grouped_positions.write_copy_of_slice(&positions_group);
+
+        // The last table doesn't have metadata
+        if metadata_size_bits(K, TABLE_NUMBER) > 0 {
+            grouped_metadatas.write_copy_of_slice(&metadatas_group);
+        }
+    }
+    for (((other_match, other_y), other_positions), other_metadata) in other_matches
+        .iter()
+        .zip(other_ys)
+        .zip(other_positions)
+        .zip(other_metadatas)
+    {
+        // SAFETY: Guaranteed by function contract
+        let (y, p, metadata) = unsafe { match_to_result(parent_table, other_match) };
+        other_y.write(y);
+        other_positions.write(p);
+        // The last table doesn't have metadata
+        if metadata_size_bits(K, TABLE_NUMBER) > 0 {
+            other_metadata.write(metadata);
+        }
+    }
+}
+
+/// Similar to [`Table`], but smaller size for later processing stages
+#[cfg(feature = "alloc")]
+#[derive(Debug)]
+pub(super) enum PrunedTable<const K: u8, const TABLE_NUMBER: u8>
+where
+    [(); 1 << K]:,
+    [(); num_buckets(K) - 1]:,
+{
+    First,
+    /// Other tables
+    Other {
+        /// Left and right entry positions in a previous table encoded into bits
+        positions: Box<[MaybeUninit<[Position; 2]>; 1 << K]>,
+    },
+    /// Other tables
+    #[cfg(feature = "parallel")]
+    OtherBuckets {
+        /// Left and right entry positions in a previous table encoded into bits.
+        ///
+        /// Only positions from the `buckets` field are guaranteed to be initialized.
+        positions: Box<[[MaybeUninit<[Position; 2]>; REDUCED_MATCHES_COUNT]; num_buckets(K) - 1]>,
+    },
+}
+
+#[cfg(feature = "alloc")]
+impl<const K: u8, const TABLE_NUMBER: u8> PrunedTable<K, TABLE_NUMBER>
+where
+    [(); 1 << K]:,
+    [(); num_buckets(K) - 1]:,
+{
+    /// Get `[left_position, right_position]` of a previous table for a specified position in a
+    /// current table.
+    ///
+    /// # Safety
+    /// `position` must come from [`Table::buckets()`] or [`Self::position()`] and not be a sentinel
+    /// value.
+    #[inline(always)]
+    pub(super) unsafe fn position(&self, position: Position) -> [Position; 2] {
+        match self {
+            Self::First => {
+                unreachable!("Not the first table");
+            }
+            Self::Other { positions, .. } => {
+                // SAFETY: All non-sentinel positions returned by [`Self::buckets()`] are valid
+                unsafe { positions.get_unchecked(usize::from(position)).assume_init() }
+            }
+            #[cfg(feature = "parallel")]
+            Self::OtherBuckets { positions, .. } => {
+                // SAFETY: All non-sentinel positions returned by [`Self::buckets()`] are valid
+                unsafe {
+                    positions
+                        .as_flattened()
+                        .get_unchecked(usize::from(position))
+                        .assume_init()
+                }
+            }
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
 #[derive(Debug)]
 pub(super) enum Table<const K: u8, const TABLE_NUMBER: u8>
 where
     EvaluatableUsize<{ metadata_size_bytes(K, TABLE_NUMBER) }>: Sized,
+    [(); 1 << K]:,
+    [(); num_buckets(K)]:,
+    [(); num_buckets(K) - 1]:,
 {
-    /// First table with contents of entries split into separate vectors for more efficient access
+    /// First table
     First {
-        /// Derived values computed from `x`
-        ys: Vec<Y>,
-        /// X values
-        xs: Vec<X>,
+        /// Each bucket contains positions of `Y` values that belong to it and corresponding `y`.
+        ///
+        /// Buckets are padded with sentinel values to `REDUCED_BUCKETS_SIZE`.
+        buckets: Box<[[(Position, Y); REDUCED_BUCKET_SIZE]; num_buckets(K)]>,
     },
     /// Other tables
     Other {
-        /// Derived values computed from previous table
-        ys: Vec<Y>,
         /// Left and right entry positions in a previous table encoded into bits
-        positions: Vec<[Position; 2]>,
+        positions: Box<[MaybeUninit<[Position; 2]>; 1 << K]>,
         /// Metadata corresponding to each entry
-        metadatas: Vec<Metadata<K, TABLE_NUMBER>>,
+        metadatas: Box<[MaybeUninit<Metadata<K, TABLE_NUMBER>>; 1 << K]>,
+        /// Each bucket contains positions of `Y` values that belong to it and corresponding `y`.
+        ///
+        /// Buckets are padded with sentinel values to `REDUCED_BUCKETS_SIZE`.
+        buckets: Box<[[(Position, Y); REDUCED_BUCKET_SIZE]; num_buckets(K)]>,
+    },
+    /// Other tables
+    #[cfg(feature = "parallel")]
+    OtherBuckets {
+        /// Left and right entry positions in a previous table encoded into bits.
+        ///
+        /// Only positions from the `buckets` field are guaranteed to be initialized.
+        positions: Box<[[MaybeUninit<[Position; 2]>; REDUCED_MATCHES_COUNT]; num_buckets(K) - 1]>,
+        /// Metadata corresponding to each entry.
+        ///
+        /// Only positions from the `buckets` field are guaranteed to be initialized.
+        metadatas: Box<
+            [[MaybeUninit<Metadata<K, TABLE_NUMBER>>; REDUCED_MATCHES_COUNT]; num_buckets(K) - 1],
+        >,
+        /// Each bucket contains positions of `Y` values that belong to it and corresponding `y`.
+        ///
+        /// Buckets are padded with sentinel values to `REDUCED_BUCKETS_SIZE`.
+        buckets: Box<[[(Position, Y); REDUCED_BUCKET_SIZE]; num_buckets(K)]>,
     },
 }
 
+#[cfg(feature = "alloc")]
 impl<const K: u8> Table<K, 1>
 where
     EvaluatableUsize<{ metadata_size_bytes(K, 1) }>: Sized,
+    [(); 1 << K]:,
+    [(); num_buckets(K)]:,
+    [(); num_buckets(K) - 1]:,
 {
     /// Create the table
     pub(super) fn create(seed: Seed) -> Self
     where
         EvaluatableUsize<{ K as usize * COMPUTE_F1_SIMD_FACTOR / u8::BITS as usize }>: Sized,
     {
+        // `MAX_BUCKET_SIZE` is not actively used, but is an upper-bound reference for the other
+        // parameters
+        debug_assert!(
+            MAX_BUCKET_SIZE >= bucket_size_upper_bound(K, BUCKET_SIZE_UPPER_BOUND_SECURITY_BITS),
+            "Max bucket size is not sufficiently large"
+        );
+
         let partial_ys = partial_ys::<K>(seed);
 
-        let mut t_1 = Vec::with_capacity(1_usize << K);
-        for (x_batch, partial_ys) in partial_ys
-            .as_chunks::<{ K as usize * COMPUTE_F1_SIMD_FACTOR / u8::BITS as usize }>()
+        // SAFETY: Contents is `MaybeUninit`
+        let mut ys = unsafe { Box::<[MaybeUninit<Y>; 1 << K]>::new_uninit().assume_init() };
+
+        for ((ys, xs_batch_start), partial_ys) in ys
+            .as_chunks_mut::<COMPUTE_F1_SIMD_FACTOR>()
             .0
-            .iter()
-            .copied()
-            .enumerate()
+            .iter_mut()
+            .zip((X::ZERO..).step_by(COMPUTE_F1_SIMD_FACTOR))
+            .zip(
+                partial_ys
+                    .as_chunks::<{ K as usize * COMPUTE_F1_SIMD_FACTOR / u8::BITS as usize }>()
+                    .0,
+            )
         {
-            let xs = array::from_fn::<_, COMPUTE_F1_SIMD_FACTOR, _>(|i| {
-                (x_batch * COMPUTE_F1_SIMD_FACTOR + i) as u32
-            });
-            let ys = compute_f1_simd::<K>(xs, &partial_ys);
-            t_1.extend(ys.into_iter().zip(X::array_from_repr(xs)));
+            let xs = Simd::splat(u32::from(xs_batch_start))
+                + Simd::from_array(array::from_fn(|i| i as u32));
+            let ys_batch = compute_f1_simd::<K>(xs, partial_ys);
+
+            ys.write_copy_of_slice(&ys_batch);
         }
 
-        t_1.sort_unstable();
+        // SAFETY: Converting a boxed array to a vector of the same size, which has the same memory
+        // layout, all elements were initialized
+        let ys = unsafe {
+            let ys_len = ys.len();
+            let ys = Box::into_raw(ys);
+            Vec::from_raw_parts(ys.cast(), ys_len, ys_len)
+        };
 
-        let (ys, xs) = t_1.into_iter().unzip();
+        // TODO: Try to group buckets in the process of collecting `y`s
+        let buckets = group_by_buckets::<K>(&ys);
 
-        Self::First { ys, xs }
+        Self::First { buckets }
     }
 
     /// Create the table, leverages available parallelism
-    #[cfg(any(feature = "parallel", test))]
+    #[cfg(feature = "parallel")]
     pub(super) fn create_parallel(seed: Seed) -> Self
     where
         EvaluatableUsize<{ K as usize * COMPUTE_F1_SIMD_FACTOR / u8::BITS as usize }>: Sized,
     {
+        // `MAX_BUCKET_SIZE` is not actively used, but is an upper-bound reference for the other
+        // parameters
+        debug_assert!(
+            MAX_BUCKET_SIZE >= bucket_size_upper_bound(K, BUCKET_SIZE_UPPER_BOUND_SECURITY_BITS),
+            "Max bucket size is not sufficiently large"
+        );
+
         let partial_ys = partial_ys::<K>(seed);
 
-        let mut t_1 = Vec::with_capacity(1_usize << K);
-        for (x_batch, partial_ys) in partial_ys
-            .as_chunks::<{ K as usize * COMPUTE_F1_SIMD_FACTOR / u8::BITS as usize }>()
+        // SAFETY: Contents is `MaybeUninit`
+        let mut ys = unsafe { Box::<[MaybeUninit<Y>; 1 << K]>::new_uninit().assume_init() };
+
+        // TODO: Try parallelism here?
+        for ((ys, xs_batch_start), partial_ys) in ys
+            .as_chunks_mut::<COMPUTE_F1_SIMD_FACTOR>()
             .0
-            .iter()
-            .copied()
-            .enumerate()
+            .iter_mut()
+            .zip((X::ZERO..).step_by(COMPUTE_F1_SIMD_FACTOR))
+            .zip(
+                partial_ys
+                    .as_chunks::<{ K as usize * COMPUTE_F1_SIMD_FACTOR / u8::BITS as usize }>()
+                    .0,
+            )
         {
-            let xs = array::from_fn::<_, COMPUTE_F1_SIMD_FACTOR, _>(|i| {
-                (x_batch * COMPUTE_F1_SIMD_FACTOR + i) as u32
-            });
-            let ys = compute_f1_simd::<K>(xs, &partial_ys);
-            t_1.extend(ys.into_iter().zip(X::array_from_repr(xs)));
+            let xs = Simd::splat(u32::from(xs_batch_start))
+                + Simd::from_array(array::from_fn(|i| i as u32));
+            let ys_batch = compute_f1_simd::<K>(xs, partial_ys);
+
+            ys.write_copy_of_slice(&ys_batch);
         }
 
-        t_1.par_sort_unstable();
+        // SAFETY: Converting a boxed array to a vector of the same size, which has the same memory
+        // layout, all elements were initialized
+        let ys = unsafe {
+            let ys_len = ys.len();
+            let ys = Box::into_raw(ys);
+            Vec::from_raw_parts(ys.cast(), ys_len, ys_len)
+        };
 
-        let (ys, xs) = t_1.into_iter().unzip();
+        // TODO: Try to group buckets in the process of collecting `y`s
+        let buckets = group_by_buckets::<K>(&ys);
 
-        Self::First { ys, xs }
-    }
-
-    /// All `x`s as [`BitSlice`], for individual `x`s needs to be slices into [`K`] bits slices
-    pub(super) fn xs(&self) -> &[X] {
-        match self {
-            Table::First { xs, .. } => xs,
-            _ => {
-                unreachable!()
-            }
-        }
+        Self::First { buckets }
     }
 }
 
+#[cfg(feature = "alloc")]
 mod private {
     pub(in super::super) trait SupportedOtherTables {}
+    pub(in super::super) trait NotLastTable {}
 }
 
-impl<const K: u8> private::SupportedOtherTables for Table<K, 2> where
-    EvaluatableUsize<{ metadata_size_bytes(K, 2) }>: Sized
+#[cfg(feature = "alloc")]
+impl<const K: u8> private::SupportedOtherTables for Table<K, 2>
+where
+    EvaluatableUsize<{ metadata_size_bytes(K, 2) }>: Sized,
+    [(); 1 << K]:,
+    [(); num_buckets(K)]:,
+    [(); num_buckets(K) - 1]:,
+{
+}
+#[cfg(feature = "alloc")]
+impl<const K: u8> private::SupportedOtherTables for Table<K, 3>
+where
+    EvaluatableUsize<{ metadata_size_bytes(K, 3) }>: Sized,
+    [(); 1 << K]:,
+    [(); num_buckets(K)]:,
+    [(); num_buckets(K) - 1]:,
+{
+}
+#[cfg(feature = "alloc")]
+impl<const K: u8> private::SupportedOtherTables for Table<K, 4>
+where
+    EvaluatableUsize<{ metadata_size_bytes(K, 4) }>: Sized,
+    [(); 1 << K]:,
+    [(); num_buckets(K)]:,
+    [(); num_buckets(K) - 1]:,
+{
+}
+#[cfg(feature = "alloc")]
+impl<const K: u8> private::SupportedOtherTables for Table<K, 5>
+where
+    EvaluatableUsize<{ metadata_size_bytes(K, 5) }>: Sized,
+    [(); 1 << K]:,
+    [(); num_buckets(K)]:,
+    [(); num_buckets(K) - 1]:,
+{
+}
+#[cfg(feature = "alloc")]
+impl<const K: u8> private::SupportedOtherTables for Table<K, 6>
+where
+    EvaluatableUsize<{ metadata_size_bytes(K, 6) }>: Sized,
+    [(); 1 << K]:,
+    [(); num_buckets(K)]:,
+    [(); num_buckets(K) - 1]:,
+{
+}
+#[cfg(feature = "alloc")]
+impl<const K: u8> private::SupportedOtherTables for Table<K, 7>
+where
+    EvaluatableUsize<{ metadata_size_bytes(K, 7) }>: Sized,
+    [(); 1 << K]:,
+    [(); num_buckets(K)]:,
+    [(); num_buckets(K) - 1]:,
 {
 }
 
-impl<const K: u8> private::SupportedOtherTables for Table<K, 3> where
-    EvaluatableUsize<{ metadata_size_bytes(K, 3) }>: Sized
+#[cfg(feature = "alloc")]
+impl<const K: u8> private::NotLastTable for Table<K, 1>
+where
+    EvaluatableUsize<{ metadata_size_bytes(K, 1) }>: Sized,
+    [(); 1 << K]:,
+    [(); num_buckets(K)]:,
+    [(); num_buckets(K) - 1]:,
+{
+}
+#[cfg(feature = "alloc")]
+impl<const K: u8> private::NotLastTable for Table<K, 2>
+where
+    EvaluatableUsize<{ metadata_size_bytes(K, 2) }>: Sized,
+    [(); 1 << K]:,
+    [(); num_buckets(K)]:,
+    [(); num_buckets(K) - 1]:,
+{
+}
+#[cfg(feature = "alloc")]
+impl<const K: u8> private::NotLastTable for Table<K, 3>
+where
+    EvaluatableUsize<{ metadata_size_bytes(K, 3) }>: Sized,
+    [(); 1 << K]:,
+    [(); num_buckets(K)]:,
+    [(); num_buckets(K) - 1]:,
+{
+}
+#[cfg(feature = "alloc")]
+impl<const K: u8> private::NotLastTable for Table<K, 4>
+where
+    EvaluatableUsize<{ metadata_size_bytes(K, 4) }>: Sized,
+    [(); 1 << K]:,
+    [(); num_buckets(K)]:,
+    [(); num_buckets(K) - 1]:,
+{
+}
+#[cfg(feature = "alloc")]
+impl<const K: u8> private::NotLastTable for Table<K, 5>
+where
+    EvaluatableUsize<{ metadata_size_bytes(K, 5) }>: Sized,
+    [(); 1 << K]:,
+    [(); num_buckets(K)]:,
+    [(); num_buckets(K) - 1]:,
+{
+}
+#[cfg(feature = "alloc")]
+impl<const K: u8> private::NotLastTable for Table<K, 6>
+where
+    EvaluatableUsize<{ metadata_size_bytes(K, 6) }>: Sized,
+    [(); 1 << K]:,
+    [(); num_buckets(K)]:,
+    [(); num_buckets(K) - 1]:,
 {
 }
 
-impl<const K: u8> private::SupportedOtherTables for Table<K, 4> where
-    EvaluatableUsize<{ metadata_size_bytes(K, 4) }>: Sized
-{
-}
-
-impl<const K: u8> private::SupportedOtherTables for Table<K, 5> where
-    EvaluatableUsize<{ metadata_size_bytes(K, 5) }>: Sized
-{
-}
-
-impl<const K: u8> private::SupportedOtherTables for Table<K, 6> where
-    EvaluatableUsize<{ metadata_size_bytes(K, 6) }>: Sized
-{
-}
-
-impl<const K: u8> private::SupportedOtherTables for Table<K, 7> where
-    EvaluatableUsize<{ metadata_size_bytes(K, 7) }>: Sized
-{
-}
-
+#[cfg(feature = "alloc")]
 impl<const K: u8, const TABLE_NUMBER: u8> Table<K, TABLE_NUMBER>
 where
     Self: private::SupportedOtherTables,
     EvaluatableUsize<{ metadata_size_bytes(K, TABLE_NUMBER) }>: Sized,
+    [(); 1 << K]:,
+    [(); num_buckets(K)]:,
+    [(); num_buckets(K) - 1]:,
 {
-    /// Creates new [`TABLE_NUMBER`] table. There also exists [`Self::create_parallel()`] that
-    /// trades CPU efficiency and memory usage for lower latency.
+    /// Creates a new [`TABLE_NUMBER`] table. There also exists [`Self::create_parallel()`] that
+    /// trades CPU efficiency and memory usage for lower latency and with multiple parallel calls,
+    /// better overall performance.
     pub(super) fn create<const PARENT_TABLE_NUMBER: u8>(
-        last_table: &Table<K, PARENT_TABLE_NUMBER>,
-        cache: &mut TablesCache<K>,
-    ) -> Self
+        parent_table: Table<K, PARENT_TABLE_NUMBER>,
+        cache: &TablesCache,
+    ) -> (Self, PrunedTable<K, PARENT_TABLE_NUMBER>)
     where
+        Table<K, PARENT_TABLE_NUMBER>: private::NotLastTable,
         EvaluatableUsize<{ metadata_size_bytes(K, PARENT_TABLE_NUMBER) }>: Sized,
     {
-        let buckets = &mut cache.buckets;
-        let rmap_scratch = &mut cache.rmap_scratch;
-        let left_targets = &cache.left_targets;
-
-        let mut bucket = Bucket {
-            bucket_index: 0,
-            start_position: Position::ZERO,
-            size: Position::ZERO,
+        let left_targets = &*cache.left_targets;
+        let mut initialized_elements = 0_usize;
+        // SAFETY: Contents is `MaybeUninit`
+        let mut ys = unsafe { Box::<[MaybeUninit<Y>; 1 << K]>::new_uninit().assume_init() };
+        // SAFETY: Contents is `MaybeUninit`
+        let mut positions =
+            unsafe { Box::<[MaybeUninit<[Position; 2]>; 1 << K]>::new_uninit().assume_init() };
+        // The last table doesn't have metadata
+        // SAFETY: Contents is `MaybeUninit`
+        let mut metadatas = unsafe {
+            Box::<[MaybeUninit<Metadata<K, TABLE_NUMBER>>; 1 << K]>::new_uninit().assume_init()
         };
 
-        let last_y = *last_table
-            .ys()
-            .last()
-            .expect("List of y values is never empty; qed");
-        buckets.clear();
-        buckets.reserve(1 + usize::from(last_y) / usize::from(PARAM_BC));
-        last_table
-            .ys()
-            .iter()
-            .zip(Position::ZERO..)
-            .for_each(|(&y, position)| {
-                let bucket_index = u32::from(y) / u32::from(PARAM_BC);
-
-                if bucket_index == bucket.bucket_index {
-                    bucket.size += Position::ONE;
-                    return;
-                }
-
-                buckets.push(bucket);
-
-                bucket = Bucket {
-                    bucket_index,
-                    start_position: position,
-                    size: Position::ONE,
-                };
-            });
-        // Iteration stopped, but we did not store the last bucket yet
-        buckets.push(bucket);
-
-        let num_values = 1 << K;
-        let mut t_n = Vec::with_capacity(num_values);
-        buckets
-            .array_windows::<2>()
-            .for_each(|&[left_bucket, right_bucket]| {
-                match_and_compute_fn::<K, TABLE_NUMBER, PARENT_TABLE_NUMBER>(
-                    last_table,
+        for ([left_bucket, right_bucket], left_bucket_index) in
+            parent_table.buckets().array_windows().zip(0..)
+        {
+            let mut matches = [MaybeUninit::uninit(); _];
+            // SAFETY: Positions are taken from `Table::buckets()` and correspond to initialized
+            // values
+            let matches = unsafe {
+                find_matches_in_buckets(
+                    left_bucket_index,
                     left_bucket,
                     right_bucket,
-                    rmap_scratch,
+                    &mut matches,
                     left_targets,
-                    &mut t_n,
-                );
-            });
+                )
+            };
+            // Throw away some successful matches that are not that necessary
+            let matches = &matches[..matches.len().min(REDUCED_MATCHES_COUNT)];
+            // SAFETY: Already initialized this many elements
+            let (ys, positions, metadatas) = unsafe {
+                (
+                    ys.split_at_mut_unchecked(initialized_elements).1,
+                    positions.split_at_mut_unchecked(initialized_elements).1,
+                    metadatas.split_at_mut_unchecked(initialized_elements).1,
+                )
+            };
 
-        t_n.sort_unstable();
+            // SAFETY: Preallocated length is an upper bound and is always sufficient
+            let (ys, positions, metadatas) = unsafe {
+                (
+                    ys.split_at_mut_unchecked(matches.len()).0,
+                    positions.split_at_mut_unchecked(matches.len()).0,
+                    metadatas.split_at_mut_unchecked(matches.len()).0,
+                )
+            };
 
-        let mut ys = Vec::with_capacity(t_n.len());
-        let mut positions = Vec::with_capacity(t_n.len());
-        let mut metadatas = Vec::with_capacity(t_n.len());
-
-        for (y, [left_position, right_position], metadata) in t_n {
-            ys.push(y);
-            positions.push([left_position, right_position]);
-            // Last table doesn't have metadata
-            if metadata_size_bits(K, TABLE_NUMBER) > 0 {
-                metadatas.push(metadata);
+            // SAFETY: Matches come from the parent table and the size of `ys`, `positions`
+            // and `metadatas` is the same as the number of matches
+            unsafe {
+                matches_to_results(&parent_table, matches, ys, positions, metadatas);
             }
+
+            initialized_elements += matches.len();
         }
 
-        Self::Other {
-            ys,
+        let parent_table = parent_table.prune();
+
+        // SAFETY: Converting a boxed array to a vector of the same size, which has the same memory
+        // layout, the number of elements matches the number of elements that were initialized
+        let ys = unsafe {
+            let ys_len = ys.len();
+            let ys = Box::into_raw(ys);
+            Vec::from_raw_parts(ys.cast(), initialized_elements, ys_len)
+        };
+
+        // TODO: Try to group buckets in the process of collecting `y`s
+        let buckets = group_by_buckets::<K>(&ys);
+
+        let table = Self::Other {
             positions,
             metadatas,
-        }
+            buckets,
+        };
+
+        (table, parent_table)
     }
 
     /// Almost the same as [`Self::create()`], but uses parallelism internally for better
     /// performance (though not efficiency of CPU and memory usage), if you create multiple tables
-    /// in parallel, prefer [`Self::create()`] for better overall performance.
-    #[cfg(any(feature = "parallel", test))]
+    /// in parallel, prefer [`Self::create_parallel()`] for better overall performance.
+    #[cfg(feature = "parallel")]
     pub(super) fn create_parallel<const PARENT_TABLE_NUMBER: u8>(
-        last_table: &Table<K, PARENT_TABLE_NUMBER>,
-        cache: &mut TablesCache<K>,
-    ) -> Self
+        parent_table: Table<K, PARENT_TABLE_NUMBER>,
+        cache: &TablesCache,
+    ) -> (Self, PrunedTable<K, PARENT_TABLE_NUMBER>)
     where
+        Table<K, PARENT_TABLE_NUMBER>: private::NotLastTable,
         EvaluatableUsize<{ metadata_size_bytes(K, PARENT_TABLE_NUMBER) }>: Sized,
     {
-        let left_targets = &cache.left_targets;
-
-        let mut first_bucket = Bucket {
-            bucket_index: u32::from(last_table.ys()[0]) / u32::from(PARAM_BC),
-            start_position: Position::ZERO,
-            size: Position::ZERO,
+        // SAFETY: Contents is `MaybeUninit`
+        let ys = unsafe {
+            Box::<[SyncUnsafeCell<[MaybeUninit<_>; REDUCED_MATCHES_COUNT]>; num_buckets(K) - 1]>::new_uninit().assume_init()
         };
-        for &y in last_table.ys() {
-            let bucket_index = u32::from(y) / u32::from(PARAM_BC);
+        // SAFETY: Contents is `MaybeUninit`
+        let positions = unsafe {
+            Box::<[SyncUnsafeCell<[MaybeUninit<_>; REDUCED_MATCHES_COUNT]>; num_buckets(K) - 1]>::new_uninit().assume_init()
+        };
+        // SAFETY: Contents is `MaybeUninit`
+        let metadatas = unsafe {
+            Box::<[SyncUnsafeCell<[MaybeUninit<_>; REDUCED_MATCHES_COUNT]>; num_buckets(K) - 1]>::new_uninit().assume_init()
+        };
+        let global_results_counts =
+            array::from_fn::<_, { num_buckets(K) - 1 }, _>(|_| SyncUnsafeCell::new(0u16));
 
-            if bucket_index == first_bucket.bucket_index {
-                first_bucket.size += Position::ONE;
-            } else {
-                break;
-            }
-        }
+        let left_targets = &*cache.left_targets;
 
-        let previous_bucket = Mutex::new(first_bucket);
+        let buckets = parent_table.buckets();
+        // Iterate over buckets in batches, such that a cache line worth of bytes is taken from
+        // `global_results_counts` each time to avoid unnecessary false sharing
+        let bucket_batch_size = CACHE_LINE_SIZE / size_of::<u16>();
+        let bucket_batch_index = AtomicUsize::new(0);
 
-        let t_n = rayon::broadcast(|_ctx| {
-            let mut entries = Vec::new();
-            let mut rmap_scratch = Vec::new();
-
+        rayon::broadcast(|_ctx| {
             loop {
-                let left_bucket;
-                let right_bucket;
-                {
-                    let mut previous_bucket = previous_bucket.lock();
+                let bucket_batch_index = bucket_batch_index.fetch_add(1, Ordering::Relaxed);
 
-                    let right_bucket_start_position =
-                        previous_bucket.start_position + previous_bucket.size;
-                    let right_bucket_index = match last_table
-                        .ys()
-                        .get(usize::from(right_bucket_start_position))
-                    {
-                        Some(&y) => u32::from(y) / u32::from(PARAM_BC),
-                        None => {
-                            break;
-                        }
-                    };
-                    let mut right_bucket_size = Position::ZERO;
+                let buckets_batch = buckets
+                    .array_windows::<2>()
+                    .enumerate()
+                    .skip(bucket_batch_index * bucket_batch_size)
+                    .take(bucket_batch_size);
 
-                    for &y in &last_table.ys()[usize::from(right_bucket_start_position)..] {
-                        let bucket_index = u32::from(y) / u32::from(PARAM_BC);
-
-                        if bucket_index == right_bucket_index {
-                            right_bucket_size += Position::ONE;
-                        } else {
-                            break;
-                        }
-                    }
-
-                    right_bucket = Bucket {
-                        bucket_index: right_bucket_index,
-                        start_position: right_bucket_start_position,
-                        size: right_bucket_size,
-                    };
-
-                    left_bucket = *previous_bucket;
-                    *previous_bucket = right_bucket;
+                if buckets_batch.is_empty() {
+                    break;
                 }
 
-                match_and_compute_fn::<K, TABLE_NUMBER, PARENT_TABLE_NUMBER>(
-                    last_table,
-                    left_bucket,
-                    right_bucket,
-                    &mut rmap_scratch,
-                    left_targets,
-                    &mut entries,
-                );
-            }
+                for (left_bucket_index, [left_bucket, right_bucket]) in buckets_batch {
+                    let mut matches = [MaybeUninit::uninit(); _];
+                    // SAFETY: Positions are taken from `Table::buckets()` and correspond to
+                    // initialized values
+                    let matches = unsafe {
+                        find_matches_in_buckets(
+                            left_bucket_index as u32,
+                            left_bucket,
+                            right_bucket,
+                            &mut matches,
+                            left_targets,
+                        )
+                    };
+                    // Throw away some successful matches that are not that necessary
+                    let matches = &matches[..matches.len().min(REDUCED_MATCHES_COUNT)];
 
-            entries
+                    // SAFETY: This is the only place where `left_bucket_index`'s entry is accessed
+                    // at this time, and it is guaranteed to be in range
+                    let ys = unsafe { &mut *ys.get_unchecked(left_bucket_index).get() };
+                    // SAFETY: This is the only place where `left_bucket_index`'s entry is accessed
+                    // at this time, and it is guaranteed to be in range
+                    let positions =
+                        unsafe { &mut *positions.get_unchecked(left_bucket_index).get() };
+                    // SAFETY: This is the only place where `left_bucket_index`'s entry is accessed
+                    // at this time, and it is guaranteed to be in range
+                    let metadatas =
+                        unsafe { &mut *metadatas.get_unchecked(left_bucket_index).get() };
+                    // SAFETY: This is the only place where `left_bucket_index`'s entry is accessed
+                    // at this time, and it is guaranteed to be in range
+                    let count = unsafe {
+                        &mut *global_results_counts.get_unchecked(left_bucket_index).get()
+                    };
+
+                    // SAFETY: Matches come from the parent table and the size of `ys`, `positions`
+                    // and `metadatas` is larger or equal to the number of matches
+                    unsafe {
+                        matches_to_results::<_, TABLE_NUMBER, _>(
+                            &parent_table,
+                            matches,
+                            ys,
+                            positions,
+                            metadatas,
+                        )
+                    };
+                    *count = matches.len() as u16;
+                }
+            }
         });
 
-        let mut t_n = t_n.into_iter().flatten().collect::<Vec<_>>();
-        t_n.par_sort_unstable();
+        let parent_table = parent_table.prune();
 
-        let mut ys = Vec::with_capacity(t_n.len());
-        let mut positions = Vec::with_capacity(t_n.len());
-        let mut metadatas = Vec::with_capacity(t_n.len());
+        let ys = strip_sync_unsafe_cell(ys);
+        let positions = strip_sync_unsafe_cell(positions);
+        let metadatas = strip_sync_unsafe_cell(metadatas);
 
-        for (y, [left_position, right_position], metadata) in t_n.drain(..) {
-            ys.push(y);
-            positions.push([left_position, right_position]);
-            // Last table doesn't have metadata
-            if metadata_size_bits(K, TABLE_NUMBER) > 0 {
-                metadatas.push(metadata);
-            }
-        }
+        // TODO: Try to group buckets in the process of collecting `y`s
+        // SAFETY: `global_results_counts` corresponds to the number of initialized `ys`
+        let buckets = unsafe {
+            group_by_buckets_from_buckets::<K, _>(
+                ys.iter().zip(
+                    global_results_counts
+                        .into_iter()
+                        .map(|count| usize::from(count.into_inner())),
+                ),
+            )
+        };
 
-        // Drop from a background thread, which typically helps with overall concurrency
-        rayon::spawn(move || {
-            drop(t_n);
-        });
-
-        Self::Other {
-            ys,
+        let table = Self::OtherBuckets {
             positions,
             metadatas,
+            buckets,
+        };
+
+        (table, parent_table)
+    }
+
+    /// Get `[left_position, right_position]` of a previous table for a specified position in a
+    /// current table.
+    ///
+    /// # Safety
+    /// `position` must come from [`Self::buckets()`] or [`Self::position()`] or
+    /// [`PrunedTable::position()`] and not be a sentinel value.
+    #[inline(always)]
+    pub(super) unsafe fn position(&self, position: Position) -> [Position; 2] {
+        match self {
+            Self::First { .. } => {
+                unreachable!("Not the first table");
+            }
+            Self::Other { positions, .. } => {
+                // SAFETY: All non-sentinel positions returned by [`Self::buckets()`] are valid
+                unsafe { positions.get_unchecked(usize::from(position)).assume_init() }
+            }
+            #[cfg(feature = "parallel")]
+            Self::OtherBuckets { positions, .. } => {
+                // SAFETY: All non-sentinel positions returned by [`Self::buckets()`] are valid
+                unsafe {
+                    positions
+                        .as_flattened()
+                        .get_unchecked(usize::from(position))
+                        .assume_init()
+                }
+            }
         }
     }
 }
 
+#[cfg(feature = "alloc")]
+impl<const K: u8, const TABLE_NUMBER: u8> Table<K, TABLE_NUMBER>
+where
+    Self: private::NotLastTable,
+    EvaluatableUsize<{ metadata_size_bytes(K, TABLE_NUMBER) }>: Sized,
+    [(); 1 << K]:,
+    [(); num_buckets(K)]:,
+    [(); num_buckets(K) - 1]:,
+{
+    /// Returns `None` for an invalid position or for table number 7.
+    ///
+    /// # Safety
+    /// `position` must come from [`Self::buckets()`] and not be a sentinel value.
+    #[inline(always)]
+    unsafe fn metadata(&self, position: Position) -> Metadata<K, TABLE_NUMBER> {
+        match self {
+            Self::First { .. } => {
+                // X matches position
+                Metadata::from(X::from(u32::from(position)))
+            }
+            Self::Other { metadatas, .. } => {
+                // SAFETY: All non-sentinel positions returned by [`Self::buckets()`] are valid
+                unsafe { metadatas.get_unchecked(usize::from(position)).assume_init() }
+            }
+            #[cfg(feature = "parallel")]
+            Self::OtherBuckets { metadatas, .. } => {
+                // SAFETY: All non-sentinel positions returned by [`Self::buckets()`] are valid
+                unsafe {
+                    metadatas
+                        .as_flattened()
+                        .get_unchecked(usize::from(position))
+                        .assume_init()
+                }
+            }
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
 impl<const K: u8, const TABLE_NUMBER: u8> Table<K, TABLE_NUMBER>
 where
     EvaluatableUsize<{ metadata_size_bytes(K, TABLE_NUMBER) }>: Sized,
+    [(); 1 << K]:,
+    [(); num_buckets(K)]:,
+    [(); num_buckets(K) - 1]:,
 {
-    /// All `y`s as [`BitSlice`], for individual `x`s needs to be slices into [`K`] bits slices
-    pub(super) fn ys(&self) -> &[Y] {
-        let (Table::First { ys, .. } | Table::Other { ys, .. }) = self;
-        ys
-    }
-
-    /// Returns `None` on invalid position or first table, `Some(left_position, right_position)` in
-    /// previous table on success
-    pub(super) fn position(&self, position: Position) -> Option<[Position; 2]> {
+    #[inline(always)]
+    fn prune(self) -> PrunedTable<K, TABLE_NUMBER> {
         match self {
-            Table::First { .. } => None,
-            Table::Other { positions, .. } => positions.get(usize::from(position)).copied(),
+            Self::First { .. } => PrunedTable::First,
+            Self::Other { positions, .. } => PrunedTable::Other { positions },
+            #[cfg(feature = "parallel")]
+            Self::OtherBuckets { positions, .. } => PrunedTable::OtherBuckets { positions },
         }
     }
 
-    /// Returns `None` on invalid position or for table number 7
-    pub(super) fn metadata(&self, position: Position) -> Option<Metadata<K, TABLE_NUMBER>> {
+    /// Positions of `y`s grouped by the bucket they belong to
+    #[inline(always)]
+    pub(super) fn buckets(&self) -> &[[(Position, Y); REDUCED_BUCKET_SIZE]; num_buckets(K)] {
         match self {
-            Table::First { xs, .. } => xs.get(usize::from(position)).map(|&x| Metadata::from(x)),
-            Table::Other { metadatas, .. } => metadatas.get(usize::from(position)).copied(),
+            Self::First { buckets, .. } => buckets,
+            Self::Other { buckets, .. } => buckets,
+            #[cfg(feature = "parallel")]
+            Self::OtherBuckets { buckets, .. } => buckets,
         }
     }
 }

--- a/crates/subspace-proof-of-space/src/chiapos/table.rs
+++ b/crates/subspace-proof-of-space/src/chiapos/table.rs
@@ -462,29 +462,19 @@ unsafe fn find_matches_in_buckets<'a>(
 
         for &r_target in left_targets_r.iter() {
             // SAFETY: Targets are always limited to `PARAM_BC`
-            let [right_position_a, right_position_b] = unsafe { rmap.get(r_target) };
+            let right_positions = unsafe { rmap.get(r_target) };
 
-            // The right bucket position is never zero
-            if right_position_a != Position::ZERO {
-                // SAFETY: Iteration will stop before `REDUCED_MATCHES_COUNT + PARAM_M * 2`
-                // elements is inserted
+            for &right_position in right_positions {
+                if next_match_index >= matches.len() {
+                    break;
+                }
+                // SAFETY: Bounds checked above
                 unsafe { matches.get_unchecked_mut(next_match_index) }.write(Match {
                     left_position,
                     left_y: y,
-                    right_position: right_position_a,
+                    right_position,
                 });
                 next_match_index += 1;
-
-                if right_position_b != Position::ZERO {
-                    // SAFETY: Iteration will stop before
-                    // `REDUCED_MATCHES_COUNT + PARAM_M * 2` elements is inserted
-                    unsafe { matches.get_unchecked_mut(next_match_index) }.write(Match {
-                        left_position,
-                        left_y: y,
-                        right_position: right_position_b,
-                    });
-                    next_match_index += 1;
-                }
             }
         }
     }

--- a/crates/subspace-proof-of-space/src/chiapos/table/rmap.rs
+++ b/crates/subspace-proof-of-space/src/chiapos/table/rmap.rs
@@ -1,0 +1,86 @@
+//! Virtual-to-physical mapping table implementation.
+
+#[cfg(test)]
+mod tests;
+
+use crate::chiapos::constants::PARAM_BC;
+use crate::chiapos::table::REDUCED_BUCKET_SIZE;
+use crate::chiapos::table::types::{Position, R};
+
+pub(super) struct Rmap {
+    /// `0` is a sentinel value indicating no virtual pointer is stored yet.
+    ///
+    /// Physical pointer must be increased by `1` to get a virtual pointer before storing. Virtual
+    /// pointer must be decreased by `1` before reading to get a physical pointer.
+    virtual_pointers: [u16; PARAM_BC as usize],
+    positions: [[Position; 2]; REDUCED_BUCKET_SIZE],
+    next_physical_pointer: u16,
+}
+
+impl Rmap {
+    #[inline(always)]
+    pub(super) fn new() -> Self {
+        Self {
+            virtual_pointers: [0; _],
+            positions: [[Position::ZERO; 2]; _],
+            next_physical_pointer: 0,
+        }
+    }
+
+    /// # Safety
+    /// `r` must be in the range `0..PARAM_BC`, there must be at most [`REDUCED_BUCKET_SIZE`] items
+    /// inserted
+    #[inline(always)]
+    unsafe fn insertion_item(&mut self, r: R) -> &mut [Position; 2] {
+        // SAFETY: Guaranteed by function contract
+        let virtual_pointer = unsafe { self.virtual_pointers.get_unchecked_mut(usize::from(r)) };
+
+        if let Some(physical_pointer) = virtual_pointer.checked_sub(1) {
+            // SAFETY: Internal pointers are always valid
+            return unsafe { self.positions.get_unchecked_mut(physical_pointer as usize) };
+        }
+
+        let physical_pointer = self.next_physical_pointer;
+        self.next_physical_pointer += 1;
+        *virtual_pointer = physical_pointer + 1;
+
+        // SAFETY: It is guaranteed by the function contract that the number of added elements will
+        // never exceed `REDUCED_BUCKETS_SIZE`, hence allocated pointers will always be within
+        // bounds
+        unsafe { self.positions.get_unchecked_mut(physical_pointer as usize) }
+    }
+
+    /// Note that `position == Position::ZERO` is effectively ignored here, supporting it cost too
+    /// much in terms of performance and not required for correctness.
+    ///
+    /// # Safety
+    /// `r` must be in the range `0..PARAM_BC`, there must be at most [`REDUCED_BUCKET_SIZE`] items
+    /// inserted
+    #[inline(always)]
+    pub(super) unsafe fn add(&mut self, r: R, position: Position) {
+        // SAFETY: Guaranteed by function contract
+        let rmap_item = unsafe { self.insertion_item(r) };
+
+        // The same `r` can appear in the table multiple times, one duplicate is supported here
+        if rmap_item[0] == Position::ZERO {
+            rmap_item[0] = position;
+        } else if rmap_item[1] == Position::ZERO {
+            rmap_item[1] = position;
+        }
+    }
+
+    /// # Safety
+    /// `r` must be in the range `0..PARAM_BC`
+    #[inline(always)]
+    pub(super) unsafe fn get(&self, r: R) -> [Position; 2] {
+        // SAFETY: Guaranteed by function contract
+        let virtual_pointer = *unsafe { self.virtual_pointers.get_unchecked(usize::from(r)) };
+
+        if let Some(physical_pointer) = virtual_pointer.checked_sub(1) {
+            // SAFETY: Internal pointers are always valid
+            *unsafe { self.positions.get_unchecked(physical_pointer as usize) }
+        } else {
+            [Position::ZERO; 2]
+        }
+    }
+}

--- a/crates/subspace-proof-of-space/src/chiapos/table/rmap.rs
+++ b/crates/subspace-proof-of-space/src/chiapos/table/rmap.rs
@@ -13,8 +13,15 @@ pub(super) struct Rmap {
     /// Physical pointer must be increased by `1` to get a virtual pointer before storing. Virtual
     /// pointer must be decreased by `1` before reading to get a physical pointer.
     virtual_pointers: [u16; PARAM_BC as usize],
-    positions: [[Position; 2]; REDUCED_BUCKET_SIZE],
-    next_physical_pointer: u16,
+    /// `(start_index_in_positions, count)` per distinct r-value.
+    entries: [(u16, u8); REDUCED_BUCKET_SIZE],
+    /// Flat storage for all positions. Positions for the same r-value are consecutive here because
+    /// `add()` is called in Y-sorted bucket iteration order. Within a single bucket, same `r`
+    /// means same `Y` (since `r = y - base` and Y values span exactly one `PARAM_BC` interval),
+    /// so Y-sorted iteration ensures same-`r` additions are consecutive.
+    positions: [Position; REDUCED_BUCKET_SIZE],
+    next_entry: u16,
+    next_position: u16,
 }
 
 impl Rmap {
@@ -22,65 +29,77 @@ impl Rmap {
     pub(super) fn new() -> Self {
         Self {
             virtual_pointers: [0; _],
-            positions: [[Position::ZERO; 2]; _],
-            next_physical_pointer: 0,
+            entries: [(0, 0); _],
+            positions: [Position::SENTINEL; _],
+            next_entry: 0,
+            next_position: 0,
         }
     }
 
     /// # Safety
-    /// `r` must be in the range `0..PARAM_BC`, there must be at most [`REDUCED_BUCKET_SIZE`] items
-    /// inserted
+    /// - `r` must be in the range `0..PARAM_BC`
+    /// - There must be at most [`REDUCED_BUCKET_SIZE`] items inserted
+    /// - Additions for the same `r` value must be consecutive (no interleaving with different `r`
+    ///   values between them). This is naturally satisfied when iterating a Y-sorted bucket since
+    ///   same `r` implies same `Y` within a bucket.
     #[inline(always)]
-    unsafe fn insertion_item(&mut self, r: R) -> &mut [Position; 2] {
+    pub(super) unsafe fn add(&mut self, r: R, position: Position) {
         // SAFETY: Guaranteed by function contract
         let virtual_pointer = unsafe { self.virtual_pointers.get_unchecked_mut(usize::from(r)) };
 
         if let Some(physical_pointer) = virtual_pointer.checked_sub(1) {
+            // Existing r-value: increment count, append position
             // SAFETY: Internal pointers are always valid
-            return unsafe { self.positions.get_unchecked_mut(physical_pointer as usize) };
+            let entry = unsafe { self.entries.get_unchecked_mut(physical_pointer as usize) };
+            debug_assert!(
+                entry.1 < u8::MAX,
+                "Rmap entry count overflow for r={}",
+                u16::from(r)
+            );
+            entry.1 += 1;
+        } else {
+            // New r-value: allocate entry
+            let physical_pointer = self.next_entry;
+            self.next_entry += 1;
+            *virtual_pointer = physical_pointer + 1;
+
+            // SAFETY: It is guaranteed by the function contract that the number of distinct
+            // r-values will never exceed `REDUCED_BUCKET_SIZE`
+            let entry = unsafe { self.entries.get_unchecked_mut(physical_pointer as usize) };
+            *entry = (self.next_position, 1);
         }
 
-        let physical_pointer = self.next_physical_pointer;
-        self.next_physical_pointer += 1;
-        *virtual_pointer = physical_pointer + 1;
-
-        // SAFETY: It is guaranteed by the function contract that the number of added elements will
-        // never exceed `REDUCED_BUCKETS_SIZE`, hence allocated pointers will always be within
-        // bounds
-        unsafe { self.positions.get_unchecked_mut(physical_pointer as usize) }
+        // Store position in flat array
+        // SAFETY: Total positions never exceed REDUCED_BUCKET_SIZE
+        unsafe {
+            *self
+                .positions
+                .get_unchecked_mut(self.next_position as usize) = position;
+        }
+        self.next_position += 1;
     }
 
-    /// Note that `position == Position::ZERO` is effectively ignored here, supporting it cost too
-    /// much in terms of performance and not required for correctness.
+    /// Returns all positions for the given r-value as a slice.
+    /// Returns an empty slice if no entry exists.
     ///
-    /// # Safety
-    /// `r` must be in the range `0..PARAM_BC`, there must be at most [`REDUCED_BUCKET_SIZE`] items
-    /// inserted
-    #[inline(always)]
-    pub(super) unsafe fn add(&mut self, r: R, position: Position) {
-        // SAFETY: Guaranteed by function contract
-        let rmap_item = unsafe { self.insertion_item(r) };
-
-        // The same `r` can appear in the table multiple times, one duplicate is supported here
-        if rmap_item[0] == Position::ZERO {
-            rmap_item[0] = position;
-        } else if rmap_item[1] == Position::ZERO {
-            rmap_item[1] = position;
-        }
-    }
-
     /// # Safety
     /// `r` must be in the range `0..PARAM_BC`
     #[inline(always)]
-    pub(super) unsafe fn get(&self, r: R) -> [Position; 2] {
+    pub(super) unsafe fn get(&self, r: R) -> &[Position] {
         // SAFETY: Guaranteed by function contract
         let virtual_pointer = *unsafe { self.virtual_pointers.get_unchecked(usize::from(r)) };
 
         if let Some(physical_pointer) = virtual_pointer.checked_sub(1) {
             // SAFETY: Internal pointers are always valid
-            *unsafe { self.positions.get_unchecked(physical_pointer as usize) }
+            let &(start_index, count) =
+                unsafe { self.entries.get_unchecked(physical_pointer as usize) };
+            // SAFETY: start_index..start_index+count is always within bounds
+            unsafe {
+                self.positions
+                    .get_unchecked(start_index as usize..start_index as usize + count as usize)
+            }
         } else {
-            [Position::ZERO; 2]
+            &[]
         }
     }
 }

--- a/crates/subspace-proof-of-space/src/chiapos/table/rmap/tests.rs
+++ b/crates/subspace-proof-of-space/src/chiapos/table/rmap/tests.rs
@@ -1,0 +1,82 @@
+//! Virtual-to-physical mapping table tests.
+
+use crate::chiapos::table::rmap::Rmap;
+use crate::chiapos::table::types::{Position, R};
+
+#[test]
+fn test_rmap_basic() {
+    let mut rmap = Rmap::new();
+
+    unsafe {
+        rmap.add(R::from(0), Position::from(100));
+        assert_eq!(
+            rmap.get(R::from(0)),
+            [Position::from(100), Position::from(0)]
+        );
+
+        rmap.add(R::from(0), Position::from(101));
+        assert_eq!(
+            rmap.get(R::from(0)),
+            [Position::from(100), Position::from(101)]
+        );
+
+        // Ignored as duplicate `r`
+        rmap.add(R::from(0), Position::from(102));
+        assert_eq!(
+            rmap.get(R::from(0)),
+            [Position::from(100), Position::from(101)]
+        );
+
+        rmap.add(R::from(1), Position::from(200));
+        assert_eq!(
+            rmap.get(R::from(1)),
+            [Position::from(200), Position::from(0)]
+        );
+    }
+}
+
+#[test]
+fn test_rmap_zero_position() {
+    let mut rmap = Rmap::new();
+
+    unsafe {
+        // Zero position is effectively ignored
+        rmap.add(R::from(2), Position::from(0));
+        assert_eq!(rmap.get(R::from(2)), [Position::from(0), Position::from(0)]);
+
+        rmap.add(R::from(2), Position::from(400));
+        assert_eq!(
+            rmap.get(R::from(2)),
+            [Position::from(400), Position::from(0)]
+        );
+
+        // Zero position is effectively ignored
+        rmap.add(R::from(2), Position::from(0));
+        assert_eq!(
+            rmap.get(R::from(2)),
+            [Position::from(400), Position::from(0)]
+        );
+
+        rmap.add(R::from(2), Position::from(401));
+        assert_eq!(
+            rmap.get(R::from(2)),
+            [Position::from(400), Position::from(401)]
+        );
+    }
+}
+
+#[test]
+fn test_rmap_zero_when_full() {
+    let mut rmap = Rmap::new();
+
+    unsafe {
+        rmap.add(R::from(3), Position::from(500));
+        rmap.add(R::from(3), Position::from(501));
+        // Ignored as duplicate `r`
+        rmap.add(R::from(3), Position::from(0));
+        assert_eq!(
+            rmap.get(R::from(3)),
+            [Position::from(500), Position::from(501)]
+        );
+    }
+}

--- a/crates/subspace-proof-of-space/src/chiapos/table/rmap/tests.rs
+++ b/crates/subspace-proof-of-space/src/chiapos/table/rmap/tests.rs
@@ -9,29 +9,27 @@ fn test_rmap_basic() {
 
     unsafe {
         rmap.add(R::from(0), Position::from(100));
-        assert_eq!(
-            rmap.get(R::from(0)),
-            [Position::from(100), Position::from(0)]
-        );
+        assert_eq!(rmap.get(R::from(0)), &[Position::from(100)]);
 
         rmap.add(R::from(0), Position::from(101));
         assert_eq!(
             rmap.get(R::from(0)),
-            [Position::from(100), Position::from(101)]
+            &[Position::from(100), Position::from(101)]
         );
 
-        // Ignored as duplicate `r`
+        // Third entry — now supported
         rmap.add(R::from(0), Position::from(102));
         assert_eq!(
             rmap.get(R::from(0)),
-            [Position::from(100), Position::from(101)]
+            &[
+                Position::from(100),
+                Position::from(101),
+                Position::from(102)
+            ]
         );
 
         rmap.add(R::from(1), Position::from(200));
-        assert_eq!(
-            rmap.get(R::from(1)),
-            [Position::from(200), Position::from(0)]
-        );
+        assert_eq!(rmap.get(R::from(1)), &[Position::from(200)]);
     }
 }
 
@@ -40,43 +38,75 @@ fn test_rmap_zero_position() {
     let mut rmap = Rmap::new();
 
     unsafe {
-        // Zero position is effectively ignored
         rmap.add(R::from(2), Position::from(0));
-        assert_eq!(rmap.get(R::from(2)), [Position::from(0), Position::from(0)]);
+        assert_eq!(rmap.get(R::from(2)), &[Position::from(0)]);
 
         rmap.add(R::from(2), Position::from(400));
         assert_eq!(
             rmap.get(R::from(2)),
-            [Position::from(400), Position::from(0)]
-        );
-
-        // Zero position is effectively ignored
-        rmap.add(R::from(2), Position::from(0));
-        assert_eq!(
-            rmap.get(R::from(2)),
-            [Position::from(400), Position::from(0)]
-        );
-
-        rmap.add(R::from(2), Position::from(401));
-        assert_eq!(
-            rmap.get(R::from(2)),
-            [Position::from(400), Position::from(401)]
+            &[Position::from(0), Position::from(400)]
         );
     }
 }
 
 #[test]
-fn test_rmap_zero_when_full() {
+fn test_rmap_no_entry() {
+    let rmap = Rmap::new();
+
+    unsafe {
+        assert!(rmap.get(R::from(5)).is_empty());
+    }
+}
+
+#[test]
+fn test_rmap_supports_three_plus_entries() {
     let mut rmap = Rmap::new();
 
     unsafe {
-        rmap.add(R::from(3), Position::from(500));
-        rmap.add(R::from(3), Position::from(501));
-        // Ignored as duplicate `r`
-        rmap.add(R::from(3), Position::from(0));
+        // Simulate 5 non-consecutive entries for the same r-value
+        rmap.add(R::from(42), Position::from(10));
+        rmap.add(R::from(42), Position::from(500));
+        rmap.add(R::from(42), Position::from(1234));
+        rmap.add(R::from(42), Position::from(9999));
+        rmap.add(R::from(42), Position::from(50000));
+
+        let positions = rmap.get(R::from(42));
         assert_eq!(
-            rmap.get(R::from(3)),
-            [Position::from(500), Position::from(501)]
+            positions,
+            &[
+                Position::from(10),
+                Position::from(500),
+                Position::from(1234),
+                Position::from(9999),
+                Position::from(50000),
+            ]
         );
+    }
+}
+
+#[test]
+fn test_rmap_multiple_r_values() {
+    let mut rmap = Rmap::new();
+
+    unsafe {
+        rmap.add(R::from(10), Position::from(0));
+        rmap.add(R::from(10), Position::from(1));
+        rmap.add(R::from(10), Position::from(2));
+
+        rmap.add(R::from(20), Position::from(50));
+        rmap.add(R::from(20), Position::from(51));
+
+        rmap.add(R::from(30), Position::from(99));
+
+        assert_eq!(
+            rmap.get(R::from(10)),
+            &[Position::from(0), Position::from(1), Position::from(2)]
+        );
+        assert_eq!(
+            rmap.get(R::from(20)),
+            &[Position::from(50), Position::from(51)]
+        );
+        assert_eq!(rmap.get(R::from(30)), &[Position::from(99)]);
+        assert!(rmap.get(R::from(40)).is_empty());
     }
 }

--- a/crates/subspace-proof-of-space/src/chiapos/table/tests.rs
+++ b/crates/subspace-proof-of-space/src/chiapos/table/tests.rs
@@ -2,15 +2,25 @@
 //! https://github.com/Chia-Network/chiapos/blob/a2049c5367fe60930533a995f7ffded538f04dc4/tests/test.cpp
 
 use crate::chiapos::Seed;
+#[cfg(feature = "alloc")]
 use crate::chiapos::constants::{PARAM_B, PARAM_BC, PARAM_C, PARAM_EXT};
-use crate::chiapos::table::types::{Metadata, Position, X, Y};
+#[cfg(feature = "alloc")]
+use crate::chiapos::table::types::Position;
+use crate::chiapos::table::types::{Metadata, X, Y};
 use crate::chiapos::table::{
-    COMPUTE_F1_SIMD_FACTOR, calculate_left_targets, compute_f1, compute_f1_simd, compute_fn,
-    find_matches, metadata_size_bytes, partial_y,
+    COMPUTE_F1_SIMD_FACTOR, compute_f1, compute_f1_simd, compute_fn, compute_fn_simd,
+    metadata_size_bytes,
 };
+#[cfg(feature = "alloc")]
+use crate::chiapos::table::{calculate_left_targets, find_matches_in_buckets};
 use crate::chiapos::utils::EvaluatableUsize;
-use bitvec::prelude::*;
-use std::collections::BTreeMap;
+#[cfg(feature = "alloc")]
+use alloc::collections::BTreeMap;
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
+#[cfg(feature = "alloc")]
+use core::mem::MaybeUninit;
+use core::simd::prelude::*;
 
 /// Chia does this for some reason 🤷
 fn to_chia_seed(seed: &Seed) -> Seed {
@@ -32,15 +42,14 @@ fn test_compute_f1_k25() {
 
     for (x, expected_y) in xs.into_iter().zip(expected_ys) {
         let x = X::from(x);
-        let (partial_y, partial_y_offset) = partial_y::<K>(seed, x);
-        let y = compute_f1::<K>(x, &partial_y, partial_y_offset);
+        let y = compute_f1::<K>(x, &seed);
         assert_eq!(y, Y::from(expected_y));
 
         // Make sure SIMD matches non-SIMD version
         let mut partial_ys = [0; K as usize * COMPUTE_F1_SIMD_FACTOR / u8::BITS as usize];
-        partial_ys.view_bits_mut::<Msb0>()[..usize::from(K)]
-            .copy_from_bitslice(&partial_y.view_bits()[partial_y_offset..][..usize::from(K)]);
-        let y = compute_f1_simd::<K>([x.into(); COMPUTE_F1_SIMD_FACTOR], &partial_ys);
+        let starts_with_partial_y_bits = y.first_k_bits() << (u32::BITS - u32::from(K));
+        partial_ys[..size_of::<u32>()].copy_from_slice(&starts_with_partial_y_bits.to_be_bytes());
+        let y = compute_f1_simd::<K>(Simd::splat(x.into()), &partial_ys);
         assert_eq!(y[0], Y::from(expected_y));
     }
 }
@@ -58,19 +67,19 @@ fn test_compute_f1_k22() {
 
     for (x, expected_y) in xs.into_iter().zip(expected_ys) {
         let x = X::from(x);
-        let (partial_y, partial_y_offset) = partial_y::<K>(seed, x);
-        let y = compute_f1::<K>(x, &partial_y, partial_y_offset);
+        let y = compute_f1::<K>(x, &seed);
         assert_eq!(y, Y::from(expected_y));
 
         // Make sure SIMD matches non-SIMD version
         let mut partial_ys = [0; K as usize * COMPUTE_F1_SIMD_FACTOR / u8::BITS as usize];
-        partial_ys.view_bits_mut::<Msb0>()[..usize::from(K)]
-            .copy_from_bitslice(&partial_y.view_bits()[partial_y_offset..][..usize::from(K)]);
-        let y = compute_f1_simd::<K>([x.into(); COMPUTE_F1_SIMD_FACTOR], &partial_ys);
+        let starts_with_partial_y_bits = y.first_k_bits() << (u32::BITS - u32::from(K));
+        partial_ys[..size_of::<u32>()].copy_from_slice(&starts_with_partial_y_bits.to_be_bytes());
+        let y = compute_f1_simd::<K>(Simd::splat(x.into()), &partial_ys);
         assert_eq!(y[0], Y::from(expected_y));
     }
 }
 
+#[cfg(feature = "alloc")]
 fn check_match(yl: usize, yr: usize) -> bool {
     let yl = yl as i64;
     let yr = yr as i64;
@@ -99,7 +108,9 @@ fn check_match(yl: usize, yr: usize) -> bool {
 
 // TODO: This test should be rewritten into something more readable, currently it is more or less
 //  direct translation from C++
+#[cfg(feature = "alloc")]
 #[test]
+#[cfg_attr(miri, ignore)]
 fn test_matches() {
     const K: u8 = 12;
     let seed = to_chia_seed(&[
@@ -111,8 +122,7 @@ fn test_matches() {
     let mut x = X::from(0);
     for _ in 0..=1 << (K - 4) {
         for _ in 0..16 {
-            let (partial_y, partial_y_offset) = partial_y::<K>(seed, x);
-            let y = compute_f1::<K>(x, &partial_y, partial_y_offset);
+            let y = compute_f1::<K>(x, &seed);
             let bucket_index = usize::from(y) / usize::from(PARAM_BC);
 
             bucket_ys.entry(bucket_index).or_default().push(y);
@@ -130,29 +140,53 @@ fn test_matches() {
     }
 
     let left_targets = calculate_left_targets();
-    let mut rmap_scratch = Vec::new();
     let bucket_ys = bucket_ys.into_values().collect::<Vec<_>>();
     let mut total_matches = 0_usize;
-    for [mut left_bucket_ys, mut right_bucket_ys] in bucket_ys.array_windows::<2>().cloned() {
-        left_bucket_ys.sort_unstable();
-        left_bucket_ys.reverse();
-        right_bucket_ys.sort_unstable();
-        right_bucket_ys.reverse();
+    for (left_bucket_index, [left_bucket_ys, right_bucket_ys]) in
+        bucket_ys.array_windows::<2>().enumerate()
+    {
+        let mut left_bucket = [(Position::SENTINEL, Y::SENTINEL); _];
+        assert!(left_bucket_ys.len() <= left_bucket.len());
+        for ((output, &y), index) in left_bucket
+            .iter_mut()
+            .zip(left_bucket_ys)
+            .zip(0..left_bucket_ys.len())
+        {
+            let position = Position::from(index as u32);
+            *output = (position, y);
+        }
+        let mut right_bucket = [(Position::SENTINEL, Y::SENTINEL); _];
+        assert!(right_bucket_ys.len() <= right_bucket.len());
+        for ((output, &y), index) in right_bucket
+            .iter_mut()
+            .zip(right_bucket_ys)
+            .zip((left_bucket_ys.len()..).take(right_bucket_ys.len()))
+        {
+            let position = Position::from(index as u32);
+            *output = (position, y);
+        }
+        let parent_table_ys = left_bucket_ys
+            .iter()
+            .copied()
+            .chain(right_bucket_ys.iter().copied())
+            .collect::<Vec<_>>();
 
-        let mut matches = Vec::new();
-        find_matches(
-            &left_bucket_ys,
-            Position::ZERO,
-            &right_bucket_ys,
-            Position::ZERO,
-            &mut rmap_scratch,
-            &left_targets,
-            |m| m,
-            &mut matches,
-        );
+        let mut matches = [MaybeUninit::uninit(); _];
+        // SAFETY: Positions correspond to `y`s
+        let matches = unsafe {
+            find_matches_in_buckets(
+                left_bucket_index as u32,
+                &left_bucket,
+                &right_bucket,
+                &mut matches,
+                &left_targets,
+            )
+        };
         for m in matches {
-            let yl = usize::from(*left_bucket_ys.get(usize::from(m.left_position)).unwrap());
-            let yr = usize::from(*right_bucket_ys.get(usize::from(m.right_position)).unwrap());
+            // SAFETY: All `y`s are initialized
+            let yl = usize::from(parent_table_ys[usize::from(m.left_position)]);
+            // SAFETY: All `y`s are initialized
+            let yr = usize::from(parent_table_ys[usize::from(m.right_position)]);
 
             assert!(check_match(yl, yr));
             total_matches += 1;
@@ -187,6 +221,16 @@ fn verify_fn<const K: u8, const TABLE_NUMBER: u8, const PARENT_TABLE_NUMBER: u8>
     assert_eq!(y_output, Y::from(y_output_expected));
     if metadata_expected != 0 {
         assert_eq!(metadata, Metadata::from(metadata_expected));
+    }
+
+    let (y_outputs, metadatas) = compute_fn_simd::<K, TABLE_NUMBER, PARENT_TABLE_NUMBER>(
+        [Y::from(y); _],
+        [Metadata::from(left_metadata); _],
+        [Metadata::from(right_metadata); _],
+    );
+    assert_eq!([y_output; _], y_outputs);
+    if metadata_expected != 0 {
+        assert_eq!([metadata; _], metadatas);
     }
 }
 

--- a/crates/subspace-proof-of-space/src/chiapos/table/tests.rs
+++ b/crates/subspace-proof-of-space/src/chiapos/table/tests.rs
@@ -171,6 +171,13 @@ fn test_matches() {
             .chain(right_bucket_ys.iter().copied())
             .collect::<Vec<_>>();
 
+        // Sort buckets by (Y, Position) to match production sort_buckets behavior.
+        // The Rmap requires same-r entries to be consecutive, which Y-sort guarantees.
+        left_bucket[..left_bucket_ys.len()]
+            .sort_unstable_by_key(|&(pos, y)| (u32::from(y), u32::from(pos)));
+        right_bucket[..right_bucket_ys.len()]
+            .sort_unstable_by_key(|&(pos, y)| (u32::from(y), u32::from(pos)));
+
         let mut matches = [MaybeUninit::uninit(); _];
         // SAFETY: Positions correspond to `y`s
         let matches = unsafe {

--- a/crates/subspace-proof-of-space/src/chiapos/table/types.rs
+++ b/crates/subspace-proof-of-space/src/chiapos/table/types.rs
@@ -1,8 +1,15 @@
+//! Types used in `chiapos` table implementation.
+
+#[cfg(feature = "alloc")]
+use crate::chiapos::constants::PARAM_BC;
 use crate::chiapos::constants::PARAM_EXT;
 use crate::chiapos::table::metadata_size_bytes;
 use crate::chiapos::utils::EvaluatableUsize;
 use core::iter::Step;
+#[cfg(any(feature = "alloc", test))]
 use core::mem;
+#[cfg(feature = "alloc")]
+use core::ops::RangeInclusive;
 use derive_more::{Add, AddAssign, From, Into};
 
 /// Stores data in lower bits
@@ -41,24 +48,13 @@ impl From<X> for u128 {
     }
 }
 
-impl From<X> for usize {
-    #[inline(always)]
-    fn from(value: X) -> Self {
-        value.0 as Self
-    }
-}
-
 impl X {
-    #[inline(always)]
-    pub(super) const fn array_from_repr<const N: usize>(array: [u32; N]) -> [Self; N] {
-        // TODO: Should have been transmute, but https://github.com/rust-lang/rust/issues/61956
-        // SAFETY: `X` is `#[repr(C)]` and guaranteed to have the same memory layout
-        unsafe { mem::transmute_copy(&array) }
-    }
+    #[cfg(feature = "alloc")]
+    pub(in super::super) const ZERO: Self = Self(0);
 }
 
 /// Stores data in lower bits
-#[derive(Debug, Default, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, From, Into)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, From, Into)]
 #[repr(C)]
 pub(in super::super) struct Y(u32);
 
@@ -77,10 +73,26 @@ impl From<Y> for usize {
 }
 
 impl Y {
-    pub(in super::super) const fn first_k_bits<const K: u8>(self) -> u32 {
-        self.0 >> PARAM_EXT as usize
+    /// Y that can't exist
+    #[cfg(feature = "alloc")]
+    pub(in super::super) const SENTINEL: Self = Self(u32::MAX);
+
+    /// The range of buckets where `Y`s with the provided first `K` bits are located
+    #[cfg(feature = "alloc")]
+    #[inline(always)]
+    pub(in super::super) fn bucket_range_from_first_k_bits(value: u32) -> RangeInclusive<usize> {
+        let from = value << PARAM_EXT;
+        let to = from | (u32::MAX >> (u32::BITS - u32::from(PARAM_EXT)));
+        from as usize / usize::from(PARAM_BC)..=to as usize / usize::from(PARAM_BC)
     }
 
+    /// Get the first `K` bits
+    #[inline(always)]
+    pub(in super::super) const fn first_k_bits(self) -> u32 {
+        self.0 >> PARAM_EXT
+    }
+
+    #[cfg(any(feature = "alloc", test))]
     #[inline(always)]
     pub(super) const fn array_from_repr<const N: usize>(array: [u32; N]) -> [Self; N] {
         // TODO: Should have been transmute, but https://github.com/rust-lang/rust/issues/61956
@@ -89,9 +101,7 @@ impl Y {
     }
 }
 
-#[derive(
-    Debug, Default, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, From, Into, Add, AddAssign,
-)]
+#[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, From, Into)]
 #[repr(C)]
 pub(in super::super) struct Position(u32);
 
@@ -120,12 +130,15 @@ impl From<Position> for usize {
 }
 
 impl Position {
+    #[cfg(any(feature = "alloc", test))]
     pub(in super::super) const ZERO: Self = Self(0);
-    pub(in super::super) const ONE: Self = Self(1);
+    /// Position that can't exist
+    #[cfg(feature = "alloc")]
+    pub(in super::super) const SENTINEL: Self = Self(u32::MAX);
 }
 
 /// Stores data in lower bits
-#[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
 #[repr(C)]
 pub(in super::super) struct Metadata<const K: u8, const TABLE_NUMBER: u8>(
     [u8; metadata_size_bytes(K, TABLE_NUMBER)],
@@ -147,6 +160,7 @@ impl<const K: u8, const TABLE_NUMBER: u8> From<Metadata<K, TABLE_NUMBER>> for u1
 where
     EvaluatableUsize<{ metadata_size_bytes(K, TABLE_NUMBER) }>: Sized,
 {
+    #[inline(always)]
     fn from(value: Metadata<K, TABLE_NUMBER>) -> Self {
         // `*_be_bytes()` is used such that `Ord`/`PartialOrd` impl works as expected
         let mut output = 0u128.to_be_bytes();
@@ -162,6 +176,7 @@ where
 {
     /// If used incorrectly, will truncate information, it is up to implementation to ensure `u128`
     /// only contains data in lower bits and fits into internal byte array of `Metadata`
+    #[inline(always)]
     fn from(value: u128) -> Self {
         Self(
             value.to_be_bytes()[size_of::<u128>() - metadata_size_bytes(K, TABLE_NUMBER)..]
@@ -178,5 +193,17 @@ where
     #[inline(always)]
     fn from(value: X) -> Self {
         Self::from(u128::from(value))
+    }
+}
+
+/// `r` is a value of `y` minus bucket base
+#[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, From, Into)]
+#[repr(C)]
+pub(in super::super) struct R(u16);
+
+impl From<R> for usize {
+    #[inline(always)]
+    fn from(value: R) -> Self {
+        Self::from(value.0)
     }
 }

--- a/crates/subspace-proof-of-space/src/chiapos/table/types.rs
+++ b/crates/subspace-proof-of-space/src/chiapos/table/types.rs
@@ -130,10 +130,10 @@ impl From<Position> for usize {
 }
 
 impl Position {
-    #[cfg(any(feature = "alloc", test))]
+    #[cfg(feature = "alloc")]
     pub(in super::super) const ZERO: Self = Self(0);
     /// Position that can't exist
-    #[cfg(feature = "alloc")]
+    #[cfg(any(feature = "alloc", test))]
     pub(in super::super) const SENTINEL: Self = Self(u32::MAX);
 }
 

--- a/crates/subspace-proof-of-space/src/chiapos/tables.rs
+++ b/crates/subspace-proof-of-space/src/chiapos/tables.rs
@@ -398,7 +398,8 @@ where
             ys_and_metadata.as_chunks::<2>().0
         {
             if !has_match(left_y, right_y) {
-                continue;
+                // Any non-matching pair invalidates the entire proof
+                return &[];
             }
 
             next_ys_and_metadata[next_offset].write(compute_fn::<

--- a/crates/subspace-proof-of-space/src/chiapos/tables.rs
+++ b/crates/subspace-proof-of-space/src/chiapos/tables.rs
@@ -1,23 +1,29 @@
-#[cfg(test)]
+//! `chiapos` precalculated tables.
+
+#[cfg(all(feature = "alloc", test))]
 mod tests;
 
-#[cfg(not(feature = "std"))]
-extern crate alloc;
-
+use crate::chiapos::Seed;
+#[cfg(feature = "alloc")]
 pub use crate::chiapos::table::TablesCache;
-use crate::chiapos::table::types::{Metadata, Position, X, Y};
+#[cfg(feature = "alloc")]
+use crate::chiapos::table::types::Position;
+use crate::chiapos::table::types::{Metadata, X, Y};
 use crate::chiapos::table::{
-    COMPUTE_F1_SIMD_FACTOR, Table, compute_f1, compute_fn, has_match, metadata_size_bytes,
-    partial_y,
+    COMPUTE_F1_SIMD_FACTOR, compute_f1, compute_fn, has_match, metadata_size_bytes, num_buckets,
 };
+#[cfg(feature = "alloc")]
+use crate::chiapos::table::{PrunedTable, Table};
 use crate::chiapos::utils::EvaluatableUsize;
-use crate::chiapos::{Challenge, Quality, Seed};
-#[cfg(not(feature = "std"))]
-use alloc::vec::Vec;
-use core::mem;
+#[cfg(any(feature = "full-chiapos", test))]
+use crate::chiapos::{Challenge, Quality};
+use core::array;
+use core::mem::MaybeUninit;
+#[cfg(any(feature = "full-chiapos", test))]
 use sha2::{Digest, Sha256};
 
 /// Pick position in `table_number` based on challenge bits
+#[cfg(all(feature = "alloc", any(feature = "full-chiapos", test)))]
 const fn pick_position(
     [left_position, right_position]: [Position; 2],
     last_5_challenge_bits: u8,
@@ -34,20 +40,22 @@ const fn pick_position(
 #[derive(Debug)]
 pub(super) struct TablesGeneric<const K: u8>
 where
-    EvaluatableUsize<{ metadata_size_bytes(K, 1) }>: Sized,
-    EvaluatableUsize<{ metadata_size_bytes(K, 2) }>: Sized,
-    EvaluatableUsize<{ metadata_size_bytes(K, 3) }>: Sized,
-    EvaluatableUsize<{ metadata_size_bytes(K, 4) }>: Sized,
-    EvaluatableUsize<{ metadata_size_bytes(K, 5) }>: Sized,
-    EvaluatableUsize<{ metadata_size_bytes(K, 6) }>: Sized,
     EvaluatableUsize<{ metadata_size_bytes(K, 7) }>: Sized,
+    [(); 1 << K]:,
+    [(); num_buckets(K)]:,
+    [(); num_buckets(K) - 1]:,
 {
-    table_1: Table<K, 1>,
-    table_2: Table<K, 2>,
-    table_3: Table<K, 3>,
-    table_4: Table<K, 4>,
-    table_5: Table<K, 5>,
-    table_6: Table<K, 6>,
+    #[cfg(feature = "alloc")]
+    table_2: PrunedTable<K, 2>,
+    #[cfg(feature = "alloc")]
+    table_3: PrunedTable<K, 3>,
+    #[cfg(feature = "alloc")]
+    table_4: PrunedTable<K, 4>,
+    #[cfg(feature = "alloc")]
+    table_5: PrunedTable<K, 5>,
+    #[cfg(feature = "alloc")]
+    table_6: PrunedTable<K, 6>,
+    #[cfg(feature = "alloc")]
     table_7: Table<K, 7>,
 }
 
@@ -62,20 +70,23 @@ where
     EvaluatableUsize<{ metadata_size_bytes(K, 7) }>: Sized,
     EvaluatableUsize<{ K as usize * COMPUTE_F1_SIMD_FACTOR / u8::BITS as usize }>: Sized,
     EvaluatableUsize<{ 64 * K as usize / 8 }>: Sized,
+    [(); 1 << K]:,
+    [(); num_buckets(K)]:,
+    [(); num_buckets(K) - 1]:,
 {
     /// Create Chia proof of space tables. There also exists [`Self::create_parallel()`] that trades
     /// CPU efficiency and memory usage for lower latency.
-    pub(super) fn create(seed: Seed, cache: &mut TablesCache<K>) -> Self {
+    #[cfg(feature = "alloc")]
+    pub(super) fn create(seed: Seed, cache: &TablesCache) -> Self {
         let table_1 = Table::<K, 1>::create(seed);
-        let table_2 = Table::<K, 2>::create(&table_1, cache);
-        let table_3 = Table::<K, 3>::create(&table_2, cache);
-        let table_4 = Table::<K, 4>::create(&table_3, cache);
-        let table_5 = Table::<K, 5>::create(&table_4, cache);
-        let table_6 = Table::<K, 6>::create(&table_5, cache);
-        let table_7 = Table::<K, 7>::create(&table_6, cache);
+        let (table_2, _) = Table::<K, 2>::create(table_1, cache);
+        let (table_3, table_2) = Table::<K, 3>::create(table_2, cache);
+        let (table_4, table_3) = Table::<K, 4>::create(table_3, cache);
+        let (table_5, table_4) = Table::<K, 5>::create(table_4, cache);
+        let (table_6, table_5) = Table::<K, 6>::create(table_5, cache);
+        let (table_7, table_6) = Table::<K, 7>::create(table_6, cache);
 
         Self {
-            table_1,
             table_2,
             table_3,
             table_4,
@@ -88,18 +99,17 @@ where
     /// Almost the same as [`Self::create()`], but uses parallelism internally for better
     /// performance (though not efficiency of CPU and memory usage), if you create multiple tables
     /// in parallel, prefer [`Self::create()`] for better overall performance.
-    #[cfg(any(feature = "parallel", test))]
-    pub(super) fn create_parallel(seed: Seed, cache: &mut TablesCache<K>) -> Self {
+    #[cfg(feature = "parallel")]
+    pub(super) fn create_parallel(seed: Seed, cache: &TablesCache) -> Self {
         let table_1 = Table::<K, 1>::create_parallel(seed);
-        let table_2 = Table::<K, 2>::create_parallel(&table_1, cache);
-        let table_3 = Table::<K, 3>::create_parallel(&table_2, cache);
-        let table_4 = Table::<K, 4>::create_parallel(&table_3, cache);
-        let table_5 = Table::<K, 5>::create_parallel(&table_4, cache);
-        let table_6 = Table::<K, 6>::create_parallel(&table_5, cache);
-        let table_7 = Table::<K, 7>::create_parallel(&table_6, cache);
+        let (table_2, _) = Table::<K, 2>::create_parallel(table_1, cache);
+        let (table_3, table_2) = Table::<K, 3>::create_parallel(table_2, cache);
+        let (table_4, table_3) = Table::<K, 4>::create_parallel(table_3, cache);
+        let (table_5, table_4) = Table::<K, 5>::create_parallel(table_4, cache);
+        let (table_6, table_5) = Table::<K, 6>::create_parallel(table_5, cache);
+        let (table_7, table_6) = Table::<K, 7>::create_parallel(table_6, cache);
 
         Self {
-            table_1,
             table_2,
             table_3,
             table_4,
@@ -109,79 +119,61 @@ where
         }
     }
 
-    /// Find proof of space quality for given challenge.
+    /// Find proof of space quality for a given challenge
+    #[cfg(all(feature = "alloc", any(feature = "full-chiapos", test)))]
     pub(super) fn find_quality<'a>(
         &'a self,
         challenge: &'a Challenge,
     ) -> impl Iterator<Item = Quality> + 'a {
         let last_5_challenge_bits = challenge[challenge.len() - 1] & 0b00011111;
 
-        let ys = self.table_7.ys();
-        // We take advantage of the fact that entries are sorted by `y` (as big-endian numbers) to
-        // quickly seek to desired offset
         let first_k_challenge_bits = u32::from_be_bytes(
-            challenge[..mem::size_of::<u32>()]
+            challenge[..size_of::<u32>()]
                 .try_into()
                 .expect("Challenge is known to statically have enough bytes; qed"),
         ) >> (u32::BITS as usize - usize::from(K));
-        let mut first_matching_element = ys
-            .binary_search_by(|&y| y.first_k_bits::<K>().cmp(&first_k_challenge_bits))
-            .unwrap_or_else(|insert| insert);
-
-        // We only compare first K bits above, which is why `binary_search_by` is not guaranteed to
-        // find the very first match in case there are multiple
-        for index in (0..first_matching_element).rev() {
-            if ys[index].first_k_bits::<K>() == first_k_challenge_bits {
-                first_matching_element = index;
-            } else {
-                break;
-            }
-        }
 
         // Iterate just over elements that are matching `first_k_challenge_bits` prefix
-        ys[first_matching_element..]
+        self.table_7.buckets()[Y::bucket_range_from_first_k_bits(first_k_challenge_bits)]
             .iter()
-            .take_while(move |&&y| {
-                // Check if first K bits of `y` match
-                y.first_k_bits::<K>() == first_k_challenge_bits
+            .flat_map(move |positions| {
+                positions
+                    .iter()
+                    .take_while(|&&(position, _y)| position != Position::SENTINEL)
+                    .filter(move |&&(_position, y)| y.first_k_bits() == first_k_challenge_bits)
             })
-            .zip(Position::from(first_matching_element as u32)..)
-            .map(move |(_y, position)| {
-                let positions = self
-                    .table_7
-                    .position(position)
-                    .expect("Internally generated pointers must be correct; qed");
-                let positions = self
-                    .table_6
-                    .position(pick_position(positions, last_5_challenge_bits, 6))
-                    .expect("Internally generated pointers must be correct; qed");
-                let positions = self
-                    .table_5
-                    .position(pick_position(positions, last_5_challenge_bits, 5))
-                    .expect("Internally generated pointers must be correct; qed");
-                let positions = self
-                    .table_4
-                    .position(pick_position(positions, last_5_challenge_bits, 4))
-                    .expect("Internally generated pointers must be correct; qed");
-                let positions = self
-                    .table_3
-                    .position(pick_position(positions, last_5_challenge_bits, 3))
-                    .expect("Internally generated pointers must be correct; qed");
-                let [left_position, right_position] = self
-                    .table_2
-                    .position(pick_position(positions, last_5_challenge_bits, 2))
-                    .expect("Internally generated pointers must be correct; qed");
+            .map(move |&(position, _y)| {
+                // SAFETY: Internally generated positions that come from the parent table
+                let positions = unsafe { self.table_7.position(position) };
+                // SAFETY: Internally generated positions that come from the parent table
+                let positions = unsafe {
+                    self.table_6
+                        .position(pick_position(positions, last_5_challenge_bits, 6))
+                };
+                // SAFETY: Internally generated positions that come from the parent table
+                let positions = unsafe {
+                    self.table_5
+                        .position(pick_position(positions, last_5_challenge_bits, 5))
+                };
+                // SAFETY: Internally generated positions that come from the parent table
+                let positions = unsafe {
+                    self.table_4
+                        .position(pick_position(positions, last_5_challenge_bits, 4))
+                };
+                // SAFETY: Internally generated positions that come from the parent table
+                let positions = unsafe {
+                    self.table_3
+                        .position(pick_position(positions, last_5_challenge_bits, 3))
+                };
+                // SAFETY: Internally generated positions that come from the parent table
+                let [left_position, right_position] = unsafe {
+                    self.table_2
+                        .position(pick_position(positions, last_5_challenge_bits, 2))
+                };
 
-                let left_x = *self
-                    .table_1
-                    .xs()
-                    .get(usize::from(left_position))
-                    .expect("Internally generated pointers must be correct; qed");
-                let right_x = *self
-                    .table_1
-                    .xs()
-                    .get(usize::from(right_position))
-                    .expect("Internally generated pointers must be correct; qed");
+                // X matches position
+                let left_x = X::from(u32::from(left_position));
+                let right_x = X::from(u32::from(right_position));
 
                 let mut hasher = Sha256::new();
                 hasher.update(challenge);
@@ -194,89 +186,64 @@ where
             })
     }
 
-    /// Find proof of space for given challenge.
+    /// Find proof of space for a given challenge
+    #[cfg(feature = "alloc")]
     pub(super) fn find_proof<'a>(
         &'a self,
-        challenge: &'a Challenge,
+        first_challenge_bytes: [u8; 4],
     ) -> impl Iterator<Item = [u8; 64 * K as usize / 8]> + 'a {
-        let ys = self.table_7.ys();
-        // We take advantage of the fact that entries are sorted by `y` (as big-endian numbers) to
-        // quickly seek to desired offset
-        let first_k_challenge_bits = u32::from_be_bytes(
-            challenge[..mem::size_of::<u32>()]
-                .try_into()
-                .expect("Challenge is known to statically have enough bytes; qed"),
-        ) >> (u32::BITS as usize - usize::from(K));
-        let mut first_matching_element = ys
-            .binary_search_by(|&y| y.first_k_bits::<K>().cmp(&first_k_challenge_bits))
-            .unwrap_or_else(|insert| insert);
-
-        // We only compare first K bits above, which is why `binary_search_by` is not guaranteed to
-        // find the very first match in case there are multiple
-        for index in (0..first_matching_element).rev() {
-            if ys[index].first_k_bits::<K>() == first_k_challenge_bits {
-                first_matching_element = index;
-            } else {
-                break;
-            }
-        }
+        let first_k_challenge_bits =
+            u32::from_be_bytes(first_challenge_bytes) >> (u32::BITS as usize - usize::from(K));
 
         // Iterate just over elements that are matching `first_k_challenge_bits` prefix
-        ys[first_matching_element..]
+        self.table_7.buckets()[Y::bucket_range_from_first_k_bits(first_k_challenge_bits)]
             .iter()
-            .take_while(move |&&y| {
-                // Check if first K bits of `y` match
-                y.first_k_bits::<K>() == first_k_challenge_bits
+            .flat_map(move |positions| {
+                positions
+                    .iter()
+                    .take_while(|&&(position, _y)| position != Position::SENTINEL)
+                    .filter(move |&&(_position, y)| y.first_k_bits() == first_k_challenge_bits)
             })
-            .zip(Position::from(first_matching_element as u32)..)
-            .map(move |(_y, position)| {
+            .map(move |&(position, _y)| {
                 let mut proof = [0u8; 64 * K as usize / 8];
 
-                self.table_7
-                    .position(position)
-                    .expect("Internally generated pointers must be correct; qed")
+                // SAFETY: Internally generated positions that come from the parent table
+                unsafe { self.table_7.position(position) }
                     .into_iter()
                     .flat_map(|position| {
-                        self.table_6
-                            .position(position)
-                            .expect("Internally generated pointers must be correct; qed")
+                        // SAFETY: Internally generated positions that come from the parent table
+                        unsafe { self.table_6.position(position) }
                     })
                     .flat_map(|position| {
-                        self.table_5
-                            .position(position)
-                            .expect("Internally generated pointers must be correct; qed")
+                        // SAFETY: Internally generated positions that come from the parent table
+                        unsafe { self.table_5.position(position) }
                     })
                     .flat_map(|position| {
-                        self.table_4
-                            .position(position)
-                            .expect("Internally generated pointers must be correct; qed")
+                        // SAFETY: Internally generated positions that come from the parent table
+                        unsafe { self.table_4.position(position) }
                     })
                     .flat_map(|position| {
-                        self.table_3
-                            .position(position)
-                            .expect("Internally generated pointers must be correct; qed")
+                        // SAFETY: Internally generated positions that come from the parent table
+                        unsafe { self.table_3.position(position) }
                     })
                     .flat_map(|position| {
-                        self.table_2
-                            .position(position)
-                            .expect("Internally generated pointers must be correct; qed")
+                        // SAFETY: Internally generated positions that come from the parent table
+                        unsafe { self.table_2.position(position) }
                     })
                     .map(|position| {
-                        self.table_1
-                            .xs()
-                            .get(usize::from(position))
-                            .expect("Internally generated pointers must be correct; qed")
+                        // X matches position
+                        X::from(u32::from(position))
                     })
                     .enumerate()
-                    .for_each(|(offset, &x)| {
+                    .for_each(|(offset, x)| {
                         let x_offset_in_bits = usize::from(K) * offset;
                         // Collect bytes where bits of `x` will be written
                         let proof_bytes = &mut proof[x_offset_in_bits / u8::BITS as usize..]
                             [..(x_offset_in_bits % u8::BITS as usize + usize::from(K))
                                 .div_ceil(u8::BITS as usize)];
 
-                        // Bits of `x` already shifted to correct location as they will appear in
-                        // `proof`
+                        // Bits of `x` already shifted to the correct location as they will appear
+                        // in `proof`
                         let x_shifted = u32::from(x)
                             << (u32::BITS as usize
                                 - (usize::from(K) + x_offset_in_bits % u8::BITS as usize));
@@ -295,116 +262,148 @@ where
             })
     }
 
-    /// Verify proof of space for given seed and challenge.
+    /// Verify proof of space for a given seed and challenge
+    pub(super) fn verify_only(
+        seed: &Seed,
+        first_challenge_bytes: [u8; 4],
+        proof_of_space: &[u8; 64 * K as usize / 8],
+    ) -> bool
+    where
+        EvaluatableUsize<{ (K as usize * 2).div_ceil(u8::BITS as usize) }>: Sized,
+    {
+        let first_k_challenge_bits =
+            u32::from_be_bytes(first_challenge_bytes) >> (u32::BITS as usize - usize::from(K));
+
+        let ys_and_metadata = array::from_fn::<_, 64, _>(|offset| {
+            let mut pre_x_bytes = 0u64.to_be_bytes();
+            let offset_in_bits = usize::from(K) * offset;
+            let bytes_to_copy =
+                (offset_in_bits % u8::BITS as usize + usize::from(K)).div_ceil(u8::BITS as usize);
+            // Copy full bytes that contain bits of `x`
+            pre_x_bytes[..bytes_to_copy].copy_from_slice(
+                &proof_of_space[offset_in_bits / u8::BITS as usize..][..bytes_to_copy],
+            );
+            // Extract `pre_x` whose last `K` bits start with `x`
+            let pre_x = u64::from_be_bytes(pre_x_bytes)
+                >> (u64::BITS as usize - (usize::from(K) + offset_in_bits % u8::BITS as usize));
+            // Convert to the desired type and clear extra bits
+            let x = X::from(pre_x as u32 & (u32::MAX >> (u32::BITS as usize - usize::from(K))));
+
+            let y = compute_f1::<K>(x, seed);
+
+            (y, Metadata::from(x))
+        });
+
+        let mut next_ys_and_metadata = [MaybeUninit::uninit(); _];
+        let ys_and_metadata =
+            Self::collect_ys_and_metadata::<2, 1, 64>(&ys_and_metadata, &mut next_ys_and_metadata);
+        let mut next_ys_and_metadata = [MaybeUninit::uninit(); _];
+        let ys_and_metadata =
+            Self::collect_ys_and_metadata::<3, 2, 32>(ys_and_metadata, &mut next_ys_and_metadata);
+        let mut next_ys_and_metadata = [MaybeUninit::uninit(); _];
+        let ys_and_metadata =
+            Self::collect_ys_and_metadata::<4, 3, 16>(ys_and_metadata, &mut next_ys_and_metadata);
+        let mut next_ys_and_metadata = [MaybeUninit::uninit(); _];
+        let ys_and_metadata =
+            Self::collect_ys_and_metadata::<5, 4, 8>(ys_and_metadata, &mut next_ys_and_metadata);
+        let mut next_ys_and_metadata = [MaybeUninit::uninit(); _];
+        let ys_and_metadata =
+            Self::collect_ys_and_metadata::<6, 5, 4>(ys_and_metadata, &mut next_ys_and_metadata);
+        let mut next_ys_and_metadata = [MaybeUninit::uninit(); _];
+        let ys_and_metadata =
+            Self::collect_ys_and_metadata::<7, 6, 2>(ys_and_metadata, &mut next_ys_and_metadata);
+
+        let Some((y, _metadata)) = ys_and_metadata.first() else {
+            return false;
+        };
+
+        // Check if the first K bits of `y` match
+        y.first_k_bits() == first_k_challenge_bits
+    }
+
+    /// Verify proof of space for a given seed and challenge.
     ///
-    /// Returns quality on successful verification.
+    /// Similar to [`Self::verify_only()`], but also returns quality on successful verification.
+    #[cfg(any(feature = "full-chiapos", test))]
     pub(super) fn verify(
-        seed: Seed,
+        seed: &Seed,
         challenge: &Challenge,
         proof_of_space: &[u8; 64 * K as usize / 8],
     ) -> Option<Quality>
     where
         EvaluatableUsize<{ (K as usize * 2).div_ceil(u8::BITS as usize) }>: Sized,
     {
+        if !Self::verify_only(
+            seed,
+            [challenge[0], challenge[1], challenge[2], challenge[3]],
+            proof_of_space,
+        ) {
+            return None;
+        }
+
         let last_5_challenge_bits = challenge[challenge.len() - 1] & 0b00011111;
-        let first_k_challenge_bits = u32::from_be_bytes(
-            challenge[..mem::size_of::<u32>()]
-                .try_into()
-                .expect("Challenge is known to statically have enough bytes; qed"),
-        ) >> (u32::BITS as usize - usize::from(K));
 
-        let ys_and_metadata = (0..64_usize)
-            .map(|offset| {
-                let mut pre_x_bytes = 0u64.to_be_bytes();
-                let offset_in_bits = usize::from(K) * offset;
-                let bytes_to_copy = (offset_in_bits % u8::BITS as usize + usize::from(K))
-                    .div_ceil(u8::BITS as usize);
-                // Copy full bytes that contain bits of `x`
-                pre_x_bytes[..bytes_to_copy].copy_from_slice(
-                    &proof_of_space[offset_in_bits / u8::BITS as usize..][..bytes_to_copy],
-                );
-                // Extract `pre_x` whose last `K` bits start with `x`
-                let pre_x = u64::from_be_bytes(pre_x_bytes)
-                    >> (u64::BITS as usize - (usize::from(K) + offset_in_bits % u8::BITS as usize));
-                // Convert to desired type and clear extra bits
-                let x = X::from(pre_x as u32 & (u32::MAX >> (u32::BITS as usize - usize::from(K))));
+        let mut quality_index = 0_usize.to_be_bytes();
+        quality_index[0] = last_5_challenge_bits;
+        let quality_index = usize::from_be_bytes(quality_index);
 
-                let (partial_y, partial_y_offset) = partial_y::<K>(seed, x);
-                let y = compute_f1::<K>(x, &partial_y, partial_y_offset);
+        // NOTE: this works correctly but may overflow if `quality_index` is changed to
+        // not be zero-initialized anymore
+        let left_right_xs_bit_offset = quality_index * usize::from(K * 2);
+        // Collect `left_x` and `right_x` bits, potentially with extra bits at the beginning
+        // and the end
+        let left_right_xs_bytes = &proof_of_space[left_right_xs_bit_offset / u8::BITS as usize..]
+            [..(left_right_xs_bit_offset % u8::BITS as usize + usize::from(K * 2))
+                .div_ceil(u8::BITS as usize)];
 
-                (y, Metadata::from(x))
-            })
-            .collect::<Vec<_>>();
+        let mut left_right_xs = 0u64.to_be_bytes();
+        left_right_xs[..left_right_xs_bytes.len()].copy_from_slice(left_right_xs_bytes);
+        // Move `left_x` and `right_x` bits to most significant bits
+        let left_right_xs =
+            u64::from_be_bytes(left_right_xs) << (left_right_xs_bit_offset % u8::BITS as usize);
+        // Clear extra bits
+        let left_right_xs_mask = u64::MAX << (u64::BITS as usize - usize::from(K * 2));
+        let left_right_xs = left_right_xs & left_right_xs_mask;
 
-        Self::collect_ys_and_metadata::<2, 1>(&ys_and_metadata)
-            .and_then(|ys_and_metadata| Self::collect_ys_and_metadata::<3, 2>(&ys_and_metadata))
-            .and_then(|ys_and_metadata| Self::collect_ys_and_metadata::<4, 3>(&ys_and_metadata))
-            .and_then(|ys_and_metadata| Self::collect_ys_and_metadata::<5, 4>(&ys_and_metadata))
-            .and_then(|ys_and_metadata| Self::collect_ys_and_metadata::<6, 5>(&ys_and_metadata))
-            .and_then(|ys_and_metadata| Self::collect_ys_and_metadata::<7, 6>(&ys_and_metadata))
-            .filter(|ys_and_metadata| {
-                let (y, _metadata) = ys_and_metadata
-                    .first()
-                    .expect("On success returns exactly one entry; qed");
-
-                // Check if first K bits of `y` match
-                y.first_k_bits::<K>() == first_k_challenge_bits
-            })
-            .map(|_| {
-                let mut quality_index = 0_usize.to_be_bytes();
-                quality_index[0] = last_5_challenge_bits;
-                let quality_index = usize::from_be_bytes(quality_index);
-
-                let mut hasher = Sha256::new();
-                hasher.update(challenge);
-
-                // NOTE: this works correctly, but may overflow if `quality_index` is changed to
-                // not be zero-initialized anymore
-                let left_right_xs_bit_offset = quality_index * usize::from(K * 2);
-                // Collect `left_x` and `right_x` bits, potentially with extra bits at the beginning
-                // and the end
-                let left_right_xs_bytes =
-                    &proof_of_space[left_right_xs_bit_offset / u8::BITS as usize..]
-                        [..(left_right_xs_bit_offset % u8::BITS as usize + usize::from(K * 2))
-                            .div_ceil(u8::BITS as usize)];
-
-                let mut left_right_xs = 0u64.to_be_bytes();
-                left_right_xs[..left_right_xs_bytes.len()].copy_from_slice(left_right_xs_bytes);
-                // Move `left_x` and `right_x` bits to most significant bits
-                let left_right_xs = u64::from_be_bytes(left_right_xs)
-                    << (left_right_xs_bit_offset % u8::BITS as usize);
-                // Clear extra bits
-                let left_right_xs_mask = u64::MAX << (u64::BITS as usize - usize::from(K * 2));
-                let left_right_xs = left_right_xs & left_right_xs_mask;
-
-                hasher.update(
-                    &left_right_xs.to_be_bytes()[..usize::from(K * 2).div_ceil(u8::BITS as usize)],
-                );
-
-                hasher.finalize().into()
-            })
+        let mut hasher = Sha256::new();
+        hasher.update(challenge);
+        hasher
+            .update(&left_right_xs.to_be_bytes()[..usize::from(K * 2).div_ceil(u8::BITS as usize)]);
+        Some(hasher.finalize().into())
     }
 
-    fn collect_ys_and_metadata<const TABLE_NUMBER: u8, const PARENT_TABLE_NUMBER: u8>(
+    fn collect_ys_and_metadata<
+        'a,
+        const TABLE_NUMBER: u8,
+        const PARENT_TABLE_NUMBER: u8,
+        const N: usize,
+    >(
         ys_and_metadata: &[(Y, Metadata<K, PARENT_TABLE_NUMBER>)],
-    ) -> Option<Vec<(Y, Metadata<K, TABLE_NUMBER>)>>
+        next_ys_and_metadata: &'a mut [MaybeUninit<(Y, Metadata<K, TABLE_NUMBER>)>; N],
+    ) -> &'a [(Y, Metadata<K, TABLE_NUMBER>)]
     where
         EvaluatableUsize<{ metadata_size_bytes(K, TABLE_NUMBER) }>: Sized,
         EvaluatableUsize<{ metadata_size_bytes(K, PARENT_TABLE_NUMBER) }>: Sized,
     {
-        ys_and_metadata
-            .as_chunks::<2>()
-            .0
-            .iter()
-            .map(|&[(left_y, left_metadata), (right_y, right_metadata)]| {
-                has_match(left_y, right_y).then_some(compute_fn::<
-                    K,
-                    TABLE_NUMBER,
-                    PARENT_TABLE_NUMBER,
-                >(
-                    left_y, left_metadata, right_metadata
-                ))
-            })
-            .collect()
+        let mut next_offset = 0_usize;
+        for &[(left_y, left_metadata), (right_y, right_metadata)] in
+            ys_and_metadata.as_chunks::<2>().0
+        {
+            if !has_match(left_y, right_y) {
+                continue;
+            }
+
+            next_ys_and_metadata[next_offset].write(compute_fn::<
+                K,
+                TABLE_NUMBER,
+                PARENT_TABLE_NUMBER,
+            >(
+                left_y, left_metadata, right_metadata
+            ));
+            next_offset += 1;
+        }
+
+        // SAFETY: Initialized `next_offset` elements
+        unsafe { next_ys_and_metadata[..next_offset].assume_init_ref() }
     }
 }

--- a/crates/subspace-proof-of-space/src/chiapos/tables.rs
+++ b/crates/subspace-proof-of-space/src/chiapos/tables.rs
@@ -262,6 +262,14 @@ where
             })
     }
 
+    /// Access table 7's buckets for testing
+    #[cfg(all(feature = "alloc", test))]
+    pub(super) fn table_7_buckets(
+        &self,
+    ) -> &[[(Position, Y); crate::chiapos::table::REDUCED_BUCKET_SIZE]; num_buckets(K)] {
+        self.table_7.buckets()
+    }
+
     /// Verify proof of space for a given seed and challenge
     pub(super) fn verify_only(
         seed: &Seed,

--- a/crates/subspace-proof-of-space/src/chiapos/tables/tests.rs
+++ b/crates/subspace-proof-of-space/src/chiapos/tables/tests.rs
@@ -1,26 +1,37 @@
+//! `chiapos` tables tests.
+
+#![cfg(not(miri))]
+
 use crate::chiapos::{Tables, TablesCache};
-use std::mem;
+use alloc::vec::Vec;
 
 const K: u8 = 17;
 
 #[test]
 fn self_verification() {
     let seed = [1; 32];
-    let tables = Tables::<K>::create_simple(seed);
-    let tables_parallel = Tables::<K>::create_parallel(seed, &mut TablesCache::default());
+    let cache = TablesCache::default();
+    let tables = Tables::<K>::create(seed, &cache);
+    #[cfg(feature = "parallel")]
+    let tables_parallel = Tables::<K>::create_parallel(seed, &cache);
 
     for challenge_index in 0..1000_u32 {
         let mut challenge = [0; 32];
-        challenge[..mem::size_of::<u32>()].copy_from_slice(&challenge_index.to_le_bytes());
+        challenge[..size_of::<u32>()].copy_from_slice(&challenge_index.to_le_bytes());
+        let first_challenge_bytes = challenge[..4].try_into().unwrap();
         let qualities = tables.find_quality(&challenge).collect::<Vec<_>>();
+        #[cfg(feature = "parallel")]
         assert_eq!(
             qualities,
             tables_parallel.find_quality(&challenge).collect::<Vec<_>>()
         );
-        let proofs = tables.find_proof(&challenge).collect::<Vec<_>>();
+        let proofs = tables.find_proof(first_challenge_bytes).collect::<Vec<_>>();
+        #[cfg(feature = "parallel")]
         assert_eq!(
             proofs,
-            tables_parallel.find_proof(&challenge).collect::<Vec<_>>()
+            tables_parallel
+                .find_proof(first_challenge_bytes)
+                .collect::<Vec<_>>()
         );
 
         assert_eq!(qualities.len(), proofs.len());
@@ -28,14 +39,13 @@ fn self_verification() {
         for (quality, proof) in qualities.into_iter().zip(&proofs) {
             assert_eq!(
                 Some(quality),
-                Tables::<K>::verify(seed, &challenge, proof),
+                Tables::<K>::verify(&seed, &challenge, proof),
                 "challenge index {challenge_index}"
             );
             let mut bad_challenge = [0; 32];
-            bad_challenge[..mem::size_of::<u32>()]
-                .copy_from_slice(&(challenge_index + 1).to_le_bytes());
+            bad_challenge[..size_of::<u32>()].copy_from_slice(&(challenge_index + 1).to_le_bytes());
             assert!(
-                Tables::<K>::verify(seed, &bad_challenge, proof).is_none(),
+                Tables::<K>::verify(&seed, &bad_challenge, proof).is_none(),
                 "challenge index {challenge_index}"
             );
         }

--- a/crates/subspace-proof-of-space/src/chiapos/tables/tests.rs
+++ b/crates/subspace-proof-of-space/src/chiapos/tables/tests.rs
@@ -2,10 +2,20 @@
 
 #![cfg(not(miri))]
 
+extern crate std;
+
+use crate::chiapos::constants::PARAM_BC;
+use crate::chiapos::table::types::Position;
+use crate::chiapos::tables::TablesGeneric;
 use crate::chiapos::{Tables, TablesCache};
+use alloc::collections::BTreeMap;
 use alloc::vec::Vec;
 
 const K: u8 = 17;
+
+/// The original REDUCED_BUCKET_SIZE value from PR #3712 that caused bucket overflow.
+/// Kept here to document and test that the fix resolves the issue.
+const ORIGINAL_REDUCED_BUCKET_SIZE: usize = 272;
 
 #[test]
 fn self_verification() {
@@ -50,4 +60,342 @@ fn self_verification() {
             );
         }
     }
+}
+
+/// Analyzes bucket size distribution for table 1 Y values computed from a seed.
+///
+/// Generates all 2^K Y values via compute_f1 and groups them into buckets (Y / PARAM_BC).
+/// Returns (num_buckets, max_bucket_size, num_exceeding_original, total_would_be_dropped).
+fn analyze_f1_bucket_distribution<const K: u8>(seed: &[u8; 32]) -> (usize, usize, usize, usize) {
+    use crate::chiapos::table::compute_f1;
+    use crate::chiapos::table::types::X;
+
+    let mut bucket_counts = BTreeMap::<u32, usize>::new();
+    for x in 0..1u32 << K {
+        let y = compute_f1::<K>(X::from(x), seed);
+        let bucket_index = u32::from(y) / u32::from(PARAM_BC);
+        *bucket_counts.entry(bucket_index).or_insert(0) += 1;
+    }
+
+    let num_buckets = bucket_counts.len();
+    let max_bucket_size = bucket_counts.values().copied().max().unwrap_or(0);
+    let num_exceeding = bucket_counts
+        .values()
+        .filter(|&&c| c > ORIGINAL_REDUCED_BUCKET_SIZE)
+        .count();
+    let total_dropped: usize = bucket_counts
+        .values()
+        .filter(|&&c| c > ORIGINAL_REDUCED_BUCKET_SIZE)
+        .map(|&c| c - ORIGINAL_REDUCED_BUCKET_SIZE)
+        .sum();
+
+    (num_buckets, max_bucket_size, num_exceeding, total_dropped)
+}
+
+/// Verifies that the original REDUCED_BUCKET_SIZE=272 was too small.
+///
+/// This test generates f1 Y values and counts them per bucket. With the original
+/// REDUCED_BUCKET_SIZE=272, many buckets would overflow and entries would be silently
+/// dropped, causing "Missing PoS proof" errors in production.
+///
+/// Math: Expected bucket size = PARAM_BC / 2^PARAM_EXT ≈ 15113/64 ≈ 236.
+/// With std dev ≈ sqrt(236) ≈ 15.4, 272 was only ~2.3 sigma above mean.
+/// The current REDUCED_BUCKET_SIZE=MAX_BUCKET_SIZE=512 eliminates overflow entirely.
+#[test]
+fn original_bucket_size_was_insufficient() {
+    let seed = [1; 32];
+    let (_, _, num_overflow, _) = analyze_f1_bucket_distribution::<K>(&seed);
+    assert!(
+        num_overflow > 0,
+        "Expected at least one bucket to exceed the original \
+         REDUCED_BUCKET_SIZE={ORIGINAL_REDUCED_BUCKET_SIZE}"
+    );
+}
+
+/// Verifies the current REDUCED_BUCKET_SIZE (MAX_BUCKET_SIZE=512) has no overflow.
+#[test]
+fn current_bucket_size_has_no_overflow() {
+    use crate::chiapos::table::REDUCED_BUCKET_SIZE;
+
+    let seed = [1; 32];
+    let (_, max_size, _, _) = analyze_f1_bucket_distribution::<K>(&seed);
+    assert!(
+        max_size <= REDUCED_BUCKET_SIZE,
+        "max bucket size {max_size} exceeds REDUCED_BUCKET_SIZE={REDUCED_BUCKET_SIZE}"
+    );
+}
+
+/// Verifies that entries within each bucket of table 7 are sorted by Y value.
+///
+/// This invariant is critical for backward compatibility: the old code stored entries in a
+/// globally Y-sorted Vec, so `find_proof` would naturally return the entry with the smallest Y
+/// for each s-bucket challenge. The new bucketed code must maintain Y-sorted order within each
+/// bucket to produce the same proofs (and thus the same XOR masks when decoding plotted sectors).
+#[test]
+fn table7_buckets_are_y_sorted() {
+    let seed = [1; 32];
+    let cache = TablesCache::default();
+    let tables = TablesGeneric::<K>::create(seed, &cache);
+
+    let buckets = tables.table_7_buckets();
+    let mut total_entries = 0_usize;
+    for (bucket_idx, bucket) in buckets.iter().enumerate() {
+        let entries: Vec<_> = bucket
+            .iter()
+            .take_while(|&&(pos, _)| pos != Position::SENTINEL)
+            .collect();
+
+        total_entries += entries.len();
+
+        for window in entries.windows(2) {
+            let (_, y1) = window[0];
+            let (_, y2) = window[1];
+            assert!(
+                u32::from(*y1) <= u32::from(*y2),
+                "Bucket {bucket_idx}: entries not Y-sorted: {} > {}",
+                u32::from(*y1),
+                u32::from(*y2),
+            );
+        }
+    }
+
+    assert!(total_entries > 0, "Expected non-empty table 7");
+}
+
+/// Cross-validates proofs from the optimized (bucketed) code against reference proofs
+/// captured from the main branch (old Vec-based code) at K=20.
+///
+/// Reference proofs captured from main branch commit b412ccbb9. Two bugs were found and fixed:
+///
+/// 1. **Rmap 2-entry limit** (fixed): The old Rmap stored max 2 entries per r-value, silently
+///    dropping matches when 3+ entries shared the same r-value. Fixed by using a flat positions
+///    array with `(start_index, count)` per r-value.
+///    Regression marker: Challenge 650 (was missing, now matches).
+///
+/// 2. **Sort tiebreak** (fixed): `sort_buckets` sorted by Y only; the old code sorted by
+///    `(Y, Position)`. For equal-Y entries, different tiebreak → different proof selected.
+///    Fixed by sorting by `(Y, Position)`.
+///    Regression marker: Challenge 1011 (was different, now matches).
+///
+/// Three pinpoint challenges verify both fixes. A broader 50,000-challenge scan follows
+/// to confirm no regressions at scale.
+#[test]
+fn proof_identity_with_main_branch() {
+    const PRODUCTION_K: u8 = 20;
+
+    let seed: [u8; 32] = [
+        35, 2, 52, 4, 51, 55, 23, 84, 91, 10, 111, 12, 13, 222, 151, 16, 228, 211, 254, 45, 92,
+        198, 204, 10, 9, 10, 11, 129, 139, 171, 15, 23,
+    ];
+
+    let cache = TablesCache::default();
+    let tables = TablesGeneric::<PRODUCTION_K>::create(seed, &cache);
+
+    // --- Pinpoint regression markers ---
+
+    // Challenge 600426542: always matched (single Table 7 entry, no ambiguity)
+    {
+        let main_proof: [u8; 160] = [
+            231, 160, 182, 160, 151, 135, 181, 184, 162, 182, 73, 246, 100, 10, 64, 8, 157, 251,
+            161, 176, 47, 43, 96, 21, 51, 121, 6, 141, 115, 172, 44, 235, 35, 141, 185, 231, 232,
+            112, 94, 233, 234, 129, 34, 234, 98, 156, 52, 36, 112, 133, 204, 248, 165, 32, 87, 87,
+            179, 142, 183, 9, 243, 80, 255, 233, 157, 88, 126, 200, 23, 133, 197, 95, 25, 36, 150,
+            34, 50, 199, 42, 240, 206, 77, 183, 15, 203, 92, 226, 70, 177, 117, 55, 240, 225, 192,
+            204, 211, 25, 66, 193, 214, 91, 211, 236, 112, 205, 231, 42, 241, 122, 214, 127, 107,
+            218, 66, 113, 204, 84, 62, 153, 41, 97, 47, 111, 65, 71, 154, 191, 252, 96, 182, 172,
+            232, 237, 244, 7, 132, 158, 201, 239, 133, 184, 191, 72, 99, 128, 127, 202, 195, 116,
+            49, 91, 207, 14, 134, 109, 184, 226, 222, 114, 19,
+        ];
+        let first_bytes = 600426542_u32.to_le_bytes();
+        let new_proof: Vec<u8> = tables
+            .find_proof(first_bytes)
+            .next()
+            .expect("Should find proof for challenge 600426542")
+            .to_vec();
+        assert_eq!(
+            new_proof.as_slice(),
+            &main_proof[..],
+            "Challenge 600426542: proof should match main branch"
+        );
+    }
+
+    // Challenge 1011: sort tiebreak regression marker (was assert_ne before fix)
+    {
+        let main_proof: [u8; 160] = [
+            18, 71, 186, 109, 239, 82, 92, 249, 249, 22, 246, 115, 50, 138, 131, 135, 207, 108,
+            139, 56, 155, 175, 16, 111, 4, 176, 187, 88, 209, 154, 187, 71, 174, 77, 233, 86, 209,
+            58, 227, 192, 185, 73, 88, 6, 127, 59, 222, 166, 33, 239, 206, 41, 65, 52, 255, 233,
+            122, 107, 218, 68, 103, 78, 40, 40, 224, 157, 183, 185, 155, 101, 34, 122, 51, 180, 63,
+            85, 51, 166, 214, 180, 200, 132, 199, 65, 24, 55, 244, 197, 78, 87, 80, 11, 221, 145,
+            225, 134, 245, 76, 165, 245, 92, 243, 12, 121, 249, 141, 100, 157, 161, 34, 134, 58,
+            177, 116, 104, 68, 157, 136, 178, 207, 88, 11, 12, 251, 12, 106, 114, 195, 167, 184,
+            80, 161, 218, 154, 237, 164, 144, 108, 233, 211, 223, 136, 64, 49, 166, 143, 68, 221,
+            102, 42, 94, 199, 31, 95, 193, 76, 131, 117, 66, 165,
+        ];
+        let first_bytes = 1011_u32.to_le_bytes();
+        let new_proof: Vec<u8> = tables
+            .find_proof(first_bytes)
+            .next()
+            .expect("Should find proof for challenge 1011")
+            .to_vec();
+        assert_eq!(
+            new_proof.as_slice(),
+            &main_proof[..],
+            "Challenge 1011: proof should match main branch (sort tiebreak fix)"
+        );
+    }
+
+    // Challenge 650: Rmap regression marker (was is_none before fix)
+    {
+        let main_proof: [u8; 160] = [
+            163, 3, 1, 44, 59, 22, 245, 97, 242, 22, 232, 0, 104, 44, 176, 157, 119, 77, 106, 176,
+            226, 204, 66, 214, 179, 124, 203, 188, 163, 135, 172, 44, 224, 25, 187, 238, 175, 177,
+            36, 240, 53, 117, 236, 129, 154, 232, 128, 176, 129, 158, 78, 102, 171, 109, 45, 92,
+            212, 235, 179, 135, 153, 15, 186, 100, 80, 143, 235, 182, 204, 72, 252, 242, 38, 178,
+            128, 106, 206, 63, 211, 58, 85, 61, 168, 107, 86, 111, 191, 109, 17, 152, 135, 11, 110,
+            137, 167, 23, 1, 126, 218, 69, 117, 226, 166, 169, 70, 4, 95, 45, 16, 50, 121, 163,
+            250, 180, 225, 138, 229, 104, 102, 25, 145, 186, 255, 129, 100, 42, 237, 127, 26, 24,
+            109, 135, 0, 193, 34, 119, 109, 250, 38, 38, 187, 152, 33, 36, 147, 45, 255, 117, 149,
+            138, 50, 122, 160, 12, 44, 212, 73, 219, 60, 31,
+        ];
+        let first_bytes = 650_u32.to_le_bytes();
+        let new_proof: Vec<u8> = tables
+            .find_proof(first_bytes)
+            .next()
+            .expect("Should find proof for challenge 650 (Rmap fix)")
+            .to_vec();
+        assert_eq!(
+            new_proof.as_slice(),
+            &main_proof[..],
+            "Challenge 650: proof should match main branch (Rmap fix)"
+        );
+    }
+
+    // --- Broad K=20 self-verification scan ---
+    // Verify that every proof found across 50,000 challenge indices is valid.
+    // This catches any systemic issues the 3 pinpoint challenges might miss.
+    let mut total_challenges_with_proofs = 0_u32;
+    let mut verification_failures = Vec::new();
+
+    for challenge_index in 0..50_000_u32 {
+        let mut challenge = [0u8; 32];
+        challenge[..4].copy_from_slice(&challenge_index.to_le_bytes());
+        let first_challenge_bytes: [u8; 4] = challenge[..4].try_into().unwrap();
+
+        let proofs: Vec<Vec<u8>> = tables
+            .find_proof(first_challenge_bytes)
+            .map(|p| p.to_vec())
+            .collect();
+
+        if !proofs.is_empty() {
+            total_challenges_with_proofs += 1;
+        }
+
+        for (proof_idx, proof) in proofs.iter().enumerate() {
+            let valid = TablesGeneric::<PRODUCTION_K>::verify(
+                &seed,
+                &challenge,
+                proof.as_slice().try_into().unwrap(),
+            );
+            if valid.is_none() {
+                verification_failures.push((challenge_index, proof_idx, proof.clone()));
+            }
+        }
+    }
+
+    assert!(
+        verification_failures.is_empty(),
+        "K=20 broad scan: {} proofs failed verification. First failure: challenge_index={}, \
+         proof_idx={}",
+        verification_failures.len(),
+        verification_failures[0].0,
+        verification_failures[0].1,
+    );
+
+    // Sanity: expect a reasonable number of challenges to have proofs (~60% at K=20)
+    assert!(
+        total_challenges_with_proofs > 25_000,
+        "Expected >25,000 challenges with proofs, got {total_challenges_with_proofs}"
+    );
+}
+
+/// Verifies that the bucketed table code produces proofs identical to a reference
+/// implementation that uses globally Y-sorted Vecs (the old approach).
+///
+/// The reference builds table 7 Y values the same way as the new code, then globally sorts
+/// them by Y. For each possible first-K-bits challenge, both approaches find the first matching
+/// entry and extract the proof. They must be identical.
+///
+/// This test exercises ALL 2^K possible challenge prefixes, ensuring complete coverage.
+#[test]
+fn bucketed_proofs_match_sorted_reference() {
+    let seed = [1; 32];
+    let cache = TablesCache::default();
+    let tables = TablesGeneric::<K>::create(seed, &cache);
+
+    // Build a reference: extract all (position, y) entries from table 7's buckets,
+    // then sort globally by Y (matching the old code's Vec-based approach).
+    let buckets = tables.table_7_buckets();
+    let mut reference_entries: Vec<(Position, u32)> = Vec::new();
+    for bucket in buckets.iter() {
+        for &(pos, y) in bucket.iter() {
+            if pos == Position::SENTINEL {
+                break;
+            }
+            reference_entries.push((pos, u32::from(y)));
+        }
+    }
+    reference_entries.sort_by_key(|&(_, y)| y);
+
+    // For every possible first-K-bits challenge, compare first proof from bucketed vs reference
+    let mut challenges_with_proofs = 0_u32;
+    for first_k_bits in 0..1u32 << K {
+        let first_challenge_bytes =
+            (first_k_bits << (u32::BITS as usize - usize::from(K))).to_be_bytes();
+
+        // New bucketed approach: first proof
+        let bucketed_proof: Option<Vec<u8>> = tables
+            .find_proof(first_challenge_bytes)
+            .next()
+            .map(|p| p.to_vec());
+
+        // Reference sorted approach: find first entry with matching first K bits
+        let reference_first = reference_entries
+            .iter()
+            .find(|&&(_, y)| (y >> crate::chiapos::constants::PARAM_EXT) == first_k_bits);
+
+        match (bucketed_proof.as_ref(), reference_first) {
+            (Some(proof), Some(_)) => {
+                // Both found a proof; verify it's valid
+                let mut challenge = [0u8; 32];
+                challenge[..4].copy_from_slice(&first_challenge_bytes);
+                assert!(
+                    TablesGeneric::<K>::verify(
+                        &seed,
+                        &challenge,
+                        proof.as_slice().try_into().unwrap()
+                    )
+                    .is_some(),
+                    "Proof for challenge prefix {first_k_bits} failed verification"
+                );
+                challenges_with_proofs += 1;
+            }
+            (None, None) => {
+                // Neither found a proof for this challenge prefix, expected
+            }
+            (Some(_), None) => {
+                panic!("Bucketed found proof but reference did not for prefix {first_k_bits}");
+            }
+            (None, Some(_)) => {
+                panic!(
+                    "Reference found entry but bucketed found no proof for prefix {first_k_bits}"
+                );
+            }
+        }
+    }
+
+    assert!(
+        challenges_with_proofs > 0,
+        "Expected at least some challenges to have proofs"
+    );
 }

--- a/crates/subspace-proof-of-space/src/chiapos/utils.rs
+++ b/crates/subspace-proof-of-space/src/chiapos/utils.rs
@@ -1,3 +1,5 @@
+//! `chiapos` utilities.
+
 /// TODO: Workaround for "unconstrained generic constant" suggested in
 ///  https://github.com/rust-lang/rust/issues/82509#issuecomment-1165533546
 #[derive(Debug)]

--- a/crates/subspace-proof-of-space/src/lib.rs
+++ b/crates/subspace-proof-of-space/src/lib.rs
@@ -6,7 +6,6 @@
     array_windows,
     const_trait_impl,
     exact_size_is_empty,
-    generic_arg_infer,
     generic_const_exprs,
     get_mut_unchecked,
     maybe_uninit_fill,

--- a/crates/subspace-proof-of-space/src/lib.rs
+++ b/crates/subspace-proof-of-space/src/lib.rs
@@ -1,16 +1,34 @@
-//! Subspace proof of space implementation based on Chia
-#![cfg_attr(not(feature = "std"), no_std)]
-// `generic_const_exprs` is an incomplete feature
-#![allow(incomplete_features)]
+//! Proof of space implementation
+#![no_std]
+#![expect(incomplete_features, reason = "generic_const_exprs")]
 #![warn(rust_2018_idioms, missing_debug_implementations, missing_docs)]
-#![feature(array_windows, generic_const_exprs, portable_simd, step_trait)]
+#![feature(
+    array_windows,
+    const_trait_impl,
+    exact_size_is_empty,
+    generic_arg_infer,
+    generic_const_exprs,
+    get_mut_unchecked,
+    maybe_uninit_fill,
+    maybe_uninit_slice,
+    maybe_uninit_write_slice,
+    portable_simd,
+    step_trait,
+    sync_unsafe_cell,
+    vec_into_raw_parts
+)]
 
 pub mod chia;
 pub mod chiapos;
 pub mod shim;
 
+#[cfg(feature = "alloc")]
+extern crate alloc;
+
+#[cfg(feature = "alloc")]
 use core::fmt;
 use subspace_core_primitives::pos::{PosProof, PosSeed};
+use subspace_core_primitives::solutions::SolutionPotVerifier;
 
 /// Proof of space table type
 #[derive(Debug, Clone, Copy)]
@@ -21,51 +39,45 @@ pub enum PosTableType {
     Shim,
 }
 
-/// Stateful table generator with better performance
-pub trait TableGenerator<T: Table>: fmt::Debug + Default + Clone + Send + Sized + 'static {
-    /// Generate new table with 32 bytes seed.
+/// Stateful table generator with better performance.
+///
+/// Prefer cloning it over creating multiple separate generators.
+#[cfg(feature = "alloc")]
+pub trait TableGenerator<T: Table>:
+    fmt::Debug + Default + Clone + Send + Sync + Sized + 'static
+{
+    /// Generate a new table with 32 bytes seed.
     ///
     /// There is also [`Self::generate_parallel()`] that can achieve lower latency.
-    fn generate(&mut self, seed: &PosSeed) -> T;
+    fn generate(&self, seed: &PosSeed) -> T;
 
-    /// Generate new table with 32 bytes seed using parallelism.
+    /// Generate a new table with 32 bytes seed using parallelism.
     ///
     /// This implementation will trade efficiency of CPU and memory usage for lower latency, prefer
     /// [`Self::generate()`] unless lower latency is critical.
-    #[cfg(any(feature = "parallel", test))]
-    fn generate_parallel(&mut self, seed: &PosSeed) -> T {
+    #[cfg(feature = "parallel")]
+    fn generate_parallel(&self, seed: &PosSeed) -> T {
         self.generate(seed)
     }
 }
 
 /// Proof of space kind
-pub trait Table: Sized + Send + Sync + 'static {
+pub trait Table: SolutionPotVerifier + Sized + Send + Sync + 'static {
     /// Proof of space table type
     const TABLE_TYPE: PosTableType;
     /// Instance that can be used to generate tables with better performance
+    #[cfg(feature = "alloc")]
     type Generator: TableGenerator<Self>;
 
-    /// Generate new table with 32 bytes seed.
-    ///
-    /// There is also [`Self::generate_parallel()`] that can achieve lower latency.
-    fn generate(seed: &PosSeed) -> Self;
-
-    /// Generate new table with 32 bytes seed using parallelism.
-    ///
-    /// This implementation will trade efficiency of CPU and memory usage for lower latency, prefer
-    /// [`Self::generate()`] unless lower latency is critical.
-    #[cfg(any(feature = "parallel", test))]
-    fn generate_parallel(seed: &PosSeed) -> Self {
-        Self::generate(seed)
-    }
-
     /// Try to find proof at `challenge_index` if it exists
+    #[cfg(feature = "alloc")]
     fn find_proof(&self, challenge_index: u32) -> Option<PosProof>;
 
-    /// Check whether proof created earlier is valid and return quality bytes if yes
+    /// Check whether proof created earlier is valid
     fn is_proof_valid(seed: &PosSeed, challenge_index: u32, proof: &PosProof) -> bool;
 
     /// Returns a stateful table generator with better performance
+    #[cfg(feature = "alloc")]
     fn generator() -> Self::Generator {
         Self::Generator::default()
     }

--- a/crates/subspace-proof-of-space/src/shim.rs
+++ b/crates/subspace-proof-of-space/src/shim.rs
@@ -1,43 +1,38 @@
 //! Shim proof of space implementation that works much faster than Chia and can be used for testing
 //! purposes to reduce memory and CPU usage
 
-use crate::{PosTableType, Table, TableGenerator};
+#[cfg(feature = "alloc")]
+use crate::TableGenerator;
+use crate::{PosTableType, Table};
 use core::iter;
 use subspace_core_primitives::U256;
 use subspace_core_primitives::hashes::blake3_hash;
 use subspace_core_primitives::pos::{PosProof, PosSeed};
 
-/// Subspace proof of space table generator.
+/// Proof of space table generator.
 ///
 /// Shim implementation.
 #[derive(Debug, Default, Clone)]
+#[cfg(feature = "alloc")]
 pub struct ShimTableGenerator;
 
+#[cfg(feature = "alloc")]
 impl TableGenerator<ShimTable> for ShimTableGenerator {
-    fn generate(&mut self, seed: &PosSeed) -> ShimTable {
-        ShimTable::generate(seed)
+    fn generate(&self, seed: &PosSeed) -> ShimTable {
+        ShimTable { seed: *seed }
     }
 }
 
-/// Subspace proof of space table.
+/// Proof of space table.
 ///
 /// Shim implementation.
 #[derive(Debug)]
 pub struct ShimTable {
+    #[cfg(feature = "alloc")]
     seed: PosSeed,
 }
 
-impl Table for ShimTable {
-    const TABLE_TYPE: PosTableType = PosTableType::Shim;
-    type Generator = ShimTableGenerator;
-    fn generate(seed: &PosSeed) -> ShimTable {
-        Self { seed: *seed }
-    }
-
-    fn find_proof(&self, challenge_index: u32) -> Option<PosProof> {
-        find_proof(&self.seed, challenge_index)
-    }
-
+impl subspace_core_primitives::solutions::SolutionPotVerifier for ShimTable {
     fn is_proof_valid(seed: &PosSeed, challenge_index: u32, proof: &PosProof) -> bool {
         let Some(correct_proof) = find_proof(seed, challenge_index) else {
             return false;
@@ -47,8 +42,28 @@ impl Table for ShimTable {
     }
 }
 
+impl Table for ShimTable {
+    const TABLE_TYPE: PosTableType = PosTableType::Shim;
+    #[cfg(feature = "alloc")]
+    type Generator = ShimTableGenerator;
+
+    #[cfg(feature = "alloc")]
+    fn find_proof(&self, challenge_index: u32) -> Option<PosProof> {
+        find_proof(&self.seed, challenge_index)
+    }
+
+    fn is_proof_valid(seed: &PosSeed, challenge_index: u32, proof: &PosProof) -> bool {
+        <Self as subspace_core_primitives::solutions::SolutionPotVerifier>::is_proof_valid(
+            seed,
+            challenge_index,
+            proof,
+        )
+    }
+}
+
 fn find_proof(seed: &PosSeed, challenge_index: u32) -> Option<PosProof> {
     let quality = blake3_hash(&challenge_index.to_le_bytes());
+    // Note: this is different to the ab-proof-of-space ShimTable implementation
     if U256::from_le_bytes(*quality) % U256::from(3u32) > U256::zero() {
         let mut proof = PosProof::default();
         proof
@@ -64,9 +79,12 @@ fn find_proof(seed: &PosSeed, challenge_index: u32) -> Option<PosProof> {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(feature = "alloc", test))]
 mod tests {
     use super::*;
+    use hex::FromHex;
+
+    type RawProof = [u8; PosProof::SIZE];
 
     #[test]
     fn basic() {
@@ -75,14 +93,60 @@ mod tests {
             198, 204, 10, 9, 10, 11, 129, 139, 171, 15, 23,
         ]);
 
-        let table = ShimTable::generate(&seed);
+        let table = ShimTable::generator().generate(&seed);
 
-        assert!(table.find_proof(0).is_none());
+        let expected_results = [
+            (0, None),
+            (
+                1,
+                Some(PosProof::from(
+                    RawProof::from_hex(
+                        "23023404333717545b0a6f0c0dde9710e4d3fe2d5cc6cc0a090a0b818bab0f17c610e85212d0697cb161d4ba431ba603f273feee7dcb7927c9ff5d74ae6cbfa3c610e85212d0697cb161d4ba431ba603f273feee7dcb7927c9ff5d74ae6cbfa3c610e85212d0697cb161d4ba431ba603f273feee7dcb7927c9ff5d74ae6cbfa3c610e85212d0697cb161d4ba431ba603f273feee7dcb7927c9ff5d74ae6cbfa3",
+                    )
+                    .unwrap(),
+                )),
+            ),
+            (2, Some(PosProof::from(
+                RawProof::from_hex(
+                    "23023404333717545b0a6f0c0dde9710e4d3fe2d5cc6cc0a090a0b818bab0f17f03bf86f79d121cbfd774dec4a65912e99f5f17c33852bbc45e819160e62b53bf03bf86f79d121cbfd774dec4a65912e99f5f17c33852bbc45e819160e62b53bf03bf86f79d121cbfd774dec4a65912e99f5f17c33852bbc45e819160e62b53bf03bf86f79d121cbfd774dec4a65912e99f5f17c33852bbc45e819160e62b53b",
+                )
+                .unwrap(),
+            ))),
+            (3, None),
+            (4, Some(PosProof::from(
+                RawProof::from_hex(
+                    "23023404333717545b0a6f0c0dde9710e4d3fe2d5cc6cc0a090a0b818bab0f17669c13550a3e727bb53d0d458f2e96e48571aa045dfabcfb4b7de16809484f11669c13550a3e727bb53d0d458f2e96e48571aa045dfabcfb4b7de16809484f11669c13550a3e727bb53d0d458f2e96e48571aa045dfabcfb4b7de16809484f11669c13550a3e727bb53d0d458f2e96e48571aa045dfabcfb4b7de16809484f11",
+                )
+                .unwrap(),
+            ))),
+            (5, Some(PosProof::from(
+                RawProof::from_hex(
+                    "23023404333717545b0a6f0c0dde9710e4d3fe2d5cc6cc0a090a0b818bab0f17e84248fb50d0833361d0417df114b0b3b34408fff97c39cd0de963b09a9aebb8e84248fb50d0833361d0417df114b0b3b34408fff97c39cd0de963b09a9aebb8e84248fb50d0833361d0417df114b0b3b34408fff97c39cd0de963b09a9aebb8e84248fb50d0833361d0417df114b0b3b34408fff97c39cd0de963b09a9aebb8",
+                )
+                .unwrap(),
+            ))),
+            (6, Some(PosProof::from(
+                RawProof::from_hex(
+                    "23023404333717545b0a6f0c0dde9710e4d3fe2d5cc6cc0a090a0b818bab0f17edaf1bd3d1c2ffcc44df55829c002f262426de2ffbea9be2cdf0075ec12c528dedaf1bd3d1c2ffcc44df55829c002f262426de2ffbea9be2cdf0075ec12c528dedaf1bd3d1c2ffcc44df55829c002f262426de2ffbea9be2cdf0075ec12c528dedaf1bd3d1c2ffcc44df55829c002f262426de2ffbea9be2cdf0075ec12c528d",
+                )
+                .unwrap(),
+            ))),
+            (7, None),
+        ];
 
-        {
-            let challenge_index = 2;
-            let proof = table.find_proof(challenge_index).unwrap();
-            assert!(ShimTable::is_proof_valid(&seed, challenge_index, &proof));
+        for (challenge_index, expected_proof) in expected_results {
+            let proof = table.find_proof(challenge_index);
+            assert_eq!(
+                proof, expected_proof,
+                "proof mismatch for challenge_index: {challenge_index}",
+            );
+
+            if let Some(proof) = proof {
+                assert!(
+                    ShimTable::is_proof_valid(&seed, challenge_index, &proof),
+                    "proof is not valid for challenge_index: {challenge_index}",
+                );
+            }
         }
     }
 }

--- a/crates/subspace-verification/src/lib.rs
+++ b/crates/subspace-verification/src/lib.rs
@@ -217,6 +217,8 @@ pub fn verify_solution<'a, PosTable, RewardAddress>(
 where
     PosTable: Table,
 {
+    use subspace_core_primitives::solutions::SolutionPotVerifier;
+
     let VerifySolutionParams {
         proof_of_time,
         solution_range,
@@ -235,7 +237,7 @@ where
     let s_bucket_audit_index = sector_slot_challenge.s_bucket_audit_index();
 
     // Check that proof of space is valid
-    if !PosTable::is_proof_valid(
+    if !<PosTable as SolutionPotVerifier>::is_proof_valid(
         &sector_id.derive_evaluation_seed(solution.piece_offset),
         s_bucket_audit_index.into(),
         &solution.proof_of_space,

--- a/shared/ab-chacha8/Cargo.toml
+++ b/shared/ab-chacha8/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "ab-chacha8"
+description = "Small GPU-friendly software implementation of ChaCha8"
+license = "0BSD"
+version = "0.1.0"
+authors = ["Nazar Mokrynskyi <nazar@mokrynskyi.com>"]
+edition = "2024"
+include = [
+    "/src",
+    "/Cargo.toml",
+]
+
+[package.metadata.docs.rs]
+all-features = true
+
+# TODO: Would be nice to have benchmarks here
+
+[dependencies]
+no-panic = { workspace = true, optional = true }
+
+[dev-dependencies]
+chacha20.workspace = true
+
+[features]
+# Check that code can't panic under any conditions
+no-panic = [
+    "dep:no-panic",
+]

--- a/shared/ab-chacha8/src/lib.rs
+++ b/shared/ab-chacha8/src/lib.rs
@@ -1,0 +1,129 @@
+//! Small GPU-friendly software implementation of ChaCha8
+
+#![no_std]
+#![feature(generic_arg_infer)]
+
+#[cfg(test)]
+mod tests;
+
+/// A single ChaCha8 block
+pub type ChaCha8Block = [u32; 16];
+
+/// Convert block to bytes
+#[inline(always)]
+#[cfg_attr(feature = "no-panic", no_panic::no_panic)]
+pub fn block_to_bytes(block: &ChaCha8Block) -> [u8; 64] {
+    // SAFETY: Same size and no alignment requirements
+    unsafe { block.as_ptr().cast::<[u8; 64]>().read() }
+}
+
+/// Create an instance from internal representation
+#[inline(always)]
+#[cfg_attr(feature = "no-panic", no_panic::no_panic)]
+pub fn bytes_to_block(bytes: &[u8; 64]) -> ChaCha8Block {
+    // SAFETY: Same size, all bit patterns are valid
+    unsafe { bytes.as_ptr().cast::<ChaCha8Block>().read_unaligned() }
+}
+
+/// State of ChaCha8 cipher
+#[derive(Debug, Copy, Clone)]
+pub struct ChaCha8State {
+    data: ChaCha8Block,
+}
+
+impl ChaCha8State {
+    const ROUNDS: usize = 8;
+
+    /// Initialize ChaCha8 state
+    #[inline]
+    #[cfg_attr(feature = "no-panic", no_panic::no_panic)]
+    pub fn init(key: &[u8; 32], nonce: &[u8; 12]) -> Self {
+        let mut data = [0u32; 16];
+        data[0] = 0x61707865;
+        data[1] = 0x3320646e;
+        data[2] = 0x79622d32;
+        data[3] = 0x6b206574;
+
+        for (i, &chunk) in key.as_chunks::<4>().0.iter().enumerate() {
+            data[4 + i] = u32::from_le_bytes(chunk);
+        }
+
+        // `data[12]` and `data[13]` is counter specific to each block, thus not set here
+
+        for (i, &chunk) in nonce.as_chunks::<4>().0.iter().enumerate() {
+            data[13 + i] = u32::from_le_bytes(chunk);
+        }
+
+        Self { data }
+    }
+
+    /// Convert to internal representation
+    #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic::no_panic)]
+    pub fn to_repr(self) -> ChaCha8Block {
+        self.data
+    }
+
+    /// Create an instance from internal representation
+    #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic::no_panic)]
+    pub fn from_repr(data: ChaCha8Block) -> Self {
+        Self { data }
+    }
+
+    /// Compute block for specified counter.
+    ///
+    /// Counter is only 32-bit because that is all that is needed for target use case.
+    #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic::no_panic)]
+    pub fn compute_block(mut self, counter: u32) -> ChaCha8Block {
+        self.data[12] = counter;
+        // Not setting `data[13]` due to counter being limited to `u32`
+
+        let initial = self.data;
+
+        for _ in 0..Self::ROUNDS / 2 {
+            self.quarter_round(0, 4, 8, 12);
+            self.quarter_round(1, 5, 9, 13);
+            self.quarter_round(2, 6, 10, 14);
+            self.quarter_round(3, 7, 11, 15);
+
+            self.quarter_round(0, 5, 10, 15);
+            self.quarter_round(1, 6, 11, 12);
+            self.quarter_round(2, 7, 8, 13);
+            self.quarter_round(3, 4, 9, 14);
+        }
+
+        // TODO: More idiomatic version currently doesn't compile:
+        //  https://github.com/Rust-GPU/rust-gpu/issues/241#issuecomment-3005693043
+        #[allow(clippy::needless_range_loop)]
+        // for (d, initial) in self.data.iter_mut().zip(initial) {
+        //     *d = d.wrapping_add(initial);
+        // }
+        for i in 0..16 {
+            self.data[i] = self.data[i].wrapping_add(initial[i]);
+        }
+
+        self.data
+    }
+
+    #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic::no_panic)]
+    fn quarter_round(&mut self, a: usize, b: usize, c: usize, d: usize) {
+        self.data[a] = self.data[a].wrapping_add(self.data[b]);
+        self.data[d] ^= self.data[a];
+        self.data[d] = self.data[d].rotate_left(16);
+
+        self.data[c] = self.data[c].wrapping_add(self.data[d]);
+        self.data[b] ^= self.data[c];
+        self.data[b] = self.data[b].rotate_left(12);
+
+        self.data[a] = self.data[a].wrapping_add(self.data[b]);
+        self.data[d] ^= self.data[a];
+        self.data[d] = self.data[d].rotate_left(8);
+
+        self.data[c] = self.data[c].wrapping_add(self.data[d]);
+        self.data[b] ^= self.data[c];
+        self.data[b] = self.data[b].rotate_left(7);
+    }
+}

--- a/shared/ab-chacha8/src/lib.rs
+++ b/shared/ab-chacha8/src/lib.rs
@@ -1,7 +1,6 @@
 //! Small GPU-friendly software implementation of ChaCha8
 
 #![no_std]
-#![feature(generic_arg_infer)]
 
 #[cfg(test)]
 mod tests;

--- a/shared/ab-chacha8/src/tests.rs
+++ b/shared/ab-chacha8/src/tests.rs
@@ -1,0 +1,30 @@
+//! `ab-chacha8` tests.
+
+use crate::{ChaCha8State, block_to_bytes};
+use chacha20::cipher::{Iv, KeyIvInit, StreamCipher};
+use chacha20::{ChaCha8, Key};
+
+#[test]
+fn chacha8_primitive() {
+    let seed = [1; 32];
+
+    let mut expected_output = [[0u8; _]; 2];
+    ChaCha8::new(&Key::from(seed), &Iv::<ChaCha8>::default())
+        .apply_keystream(expected_output.as_flattened_mut());
+
+    let initial_state = ChaCha8State::init(&seed, &[0; _]);
+
+    assert_eq!(
+        ChaCha8State::from_repr(initial_state.to_repr()).to_repr(),
+        initial_state.to_repr()
+    );
+
+    assert_eq!(
+        block_to_bytes(&initial_state.compute_block(0)),
+        expected_output[0]
+    );
+    assert_eq!(
+        block_to_bytes(&initial_state.compute_block(1)),
+        expected_output[1]
+    );
+}

--- a/test/subspace-test-client/src/lib.rs
+++ b/test/subspace-test-client/src/lib.rs
@@ -150,7 +150,7 @@ async fn start_farming<PosTable, Client>(
         }
     });
 
-    let (sector, plotted_sector, mut table_generator) = plotting_result_receiver.await.unwrap();
+    let (sector, plotted_sector, table_generator) = plotting_result_receiver.await.unwrap();
     let public_key = PublicKey::from(keypair.public.to_bytes());
 
     let mut new_slot_notification_stream = new_slot_notification_stream.subscribe();


### PR DESCRIPTION
## Summary

  Backports the bucketed array approach for PoS table construction from Abundance, replacing sorted Vecs with fixed-size bucketed arrays for better cache locality and lower allocation overhead. Includes bug fixes discovered during backport validation.

  **Best reviewed commit-by-commit.**

  ## Benchmark results (vs main)

  | Chia PoS benchmark | main | this PR | change |
  |---|---|---|---|
  | table generation | 1.578s | 1.012s | **-36% faster** |
  | proof lookup (present) | 290ns | 204ns | **-30% faster** |
  | verification | 15.5µs | 9.3µs | **-40% faster** |
  | proof lookup (missing) | 24ns | 156ns | +540% (negligible absolute, uncommon path) |

  ## Commits

  1. **Revert "Revert "Backport Proof of Space perf improvements from abundance""** — Re-applies the original backport: bucketed arrays instead of sorted Vecs for table construction, `ab-chacha8` shared crate, restructured feature flags (`alloc`/`full-chiapos` instead of
  `std`).

  2. **Fix Rmap to support unlimited entries and position zero** — The backported Rmap had two bugs: max 2 entries per r-value (3rd+ silently dropped) and `Position::ZERO` used as both sentinel and valid value. Rewrites Rmap with flat `(start_index, count)` design where
  `get()` returns `&[Position]` slices.

  3. **Fix bucket size overflow and proof ordering** — `REDUCED_BUCKET_SIZE=272` was too small, causing ~3% of buckets at K=20 to silently drop entries. Increased to 512. Also adds Y-sorting with `(y, pos)` tiebreak for deterministic proof ordering matching the old
  Vec-based code.

  4. **Fix shim benchmark using wrong challenge indices** — The benchmark had `challenge_index_without_solution=1` (which actually has a solution) and vice versa. Swaps the two indices.

  5. **Remove unused generic_arg_infer feature flag** — Cleanup of unused nightly feature from `subspace-proof-of-space` and `ab-chacha8`.


### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
