### PR TITLE
Bump client versions to 0.1.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13931,7 +13931,7 @@ dependencies = [
 
 [[package]]
 name = "subspace-bootstrap-node"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "clap",
  "futures",
@@ -14029,7 +14029,7 @@ dependencies = [
 
 [[package]]
 name = "subspace-farmer"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "async-lock",
@@ -14140,7 +14140,7 @@ dependencies = [
 
 [[package]]
 name = "subspace-gateway"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -14310,7 +14310,7 @@ dependencies = [
 
 [[package]]
 name = "subspace-node"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "auto-id-domain-runtime",
  "bip39",

--- a/crates/subspace-bootstrap-node/Cargo.toml
+++ b/crates/subspace-bootstrap-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subspace-bootstrap-node"
-version = "0.1.7"
+version = "0.1.8"
 authors = [
     "Nazar Mokrynskyi <nazar@mokrynskyi.com>",
     "Shamil Gadelshin <shamilgadelshin@gmail.com>"

--- a/crates/subspace-farmer/Cargo.toml
+++ b/crates/subspace-farmer/Cargo.toml
@@ -2,7 +2,7 @@
 name = "subspace-farmer"
 description = "Farmer for the Subspace Network Blockchain"
 license = "0BSD"
-version = "0.1.7"
+version = "0.1.8"
 authors = ["Nazar Mokrynskyi <nazar@mokrynskyi.com>"]
 edition.workspace = true
 include = [

--- a/crates/subspace-gateway/Cargo.toml
+++ b/crates/subspace-gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subspace-gateway"
-version = "0.1.7"
+version = "0.1.8"
 authors = [
     "Teor <teor@riseup.net>",
     "Shamil Gadelshin <shamilgadelshin@gmail.com>"

--- a/crates/subspace-node/Cargo.toml
+++ b/crates/subspace-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subspace-node"
-version = "0.1.7"
+version = "0.1.8"
 authors = ["Subspace Labs <https://subspace.network>"]
 description = "A Subspace Network Blockchain node."
 edition.workspace = true


### PR DESCRIPTION
## Summary
- Bump subspace-node, subspace-farmer, subspace-gateway, and subspace-bootstrap-node from 0.1.7 to 0.1.8 in preparation for release

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)