### PR TITLE
Ignore 3 new Rustsec advisories from transitive dependencies

### DIFF
--- a/.github/workflows/rustsec-audit.yml
+++ b/.github/workflows/rustsec-audit.yml
@@ -20,9 +20,11 @@ jobs:
       - uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 #v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          # TODO: Remove first once Substrate upgrades litep2p and we no longer have rustls 0.20.9 in our dependencies
-          # TODO: Remove second once Substrate upgrades litep2p and sc-network and we no longer have ring 0.16 in our dependencies
-          # TODO: Remove third once Substrate upgrades wasmtime and we no longer have wasmtime <= 9 in our dependencies
-          # TODO: Remove fourth once Substrate upgrades wasmtime and we no longer have wasmtime <= 23 in our dependencies
-          # TODO: Remove fifth once Substrate upgrades wasmtime and we no longer have wasmtime < 24.0.5 in our dependencies (RUSTSEC-2025-0118)
-          ignore: RUSTSEC-2024-0336, RUSTSEC-2025-0009, RUSTSEC-2023-0091, RUSTSEC-2024-0438, RUSTSEC-2025-0118
+          # TODO: Remove once Substrate upgrades litep2p and we no longer have rustls 0.20.9 in our dependencies
+          # TODO: Remove once Substrate upgrades litep2p and sc-network and we no longer have ring 0.16 in our dependencies
+          # TODO: Remove once Substrate upgrades wasmtime and we no longer have wasmtime <= 9 in our dependencies
+          # TODO: Remove once Substrate upgrades wasmtime and we no longer have wasmtime <= 23 in our dependencies
+          # TODO: Remove once Substrate upgrades wasmtime and we no longer have wasmtime < 24.0.5 in our dependencies (RUSTSEC-2025-0118)
+          # TODO: Remove once Substrate upgrades litep2p/libp2p and we no longer have quinn-proto < 0.11.14 in our dependencies
+          # TODO: Remove once Substrate upgrades wasmtime and we no longer have wasmtime <= 23 in our dependencies (RUSTSEC-2026-0020, RUSTSEC-2026-0021)
+          ignore: RUSTSEC-2024-0336, RUSTSEC-2025-0009, RUSTSEC-2023-0091, RUSTSEC-2024-0438, RUSTSEC-2025-0118, RUSTSEC-2026-0037, RUSTSEC-2026-0020, RUSTSEC-2026-0021


### PR DESCRIPTION
## Summary

- Add 3 new security advisories to the cargo audit ignore list that are causing CI failures on main
  - **RUSTSEC-2026-0037**: `quinn-proto` 0.11.13 — DoS via QUIC transport params (from `rust-libp2p` fork → `libp2p-quic` → `quinn` 0.11.6)
  - **RUSTSEC-2026-0020**: `wasmtime` 8.0.1 — Guest-controlled resource exhaustion (from `polkadot-sdk` fork → `sc-executor`)
  - **RUSTSEC-2026-0021**: `wasmtime` 8.0.1 — Panic in `wasi:http/types.fields` (same dependency chain)
- All come from transitive dependencies pinned by our polkadot-sdk and rust-libp2p forks and cannot be upgraded directly
- Verified all existing ignores are still needed (vulnerable versions still in Cargo.lock)