### PR TITLE
Bump Rust nightly to nightly-2026-04-11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1252,7 +1252,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 [[package]]
 name = "binary-merkle-tree"
 version = "16.1.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "hash-db",
  "log",
@@ -2404,7 +2404,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-parachain-inherent"
 version = "0.22.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2415,7 +2415,7 @@ dependencies = [
  "sc-client-api",
  "sc-consensus-babe",
  "sc-network-types",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b)",
  "sp-inherents",
  "sp-runtime",
  "sp-state-machine",
@@ -2426,7 +2426,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system"
 version = "0.25.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "array-bytes",
  "bytes",
@@ -2464,7 +2464,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system-proc-macro"
 version = "0.7.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
@@ -2475,7 +2475,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-core"
 version = "0.23.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "parity-scale-codec",
  "polkadot-core-primitives",
@@ -2492,7 +2492,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-parachain-inherent"
 version = "0.23.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2506,7 +2506,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-proof-size-hostfunction"
 version = "0.16.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "sp-externalities",
  "sp-runtime-interface",
@@ -2516,7 +2516,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-storage-weight-reclaim"
 version = "16.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-proof-size-hostfunction",
@@ -2533,7 +2533,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-interface"
 version = "0.28.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2553,7 +2553,7 @@ dependencies = [
 [[package]]
 name = "cumulus-test-relay-sproof-builder"
 version = "0.24.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
@@ -4143,7 +4143,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b)",
 ]
 
 [[package]]
@@ -4287,7 +4287,7 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 [[package]]
 name = "fork-tree"
 version = "13.0.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -4414,7 +4414,7 @@ checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 [[package]]
 name = "frame-benchmarking"
 version = "45.0.3"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -4438,7 +4438,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "53.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "Inflector",
  "array-bytes",
@@ -4517,7 +4517,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-solution-type"
 version = "16.1.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
@@ -4528,7 +4528,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-support"
 version = "45.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "frame-election-provider-solution-type",
  "frame-support",
@@ -4545,7 +4545,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "45.0.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "aquamarine",
  "frame-support",
@@ -4575,7 +4575,7 @@ dependencies = [
 [[package]]
 name = "frame-storage-access-test-runtime"
 version = "0.6.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "parity-scale-codec",
@@ -4589,7 +4589,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "45.1.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "aquamarine",
  "array-bytes",
@@ -4630,7 +4630,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "36.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -4643,14 +4643,14 @@ dependencies = [
  "proc-macro-warning",
  "proc-macro2",
  "quote",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b)",
  "syn 2.0.117",
 ]
 
 [[package]]
 name = "frame-support-procedural-tools"
 version = "13.0.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate 3.5.0",
@@ -4662,7 +4662,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "12.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4672,7 +4672,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "45.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "cfg-if",
  "docify",
@@ -4691,7 +4691,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "45.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4705,7 +4705,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "40.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "docify",
  "parity-scale-codec",
@@ -4715,7 +4715,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.51.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -7244,7 +7244,7 @@ dependencies = [
 [[package]]
 name = "mmr-gadget"
 version = "50.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "futures",
  "log",
@@ -7263,7 +7263,7 @@ dependencies = [
 [[package]]
 name = "mmr-rpc"
 version = "44.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -7921,7 +7921,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-conversion"
 version = "27.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7939,7 +7939,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "45.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7954,7 +7954,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "45.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7987,7 +7987,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "45.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8010,7 +8010,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "46.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8042,7 +8042,7 @@ dependencies = [
 [[package]]
 name = "pallet-broker"
 version = "0.24.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -8060,7 +8060,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "45.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8077,7 +8077,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "45.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8274,7 +8274,7 @@ dependencies = [
 [[package]]
 name = "pallet-message-queue"
 version = "48.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -8317,7 +8317,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr"
 version = "45.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -8329,7 +8329,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "45.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -8340,7 +8340,7 @@ dependencies = [
 [[package]]
 name = "pallet-preimage"
 version = "45.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8389,7 +8389,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "46.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8406,7 +8406,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "45.2.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8428,7 +8428,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "45.1.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -8509,7 +8509,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "45.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8524,7 +8524,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "44.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8553,7 +8553,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "45.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8569,7 +8569,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "48.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -8585,7 +8585,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "45.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -8618,7 +8618,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "45.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8978,7 +8978,7 @@ dependencies = [
 [[package]]
 name = "polkadot-core-primitives"
 version = "21.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -8989,7 +8989,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-metrics"
 version = "28.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "bs58",
  "futures",
@@ -9006,7 +9006,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-network-protocol"
 version = "28.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -9031,7 +9031,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-primitives"
 version = "23.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "bitvec",
  "bounded-vec",
@@ -9055,7 +9055,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-types"
 version = "28.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "async-trait",
  "derive_more 0.99.20",
@@ -9083,7 +9083,7 @@ dependencies = [
 [[package]]
 name = "polkadot-overseer"
 version = "28.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "async-trait",
  "futures",
@@ -9103,7 +9103,7 @@ dependencies = [
 [[package]]
 name = "polkadot-parachain-primitives"
 version = "20.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "array-bytes",
  "bounded-collections",
@@ -9120,7 +9120,7 @@ dependencies = [
 [[package]]
 name = "polkadot-primitives"
 version = "22.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "bitvec",
  "bounded-collections",
@@ -9149,7 +9149,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-metrics"
 version = "25.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "bs58",
  "frame-benchmarking",
@@ -9161,7 +9161,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-parachains"
 version = "24.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "bitflags 1.3.2",
  "bitvec",
@@ -9209,7 +9209,7 @@ dependencies = [
 [[package]]
 name = "polkadot-sdk-frame"
 version = "0.14.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9244,7 +9244,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-table"
 version = "23.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
@@ -9460,7 +9460,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b)",
  "syn 2.0.117",
 ]
 
@@ -10664,7 +10664,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "35.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "log",
  "sp-core",
@@ -10675,7 +10675,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.55.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "async-trait",
  "futures",
@@ -10707,7 +10707,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.53.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "futures",
  "log",
@@ -10729,7 +10729,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.48.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -10744,7 +10744,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "48.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "array-bytes",
  "docify",
@@ -10759,7 +10759,7 @@ dependencies = [
  "serde_json",
  "sp-blockchain",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b)",
  "sp-genesis-builder",
  "sp-io",
  "sp-runtime",
@@ -10770,7 +10770,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "12.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
@@ -10781,7 +10781,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.57.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "array-bytes",
  "bip39",
@@ -10823,7 +10823,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "44.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "fnv",
  "futures",
@@ -10849,7 +10849,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.51.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -10876,7 +10876,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.54.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "async-trait",
  "futures",
@@ -10899,7 +10899,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.55.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -10924,7 +10924,7 @@ dependencies = [
  "sp-consensus-babe",
  "sp-consensus-slots",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b)",
  "sp-inherents",
  "sp-keystore",
  "sp-runtime",
@@ -10936,7 +10936,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.54.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -10949,7 +10949,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.54.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "async-trait",
  "futures",
@@ -11079,7 +11079,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.47.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.5",
@@ -11102,7 +11102,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.43.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "polkavm",
  "sc-allocator",
@@ -11115,7 +11115,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-polkavm"
 version = "0.40.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "log",
  "polkavm",
@@ -11126,7 +11126,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.43.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "anyhow",
  "log",
@@ -11142,7 +11142,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.54.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "console",
  "futures",
@@ -11158,7 +11158,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "39.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "array-bytes",
  "parking_lot 0.12.5",
@@ -11172,7 +11172,7 @@ dependencies = [
 [[package]]
 name = "sc-mixnet"
 version = "0.25.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "array-bytes",
  "arrayvec 0.7.6",
@@ -11200,7 +11200,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.55.2"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -11249,7 +11249,7 @@ dependencies = [
 [[package]]
 name = "sc-network-common"
 version = "0.52.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "bitflags 1.3.2",
  "parity-scale-codec",
@@ -11259,7 +11259,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.55.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "ahash 0.8.12",
  "futures",
@@ -11278,7 +11278,7 @@ dependencies = [
 [[package]]
 name = "sc-network-light"
 version = "0.54.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -11299,7 +11299,7 @@ dependencies = [
 [[package]]
 name = "sc-network-sync"
 version = "0.54.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -11334,7 +11334,7 @@ dependencies = [
 [[package]]
 name = "sc-network-transactions"
 version = "0.54.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "array-bytes",
  "futures",
@@ -11353,7 +11353,7 @@ dependencies = [
 [[package]]
 name = "sc-network-types"
 version = "0.20.2"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "bs58",
  "bytes",
@@ -11374,7 +11374,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "50.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "bytes",
  "fnv",
@@ -11437,7 +11437,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.20.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -11446,7 +11446,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "50.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -11478,7 +11478,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.54.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -11498,7 +11498,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "27.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "dyn-clone",
  "forwarded-header-value",
@@ -11522,7 +11522,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-spec-v2"
 version = "0.55.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "array-bytes",
  "futures",
@@ -11555,13 +11555,13 @@ dependencies = [
 [[package]]
 name = "sc-runtime-utilities"
 version = "0.7.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "parity-scale-codec",
  "sc-executor",
  "sc-executor-common",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b)",
  "sp-state-machine",
  "sp-wasm-interface",
  "thiserror 1.0.69",
@@ -11570,7 +11570,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.56.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "async-trait",
  "directories",
@@ -11634,7 +11634,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.41.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -11645,7 +11645,7 @@ dependencies = [
 [[package]]
 name = "sc-storage-monitor"
 version = "0.27.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "clap",
  "fs4 0.7.0",
@@ -11703,7 +11703,7 @@ dependencies = [
 [[package]]
 name = "sc-sysinfo"
 version = "46.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "derive_more 0.99.20",
  "futures",
@@ -11716,14 +11716,14 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b)",
  "sp-io",
 ]
 
 [[package]]
 name = "sc-telemetry"
 version = "30.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "chrono",
  "futures",
@@ -11742,7 +11742,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "44.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "chrono",
  "console",
@@ -11770,7 +11770,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "11.1.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
@@ -11781,7 +11781,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "44.1.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "async-trait",
  "futures",
@@ -11798,7 +11798,7 @@ dependencies = [
  "sp-api",
  "sp-blockchain",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b)",
  "sp-runtime",
  "sp-tracing",
  "sp-transaction-pool",
@@ -11813,7 +11813,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "43.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "async-trait",
  "futures",
@@ -11831,7 +11831,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "20.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "async-channel 1.9.0",
  "futures",
@@ -12674,7 +12674,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "40.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "docify",
  "hash-db",
@@ -12696,7 +12696,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "26.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "Inflector",
  "blake2 0.10.6",
@@ -12710,7 +12710,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "44.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12722,7 +12722,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "28.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "docify",
  "integer-sqrt",
@@ -12736,7 +12736,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "40.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12761,7 +12761,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "40.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "sp-api",
  "sp-inherents",
@@ -12782,7 +12782,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "43.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -12801,7 +12801,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.46.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "async-trait",
  "futures",
@@ -12815,7 +12815,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.46.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -12831,7 +12831,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.46.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -12849,7 +12849,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-beefy"
 version = "28.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12857,7 +12857,7 @@ dependencies = [
  "sp-api",
  "sp-application-crypto",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b)",
  "sp-io",
  "sp-keystore",
  "sp-mmr-primitives",
@@ -12869,7 +12869,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-grandpa"
 version = "27.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -12886,7 +12886,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.46.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12925,7 +12925,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "39.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "ark-vrf",
  "array-bytes",
@@ -12956,7 +12956,7 @@ dependencies = [
  "secrecy 0.8.0",
  "serde",
  "sha2 0.10.9",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b)",
  "sp-debug-derive",
  "sp-externalities",
  "sp-std",
@@ -12986,7 +12986,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing"
 version = "0.1.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -12999,17 +12999,17 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "quote",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b)",
  "syn 2.0.117",
 ]
 
 [[package]]
 name = "sp-database"
 version = "10.0.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.5",
@@ -13018,7 +13018,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "14.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -13171,7 +13171,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.31.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -13181,7 +13181,7 @@ dependencies = [
 [[package]]
 name = "sp-genesis-builder"
 version = "0.21.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -13193,7 +13193,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "40.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -13206,7 +13206,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "44.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "bytes",
  "docify",
@@ -13218,7 +13218,7 @@ dependencies = [
  "rustversion",
  "secp256k1 0.28.2",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b)",
  "sp-externalities",
  "sp-keystore",
  "sp-runtime-interface",
@@ -13232,7 +13232,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "45.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "sp-core",
  "sp-runtime",
@@ -13242,7 +13242,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.45.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.5",
@@ -13253,7 +13253,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "11.1.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "thiserror 1.0.69",
  "zstd 0.12.4",
@@ -13301,7 +13301,7 @@ dependencies = [
 [[package]]
 name = "sp-metadata-ir"
 version = "0.12.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "frame-metadata",
  "parity-scale-codec",
@@ -13311,7 +13311,7 @@ dependencies = [
 [[package]]
 name = "sp-mixnet"
 version = "0.18.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -13322,7 +13322,7 @@ dependencies = [
 [[package]]
 name = "sp-mmr-primitives"
 version = "40.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -13339,7 +13339,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "40.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -13360,7 +13360,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "40.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -13370,7 +13370,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "13.0.2"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "backtrace",
  "regex",
@@ -13379,7 +13379,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "37.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "rustc-hash 1.1.0",
  "serde",
@@ -13389,7 +13389,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "45.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "binary-merkle-tree",
  "bytes",
@@ -13420,7 +13420,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "33.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -13438,7 +13438,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "20.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "Inflector",
  "expander",
@@ -13451,7 +13451,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "42.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -13465,7 +13465,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "42.2.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -13478,7 +13478,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.49.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "hash-db",
  "log",
@@ -13498,7 +13498,7 @@ dependencies = [
 [[package]]
 name = "sp-statement-store"
 version = "24.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "aes-gcm",
  "curve25519-dalek",
@@ -13511,7 +13511,7 @@ dependencies = [
  "sp-api",
  "sp-application-crypto",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b)",
  "sp-externalities",
  "sp-runtime",
  "sp-runtime-interface",
@@ -13522,12 +13522,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "14.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 
 [[package]]
 name = "sp-storage"
 version = "22.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -13557,7 +13557,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "40.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -13569,7 +13569,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "19.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "parity-scale-codec",
  "regex",
@@ -13581,7 +13581,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "40.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -13590,7 +13590,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "40.1.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -13605,7 +13605,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "42.0.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "ahash 0.8.12",
  "foldhash 0.1.5",
@@ -13630,7 +13630,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "43.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -13647,7 +13647,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "15.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "parity-scale-codec",
  "proc-macro-warning",
@@ -13659,7 +13659,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "24.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -13671,7 +13671,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "33.2.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "bounded-collections",
  "parity-scale-codec",
@@ -13749,7 +13749,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 [[package]]
 name = "staging-xcm"
 version = "21.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "array-bytes",
  "bounded-collections",
@@ -13770,7 +13770,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-builder"
 version = "25.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "environmental",
  "frame-support",
@@ -13794,7 +13794,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-executor"
 version = "24.0.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -14817,12 +14817,12 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "11.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "49.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "docify",
  "frame-system-rpc-runtime-api",
@@ -14842,7 +14842,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.17.7"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "http-body-util",
  "hyper",
@@ -14856,7 +14856,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-client"
 version = "2.0.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "array-bytes",
  "async-trait",
@@ -14881,7 +14881,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "31.1.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "build-helper",
  "cargo_metadata",
@@ -15739,7 +15739,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum"
 version = "23.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "coarsetime",
  "polkadot-primitives",
@@ -15750,7 +15750,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "expander",
  "proc-macro-crate 3.5.0",
@@ -17479,7 +17479,7 @@ dependencies = [
 [[package]]
 name = "xcm-procedural"
 version = "11.0.2"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=2eb28846ad471aa33bf9a532e06b42835bec27df#2eb28846ad471aa33bf9a532e06b42835bec27df"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
 dependencies = [
  "Inflector",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ core_affinity = "0.8.1"
 cpufeatures = "0.2.17"
 criterion = { version = "0.5.1", default-features = false }
 cross-domain-message-gossip = { version = "0.1.0", path = "domains/client/cross-domain-message-gossip" }
-cumulus-primitives-proof-size-hostfunction = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df", default-features = false }
+cumulus-primitives-proof-size-hostfunction = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
 derive_more = { version = "1.0.0", default-features = false }
 domain-block-builder = { version = "0.1.0", path = "domains/client/block-builder", default-features = false }
 domain-block-preprocessor = { version = "0.1.0", path = "domains/client/block-preprocessor", default-features = false }
@@ -90,13 +90,13 @@ fp-account = { version = "1.0.0-dev", git = "https://github.com/polkadot-evm/fro
 fp-evm = { version = "3.0.0-dev", git = "https://github.com/polkadot-evm/frontier", rev = "9d49e36ed5bac38241594f8ba055fdb94991483a", default-features = false }
 fp-rpc = { version = "3.0.0-dev", git = "https://github.com/polkadot-evm/frontier", rev = "9d49e36ed5bac38241594f8ba055fdb94991483a", default-features = false }
 fp-self-contained = { version = "1.0.0-dev", git = "https://github.com/polkadot-evm/frontier", rev = "9d49e36ed5bac38241594f8ba055fdb94991483a", default-features = false }
-frame-benchmarking = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df", default-features = false }
-frame-benchmarking-cli = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df", default-features = false }
-frame-executive = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df", default-features = false }
-frame-support = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df", default-features = false }
-frame-system = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df", default-features = false }
-frame-system-benchmarking = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df", default-features = false }
-frame-system-rpc-runtime-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df", default-features = false }
+frame-benchmarking = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
+frame-benchmarking-cli = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
+frame-executive = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
+frame-support = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
+frame-system = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
+frame-system-benchmarking = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
+frame-system-rpc-runtime-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
 fs2 = "0.4.3"
 fs4 = "0.9.1"
 futures = "0.3.31"
@@ -115,8 +115,8 @@ log = { version = "0.4.22", default-features = false }
 memmap2 = "0.9.5"
 memory-db = { version = "0.34.0", default-features = false }
 mimalloc = "0.1.43"
-mmr-gadget = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df" }
-mmr-rpc = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df" }
+mmr-gadget = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
+mmr-rpc = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
 multihash = "0.19.1"
 nohash-hasher = "0.2.0"
 num-traits = { version = "0.2.18", default-features = false }
@@ -124,10 +124,10 @@ num_cpus = "1.16.0"
 num_enum = { version = "0.5.3", default-features = false }
 ouroboros = "0.18.4"
 pallet-auto-id = { version = "0.1.0", path = "domains/pallets/auto-id", default-features = false }
-pallet-balances = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df", default-features = false }
+pallet-balances = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
 pallet-block-fees = { version = "0.1.0", path = "domains/pallets/block-fees", default-features = false }
-pallet-collective = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df", default-features = false }
-pallet-democracy = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df", default-features = false }
+pallet-collective = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
+pallet-democracy = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
 pallet-domain-id = { version = "0.1.0", path = "domains/pallets/domain-id", default-features = false }
 pallet-domain-sudo = { version = "0.1.0", path = "domains/pallets/domain-sudo", default-features = false }
 pallet-domains = { version = "0.1.0", path = "crates/pallet-domains", default-features = false }
@@ -139,23 +139,23 @@ pallet-evm-precompile-sha3fips = { version = "2.0.0-dev", git = "https://github.
 pallet-evm-precompile-simple = { version = "2.0.0-dev", git = "https://github.com/polkadot-evm/frontier", rev = "9d49e36ed5bac38241594f8ba055fdb94991483a", default-features = false }
 pallet-evm-tracker = { version = "0.1.0", path = "domains/pallets/evm-tracker", default-features = false }
 pallet-messenger = { version = "0.1.0", path = "domains/pallets/messenger", default-features = false }
-pallet-mmr = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df", default-features = false }
-pallet-multisig = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df", default-features = false }
-pallet-preimage = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df", default-features = false }
+pallet-mmr = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
+pallet-multisig = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
+pallet-preimage = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
 pallet-rewards = { version = "0.1.0", path = "crates/pallet-rewards", default-features = false }
 pallet-runtime-configs = { version = "0.1.0", path = "crates/pallet-runtime-configs", default-features = false }
-pallet-scheduler = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df", default-features = false }
+pallet-scheduler = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
 pallet-storage-overlay-checks = { version = "0.1.0", path = "domains/test/pallets/storage_overlay_checks", default-features = false }
 pallet-subspace = { version = "0.1.0", path = "crates/pallet-subspace", default-features = false }
 pallet-subspace-mmr = { version = "0.1.0", path = "crates/pallet-subspace-mmr", default-features = false }
-pallet-sudo = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df", default-features = false }
-pallet-timestamp = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df", default-features = false }
+pallet-sudo = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
+pallet-timestamp = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
 pallet-transaction-fees = { version = "0.1.0", path = "crates/pallet-transaction-fees", default-features = false }
-pallet-transaction-payment = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df", default-features = false }
-pallet-transaction-payment-rpc = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df" }
-pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df", default-features = false }
+pallet-transaction-payment = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
+pallet-transaction-payment-rpc = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
+pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
 pallet-transporter = { version = "0.1.0", path = "domains/pallets/transporter", default-features = false }
-pallet-utility = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df", default-features = false }
+pallet-utility = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
 parity-scale-codec = { version = "3.7.5", default-features = false }
 parking_lot = "0.12.2"
 pem = "3.0.4"
@@ -173,42 +173,42 @@ ring = "0.17.8"
 rlp = "0.6"
 rs_merkle = { version = "1.4.2", default-features = false }
 rust-kzg-blst = { git = "https://github.com/grandinetech/rust-kzg", rev = "8f5f1a0f73b3c529c77cb880ff8d265830c7d7ac", default-features = false }
-sc-basic-authorship = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df" }
-sc-block-builder = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df" }
-sc-chain-spec = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df" }
-sc-cli = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df", default-features = false }
-sc-client-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df" }
-sc-client-db = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df" }
-sc-consensus = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df" }
-sc-consensus-slots = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df" }
+sc-basic-authorship = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
+sc-block-builder = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
+sc-chain-spec = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
+sc-cli = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
+sc-client-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
+sc-client-db = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
+sc-consensus = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
+sc-consensus-slots = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
 sc-consensus-subspace = { version = "0.1.0", path = "crates/sc-consensus-subspace" }
 sc-consensus-subspace-rpc = { version = "0.1.0", path = "crates/sc-consensus-subspace-rpc" }
 sc-domains = { version = "0.1.0", path = "crates/sc-domains" }
-sc-executor = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df", default-features = false }
-sc-informant = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df" }
-sc-keystore = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df" }
-sc-network = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df" }
-sc-network-common = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df" }
-sc-network-gossip = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df" }
-sc-network-sync = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df", default-features = false }
-sc-network-transactions = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df" }
-sc-offchain = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df" }
+sc-executor = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
+sc-informant = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
+sc-keystore = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
+sc-network = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
+sc-network-common = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
+sc-network-gossip = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
+sc-network-sync = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
+sc-network-transactions = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
+sc-offchain = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
 sc-proof-of-time = { version = "0.1.0", path = "crates/sc-proof-of-time" }
-sc-rpc = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df" }
-sc-rpc-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df" }
-sc-rpc-server = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df" }
-sc-service = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df", default-features = false }
-sc-state-db = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df" }
-sc-storage-monitor = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df", default-features = false }
+sc-rpc = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
+sc-rpc-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
+sc-rpc-server = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
+sc-service = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
+sc-state-db = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
+sc-storage-monitor = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
 sc-subspace-block-relay = { version = "0.1.0", path = "crates/sc-subspace-block-relay" }
 sc-subspace-chain-specs = { version = "0.1.0", path = "crates/sc-subspace-chain-specs" }
 sc-subspace-sync-common = { version = "0.1.0", path = "shared/sc-subspace-sync-common", default-features = false }
-sc-sysinfo = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df", default-features = false }
-sc-telemetry = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df" }
-sc-tracing = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df" }
-sc-transaction-pool = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df" }
-sc-transaction-pool-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df" }
-sc-utils = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df" }
+sc-sysinfo = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
+sc-telemetry = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
+sc-tracing = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
+sc-transaction-pool = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
+sc-transaction-pool-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
+sc-utils = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
 scale-info = { version = "2.11.6", default-features = false }
 schnellru = "0.2.4"
 schnorrkel = { version = "0.11.4", default-features = false }
@@ -217,48 +217,48 @@ serde = { version = "1.0.216", default-features = false }
 serde-big-array = "0.5.1"
 serde_json = "1.0.133"
 sha2 = { version = "0.10.7", default-features = false }
-sp-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df", default-features = false }
-sp-application-crypto = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df", default-features = false }
-sp-arithmetic = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df", default-features = false }
+sp-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
+sp-application-crypto = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
+sp-arithmetic = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
 sp-auto-id = { version = "0.1.0", path = "domains/primitives/auto-id", default-features = false }
-sp-block-builder = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df", default-features = false }
+sp-block-builder = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
 sp-block-fees = { version = "0.1.0", path = "domains/primitives/block-fees", default-features = false }
-sp-blockchain = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df", default-features = false }
-sp-consensus = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df" }
-sp-consensus-slots = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df", default-features = false }
+sp-blockchain = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
+sp-consensus = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
+sp-consensus-slots = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
 sp-consensus-subspace = { version = "0.1.0", path = "crates/sp-consensus-subspace", default-features = false }
-sp-core = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df", default-features = false }
+sp-core = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
 sp-domain-digests = { version = "0.1.0", path = "domains/primitives/digests", default-features = false }
 sp-domain-sudo = { version = "0.1.0", path = "domains/primitives/domain-sudo", default-features = false }
 sp-domains = { version = "0.1.0", path = "crates/sp-domains", default-features = false }
 sp-domains-fraud-proof = { version = "0.1.0", path = "crates/sp-domains-fraud-proof", default-features = false }
 sp-evm-tracker = { version = "0.1.0", path = "domains/primitives/evm-tracker", default-features = false }
 sp-executive = { version = "0.1.0", path = "domains/primitives/executive", default-features = false }
-sp-externalities = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df", default-features = false }
+sp-externalities = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
 sp-evm-precompiles = { version = "0.1.0", path = "domains/primitives/evm-precompiles", default-features = false }
-sp-genesis-builder = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df", default-features = false }
-sp-inherents = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df", default-features = false }
-sp-io = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df", default-features = false }
-sp-keyring = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df" }
-sp-keystore = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df" }
+sp-genesis-builder = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
+sp-inherents = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
+sp-io = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
+sp-keyring = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
+sp-keystore = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
 sp-messenger = { version = "0.1.0", path = "domains/primitives/messenger", default-features = false }
 sp-messenger-host-functions = { version = "0.1.0", path = "domains/primitives/messenger-host-functions", default-features = false }
-sp-mmr-primitives = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df", default-features = false }
+sp-mmr-primitives = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
 sp-objects = { version = "0.1.0", path = "crates/sp-objects", default-features = false }
-sp-offchain = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df", default-features = false }
-sp-runtime = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df", default-features = false }
-sp-runtime-interface = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df", default-features = false }
-sp-session = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df", default-features = false }
-sp-state-machine = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df", default-features = false }
-sp-std = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df", default-features = false }
-sp-storage = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df", default-features = false }
+sp-offchain = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
+sp-runtime = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
+sp-runtime-interface = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
+sp-session = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
+sp-state-machine = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
+sp-std = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
+sp-storage = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
 sp-subspace-mmr = { version = "0.1.0", path = "crates/sp-subspace-mmr", default-features = false }
-sp-timestamp = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df", default-features = false }
-sp-tracing = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df", default-features = false }
-sp-transaction-pool = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df", default-features = false }
-sp-trie = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df", default-features = false }
-sp-version = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df", default-features = false }
-sp-weights = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df", default-features = false }
+sp-timestamp = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
+sp-tracing = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
+sp-transaction-pool = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
+sp-trie = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
+sp-version = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
+sp-weights = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
 spin = "0.9.7"
 sppark = { version = "0.1.8", git = "https://github.com/autonomys/sppark", rev = "b2a181eb99c8200f1a604f04122551ea39fbf63f" }
 ss58-registry = "1.51.0"
@@ -287,11 +287,11 @@ subspace-test-runtime = { version = "0.1.0", path = "test/subspace-test-runtime"
 subspace-test-service = { version = "0.1.0", path = "test/subspace-test-service" }
 subspace-verification = { version = "0.1.0", path = "crates/subspace-verification", default-features = false }
 substrate-bip39 = "=0.6.0"
-substrate-build-script-utils = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df" }
-substrate-frame-rpc-system = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df" }
-substrate-prometheus-endpoint = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df" }
-substrate-test-client = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df" }
-substrate-wasm-builder = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df" }
+substrate-build-script-utils = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
+substrate-frame-rpc-system = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
+substrate-prometheus-endpoint = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
+substrate-test-client = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
+substrate-wasm-builder = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
 supports-color = "3.0.1"
 tempfile = "3.13.0"
 thiserror = { version = "2.0.0", default-features = false }
@@ -390,51 +390,51 @@ lto = "fat"
 # Reason: We need to patch substrate dependency of frontier to our fork
 # TODO: Remove if/when we are using upstream substrate instead of fork
 [patch."https://github.com/paritytech/polkadot-sdk.git"]
-cumulus-primitives-storage-weight-reclaim = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df" }
-frame-benchmarking = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df" }
-frame-support = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df" }
-frame-system = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df" }
-sc-block-builder = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df" }
-sc-client-db = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df" }
-sc-consensus = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df" }
-sc-consensus-slots = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df" }
-sc-client-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df" }
-sc-network = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df" }
-sc-network-common = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df" }
-sc-network-sync = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df" }
-sc-rpc = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df" }
-sc-service = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df" }
-sc-telemetry = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df" }
-sc-transaction-pool = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df" }
-sc-transaction-pool-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df" }
-sc-utils = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df" }
-sp-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df" }
-sp-application-crypto = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df" }
-sp-arithmetic = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df" }
-sp-block-builder = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df" }
-sp-blockchain = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df" }
-sp-consensus = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df" }
-sp-consensus-slots = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df" }
-sp-core = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df" }
-sp-crypto-hashing = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df" }
-sp-database = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df" }
-sp-debug-derive = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df" }
-sp-externalities = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df" }
-sp-inherents = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df" }
-sp-io = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df" }
-sp-keystore = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df" }
-sp-runtime = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df" }
-sp-runtime-interface = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df" }
-sp-state-machine = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df" }
-sp-std = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df" }
-sp-storage = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df" }
-sp-timestamp = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df" }
-sp-trie = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df" }
-sp-version = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df" }
-sp-weights = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df" }
-staging-xcm = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df" }
-substrate-prometheus-endpoint = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df" }
-xcm-procedural = { git = "https://github.com/subspace/polkadot-sdk", rev = "2eb28846ad471aa33bf9a532e06b42835bec27df" }
+cumulus-primitives-storage-weight-reclaim = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
+frame-benchmarking = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
+frame-support = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
+frame-system = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
+sc-block-builder = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
+sc-client-db = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
+sc-consensus = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
+sc-consensus-slots = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
+sc-client-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
+sc-network = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
+sc-network-common = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
+sc-network-sync = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
+sc-rpc = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
+sc-service = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
+sc-telemetry = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
+sc-transaction-pool = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
+sc-transaction-pool-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
+sc-utils = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
+sp-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
+sp-application-crypto = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
+sp-arithmetic = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
+sp-block-builder = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
+sp-blockchain = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
+sp-consensus = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
+sp-consensus-slots = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
+sp-core = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
+sp-crypto-hashing = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
+sp-database = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
+sp-debug-derive = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
+sp-externalities = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
+sp-inherents = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
+sp-io = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
+sp-keystore = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
+sp-runtime = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
+sp-runtime-interface = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
+sp-state-machine = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
+sp-std = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
+sp-storage = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
+sp-timestamp = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
+sp-trie = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
+sp-version = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
+sp-weights = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
+staging-xcm = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
+substrate-prometheus-endpoint = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
+xcm-procedural = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
 
 [patch."https://github.com/subspace/polkadot-sdk.git"]
 # De-duplicate extra copy that comes from Substrate repo

--- a/crates/pallet-domains/src/block_tree.rs
+++ b/crates/pallet-domains/src/block_tree.rs
@@ -1085,7 +1085,7 @@ mod tests {
             // Construct a future receipt
             let mut future_receipt = next_receipt.clone();
             future_receipt.set_domain_block_number(head_receipt_number + 2);
-            future_receipt.set_consensus_block_number(head_receipt_number as u32 + 2);
+            future_receipt.set_consensus_block_number(head_receipt_number + 2);
             ExecutionInbox::<Test>::insert(
                 (
                     domain_id,
@@ -1199,7 +1199,7 @@ mod tests {
             // Construct a future receipt
             let mut future_receipt = next_receipt.clone();
             future_receipt.set_domain_block_number(head_receipt_number + 1);
-            future_receipt.set_consensus_block_number(head_receipt_number as u32 + 1);
+            future_receipt.set_consensus_block_number(head_receipt_number + 1);
 
             ExecutionInbox::<Test>::insert(
                 (

--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -1,7 +1,7 @@
 //! Pallet Domains
 
 #![cfg_attr(not(feature = "std"), no_std)]
-#![feature(array_windows, variant_count)]
+#![cfg_attr(any(feature = "fuzz", test), feature(variant_count))]
 
 #[cfg(feature = "runtime-benchmarks")]
 mod benchmarking;

--- a/crates/pallet-rewards/src/lib.rs
+++ b/crates/pallet-rewards/src/lib.rs
@@ -3,7 +3,6 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![forbid(unsafe_code)]
 #![warn(rust_2018_idioms)]
-#![feature(array_windows, try_blocks)]
 
 #[cfg(feature = "runtime-benchmarks")]
 mod benchmarking;

--- a/crates/pallet-subspace/src/lib.rs
+++ b/crates/pallet-subspace/src/lib.rs
@@ -1,6 +1,6 @@
 #![doc = include_str!("../README.md")]
 #![cfg_attr(not(feature = "std"), no_std)]
-#![feature(assert_matches, portable_simd)]
+#![cfg_attr(test, feature(portable_simd))]
 #![warn(unused_must_use, unsafe_code, unused_variables)]
 
 #[cfg(not(feature = "std"))]

--- a/crates/pallet-subspace/src/mock.rs
+++ b/crates/pallet-subspace/src/mock.rs
@@ -200,10 +200,9 @@ pub fn progress_to_block(
     n: u64,
     reward_address: <Test as frame_system::Config>::AccountId,
 ) {
-    let mut slot = u64::from(Subspace::current_slot()) + 1;
-    for i in System::block_number() + 1..=n {
+    let start_slot = u64::from(Subspace::current_slot()) + 1;
+    for (slot, i) in (start_slot..).zip(System::block_number() + 1..=n) {
         go_to_block(keypair, i, slot, reward_address);
-        slot += 1;
     }
 }
 

--- a/crates/pallet-subspace/src/tests.rs
+++ b/crates/pallet-subspace/src/tests.rs
@@ -21,7 +21,7 @@ use sp_runtime::traits::BlockNumberProvider;
 use sp_runtime::transaction_validity::{
     InvalidTransaction, TransactionPriority, TransactionSource, ValidTransaction,
 };
-use std::assert_matches::assert_matches;
+use std::assert_matches;
 use std::collections::BTreeMap;
 use std::num::NonZeroU32;
 use std::sync::{Arc, Mutex};

--- a/crates/sc-consensus-subspace/src/lib.rs
+++ b/crates/sc-consensus-subspace/src/lib.rs
@@ -6,7 +6,6 @@
 //!
 //! All of the modules here are crucial for consensus, open each module for specific details.
 
-#![feature(try_blocks)]
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
 

--- a/crates/sp-domains-fraud-proof/src/tests.rs
+++ b/crates/sp-domains-fraud-proof/src/tests.rs
@@ -51,8 +51,7 @@ async fn benchmark_bundle_with_evm_tx(
 
     let other_accounts_balance = alice_balance / (tx_to_create as u128 + 2);
 
-    let mut alice_nonce = alice.account_nonce();
-    for account_info in &account_infos {
+    for (alice_nonce, account_info) in (alice.account_nonce()..).zip(&account_infos) {
         let alice_balance_transfer_extrinsic = alice.construct_extrinsic(
             alice_nonce,
             pallet_balances::Call::transfer_allow_death {
@@ -64,7 +63,6 @@ async fn benchmark_bundle_with_evm_tx(
             .send_extrinsic(alice_balance_transfer_extrinsic)
             .await
             .expect("Failed to send extrinsic");
-        alice_nonce += 1;
     }
 
     const TX_TYPES: u32 = 4;

--- a/crates/subspace-archiving/src/archiver.rs
+++ b/crates/subspace-archiving/src/archiver.rs
@@ -487,9 +487,7 @@ impl Archiver {
         }
 
         // Check if there is an excess of data that should be spilled over into the next segment
-        let spill_over = segment_size
-            .checked_sub(RecordedHistorySegment::SIZE)
-            .unwrap_or_default();
+        let spill_over = segment_size.saturating_sub(RecordedHistorySegment::SIZE);
 
         if spill_over > 0 {
             let items = segment.items_mut();

--- a/crates/subspace-archiving/tests/integration/archiver.rs
+++ b/crates/subspace-archiving/tests/integration/archiver.rs
@@ -2,10 +2,9 @@ use parity_scale_codec::{Compact, CompactLen, Decode, Encode};
 use rand::{Rng, thread_rng};
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
-use std::assert_matches;
 use std::io::Write;
-use std::iter;
 use std::num::NonZeroUsize;
+use std::{assert_matches, iter};
 use subspace_archiving::archiver::{Archiver, ArchiverInstantiationError, SegmentItem};
 use subspace_core_primitives::hashes::Blake3Hash;
 use subspace_core_primitives::objects::{BlockObject, BlockObjectMapping, GlobalObject};

--- a/crates/subspace-archiving/tests/integration/archiver.rs
+++ b/crates/subspace-archiving/tests/integration/archiver.rs
@@ -2,7 +2,7 @@ use parity_scale_codec::{Compact, CompactLen, Decode, Encode};
 use rand::{Rng, thread_rng};
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
-use std::assert_matches::assert_matches;
+use std::assert_matches;
 use std::io::Write;
 use std::iter;
 use std::num::NonZeroUsize;

--- a/crates/subspace-archiving/tests/integration/main.rs
+++ b/crates/subspace-archiving/tests/integration/main.rs
@@ -1,5 +1,3 @@
-#![feature(assert_matches)]
-
 mod archiver;
 mod piece_reconstruction;
 mod reconstructor;

--- a/crates/subspace-archiving/tests/integration/reconstructor.rs
+++ b/crates/subspace-archiving/tests/integration/reconstructor.rs
@@ -1,7 +1,6 @@
 use rand::{Rng, thread_rng};
-use std::assert_matches;
-use std::iter;
 use std::num::NonZeroUsize;
+use std::{assert_matches, iter};
 use subspace_archiving::archiver::Archiver;
 use subspace_archiving::reconstructor::{Reconstructor, ReconstructorError};
 use subspace_core_primitives::objects::BlockObjectMapping;

--- a/crates/subspace-archiving/tests/integration/reconstructor.rs
+++ b/crates/subspace-archiving/tests/integration/reconstructor.rs
@@ -1,5 +1,5 @@
 use rand::{Rng, thread_rng};
-use std::assert_matches::assert_matches;
+use std::assert_matches;
 use std::iter;
 use std::num::NonZeroUsize;
 use subspace_archiving::archiver::Archiver;

--- a/crates/subspace-bootstrap-node/src/main.rs
+++ b/crates/subspace-bootstrap-node/src/main.rs
@@ -1,7 +1,5 @@
 //! Simple bootstrap node implementation
 
-#![feature(type_changing_struct_update)]
-
 use clap::Parser;
 use futures::FutureExt;
 use futures::channel::oneshot;

--- a/crates/subspace-core-primitives/src/lib.rs
+++ b/crates/subspace-core-primitives/src/lib.rs
@@ -3,7 +3,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![warn(rust_2018_idioms, missing_docs)]
 #![cfg_attr(feature = "std", warn(missing_debug_implementations))]
-#![feature(const_trait_impl, const_try, portable_simd, step_trait)]
+#![feature(const_trait_impl, portable_simd, step_trait)]
 
 pub mod checksum;
 pub mod hashes;
@@ -259,7 +259,6 @@ impl ScalarBytes {
 }
 
 #[expect(clippy::manual_div_ceil)]
-#[expect(clippy::double_parens)]
 mod private_u256 {
     //! This module is needed to scope clippy allows
     use parity_scale_codec::{Decode, Encode};

--- a/crates/subspace-farmer-components/src/lib.rs
+++ b/crates/subspace-farmer-components/src/lib.rs
@@ -2,12 +2,7 @@
 //!
 //! These components are used to implement farmer itself, but can also be used independently if necessary.
 
-#![feature(
-    const_trait_impl,
-    never_type,
-    portable_simd,
-    try_blocks
-)]
+#![feature(const_trait_impl, never_type, portable_simd, try_blocks)]
 #![warn(rust_2018_idioms, missing_debug_implementations, missing_docs)]
 
 pub mod auditing;

--- a/crates/subspace-farmer-components/src/lib.rs
+++ b/crates/subspace-farmer-components/src/lib.rs
@@ -4,9 +4,6 @@
 
 #![feature(
     const_trait_impl,
-    exact_size_is_empty,
-    int_roundings,
-    iter_collect_into,
     never_type,
     portable_simd,
     try_blocks

--- a/crates/subspace-farmer-components/src/proving.rs
+++ b/crates/subspace-farmer-components/src/proving.rs
@@ -259,7 +259,8 @@ where
             );
             let sector_record_chunks = sector_record_chunks_fut
                 .now_or_never()
-                .expect("Sync reader; qed")?;
+                .expect("Sync reader; qed")
+                .map_err(ProvingError::RecordReadingError)?;
 
             let chunk = ScalarBytes::from(
                 sector_record_chunks
@@ -274,7 +275,8 @@ where
                 .map_err(|error| ReadingError::FailedToErasureDecodeRecord {
                     piece_offset,
                     error,
-                })?;
+                })
+                .map_err(ProvingError::RecordReadingError)?;
             drop(sector_record_chunks);
 
             // NOTE: We do not check plot consistency using checksum because it is more
@@ -286,7 +288,8 @@ where
             );
             let record_metadata = record_metadata_fut
                 .now_or_never()
-                .expect("Sync reader; qed")?;
+                .expect("Sync reader; qed")
+                .map_err(ProvingError::RecordReadingError)?;
 
             let proof_of_space = pos_table.find_proof(self.s_bucket.into()).expect(
                 "Quality exists for this s-bucket, otherwise it wouldn't be a winning chunk; qed",

--- a/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
@@ -1,5 +1,3 @@
-#![feature(type_changing_struct_update)]
-
 mod commands;
 
 use clap::Parser;

--- a/crates/subspace-farmer/src/disk_piece_cache/tests.rs
+++ b/crates/subspace-farmer/src/disk_piece_cache/tests.rs
@@ -1,6 +1,6 @@
 use crate::disk_piece_cache::{DiskPieceCache, DiskPieceCacheError, PieceCacheOffset};
 use rand::prelude::*;
-use std::assert_matches::assert_matches;
+use std::assert_matches;
 use std::num::NonZeroU32;
 use subspace_core_primitives::pieces::{Piece, PieceIndex};
 use tempfile::tempdir;

--- a/crates/subspace-farmer/src/lib.rs
+++ b/crates/subspace-farmer/src/lib.rs
@@ -1,16 +1,10 @@
 #![feature(
-    array_windows,
-    assert_matches,
     exact_size_is_empty,
     fmt_helpers_for_derive,
     future_join,
-    impl_trait_in_assoc_type,
-    int_roundings,
-    iter_collect_into,
     never_type,
     trait_alias,
     try_blocks,
-    type_alias_impl_trait,
     type_changing_struct_update
 )]
 #![warn(rust_2018_idioms, missing_debug_implementations, missing_docs)]

--- a/crates/subspace-farmer/src/lib.rs
+++ b/crates/subspace-farmer/src/lib.rs
@@ -2,10 +2,8 @@
     exact_size_is_empty,
     fmt_helpers_for_derive,
     future_join,
-    never_type,
-    trait_alias,
-    try_blocks,
-    type_changing_struct_update
+    iter_collect_into,
+    try_blocks
 )]
 #![warn(rust_2018_idioms, missing_debug_implementations, missing_docs)]
 

--- a/crates/subspace-farmer/src/single_disk_farm/farming.rs
+++ b/crates/subspace-farmer/src/single_disk_farm/farming.rs
@@ -265,7 +265,7 @@ where
         global_mutex.lock().await;
 
         let mut problematic_sectors = Vec::new();
-        let result: Result<(), FarmingError> = try {
+        let result = try {
             let start = Instant::now();
             let sectors_metadata = sectors_metadata.read().await;
 
@@ -288,7 +288,8 @@ where
                         read_sector_record_chunks_mode,
                         table_generator: &table_generator,
                     })
-                })?
+                })
+                .map_err(FarmingError::LowLevelAuditing)?
             };
 
             sectors_solutions.sort_by(|a, b| {

--- a/crates/subspace-farmer/src/single_disk_farm/farming.rs
+++ b/crates/subspace-farmer/src/single_disk_farm/farming.rs
@@ -274,22 +274,23 @@ where
             let mut sectors_solutions = {
                 let sectors_being_modified = &*sectors_being_modified.read().await;
 
-                thread_pool.install(|| {
-                    let _span_guard = span.enter();
+                thread_pool
+                    .install(|| {
+                        let _span_guard = span.enter();
 
-                    plot_audit.audit(PlotAuditOptions::<PosTable> {
-                        public_key: &public_key,
-                        reward_address: &reward_address,
-                        slot_info,
-                        sectors_metadata: &sectors_metadata,
-                        kzg: &kzg,
-                        erasure_coding: &erasure_coding,
-                        sectors_being_modified,
-                        read_sector_record_chunks_mode,
-                        table_generator: &table_generator,
+                        plot_audit.audit(PlotAuditOptions::<PosTable> {
+                            public_key: &public_key,
+                            reward_address: &reward_address,
+                            slot_info,
+                            sectors_metadata: &sectors_metadata,
+                            kzg: &kzg,
+                            erasure_coding: &erasure_coding,
+                            sectors_being_modified,
+                            read_sector_record_chunks_mode,
+                            table_generator: &table_generator,
+                        })
                     })
-                })
-                .map_err(FarmingError::LowLevelAuditing)?
+                    .map_err(FarmingError::LowLevelAuditing)?
             };
 
             sectors_solutions.sort_by(|a, b| {

--- a/crates/subspace-farmer/src/single_disk_farm/plot_cache/tests.rs
+++ b/crates/subspace-farmer/src/single_disk_farm/plot_cache/tests.rs
@@ -2,7 +2,7 @@ use crate::farm::MaybePieceStoredResult;
 use crate::single_disk_farm::direct_io_file::{DISK_SECTOR_SIZE, DirectIoFile};
 use crate::single_disk_farm::plot_cache::DiskPlotCache;
 use rand::prelude::*;
-use std::assert_matches::assert_matches;
+use std::assert_matches;
 use std::num::NonZeroU64;
 use std::sync::Arc;
 use subspace_core_primitives::pieces::{Piece, PieceIndex, Record};

--- a/crates/subspace-networking/examples/networking.rs
+++ b/crates/subspace-networking/examples/networking.rs
@@ -1,5 +1,3 @@
-#![feature(type_changing_struct_update)]
-
 use futures::StreamExt;
 use futures::channel::oneshot;
 use libp2p::gossipsub::Sha256Topic;

--- a/crates/subspace-networking/src/constructor/transport.rs
+++ b/crates/subspace-networking/src/constructor/transport.rs
@@ -100,15 +100,11 @@ where
         let mut addr_iter = addr.iter();
 
         match addr_iter.next() {
-            Some(Protocol::Ip4(a))
-                if !(self.allow_non_global_addresses || a.is_global()) =>
-            {
+            Some(Protocol::Ip4(a)) if !(self.allow_non_global_addresses || a.is_global()) => {
                 debug!(?a, "Not dialing non global IP address.",);
                 return Err(TransportError::MultiaddrNotSupported(addr));
             }
-            Some(Protocol::Ip6(a))
-                if !(self.allow_non_global_addresses || a.is_global()) =>
-            {
+            Some(Protocol::Ip6(a)) if !(self.allow_non_global_addresses || a.is_global()) => {
                 debug!(?a, "Not dialing non global IP address.");
                 return Err(TransportError::MultiaddrNotSupported(addr));
             }

--- a/crates/subspace-networking/src/constructor/transport.rs
+++ b/crates/subspace-networking/src/constructor/transport.rs
@@ -100,17 +100,17 @@ where
         let mut addr_iter = addr.iter();
 
         match addr_iter.next() {
-            Some(Protocol::Ip4(a)) => {
-                if !(self.allow_non_global_addresses || a.is_global()) {
-                    debug!(?a, "Not dialing non global IP address.",);
-                    return Err(TransportError::MultiaddrNotSupported(addr));
-                }
+            Some(Protocol::Ip4(a))
+                if !(self.allow_non_global_addresses || a.is_global()) =>
+            {
+                debug!(?a, "Not dialing non global IP address.",);
+                return Err(TransportError::MultiaddrNotSupported(addr));
             }
-            Some(Protocol::Ip6(a)) => {
-                if !(self.allow_non_global_addresses || a.is_global()) {
-                    debug!(?a, "Not dialing non global IP address.");
-                    return Err(TransportError::MultiaddrNotSupported(addr));
-                }
+            Some(Protocol::Ip6(a))
+                if !(self.allow_non_global_addresses || a.is_global()) =>
+            {
+                debug!(?a, "Not dialing non global IP address.");
+                return Err(TransportError::MultiaddrNotSupported(addr));
             }
             _ => {
                 // TODO: This will not catch DNS records pointing to private addresses

--- a/crates/subspace-networking/src/lib.rs
+++ b/crates/subspace-networking/src/lib.rs
@@ -1,11 +1,7 @@
 //! Networking functionality of Subspace Network, primarily used for DSN (Distributed Storage
 //! Network).
 
-#![feature(
-    exact_size_is_empty,
-    ip,
-    trivial_bounds
-)]
+#![feature(exact_size_is_empty, ip, trivial_bounds)]
 #![warn(missing_docs)]
 
 mod behavior;

--- a/crates/subspace-networking/src/lib.rs
+++ b/crates/subspace-networking/src/lib.rs
@@ -3,10 +3,8 @@
 
 #![feature(
     exact_size_is_empty,
-    impl_trait_in_assoc_type,
     ip,
-    trivial_bounds,
-    try_blocks
+    trivial_bounds
 )]
 #![warn(missing_docs)]
 

--- a/crates/subspace-networking/src/utils/piece_provider.rs
+++ b/crates/subspace-networking/src/utils/piece_provider.rs
@@ -410,7 +410,7 @@ impl KademliaWrapper {
             })
             .collect::<Vec<_>>();
 
-        closest_peers.sort_unstable_by(|a, b| a.0.cmp(&b.0));
+        closest_peers.sort_unstable_by_key(|a| a.0);
         closest_peers
             .into_iter()
             .map(|(_distance, peer_id, addresses)| (peer_id, addresses))

--- a/crates/subspace-proof-of-space/src/chiapos/tables.rs
+++ b/crates/subspace-proof-of-space/src/chiapos/tables.rs
@@ -205,61 +205,83 @@ where
                     .filter(move |&&(_position, y)| y.first_k_bits() == first_k_challenge_bits)
             })
             .map(move |&(position, _y)| {
-                let mut proof = [0u8; 64 * K as usize / 8];
-
                 // SAFETY: Internally generated positions that come from the parent table
-                unsafe { self.table_7.position(position) }
-                    .into_iter()
-                    .flat_map(|position| {
-                        // SAFETY: Internally generated positions that come from the parent table
-                        unsafe { self.table_6.position(position) }
-                    })
-                    .flat_map(|position| {
-                        // SAFETY: Internally generated positions that come from the parent table
-                        unsafe { self.table_5.position(position) }
-                    })
-                    .flat_map(|position| {
-                        // SAFETY: Internally generated positions that come from the parent table
-                        unsafe { self.table_4.position(position) }
-                    })
-                    .flat_map(|position| {
-                        // SAFETY: Internally generated positions that come from the parent table
-                        unsafe { self.table_3.position(position) }
-                    })
-                    .flat_map(|position| {
-                        // SAFETY: Internally generated positions that come from the parent table
-                        unsafe { self.table_2.position(position) }
-                    })
-                    .map(|position| {
-                        // X matches position
-                        X::from(u32::from(position))
-                    })
-                    .enumerate()
-                    .for_each(|(offset, x)| {
-                        let x_offset_in_bits = usize::from(K) * offset;
-                        // Collect bytes where bits of `x` will be written
-                        let proof_bytes = &mut proof[x_offset_in_bits / u8::BITS as usize..]
-                            [..(x_offset_in_bits % u8::BITS as usize + usize::from(K))
-                                .div_ceil(u8::BITS as usize)];
+                let table_6_proof_targets = unsafe { self.table_7.position(position) };
 
-                        // Bits of `x` already shifted to the correct location as they will appear
-                        // in `proof`
-                        let x_shifted = u32::from(x)
-                            << (u32::BITS as usize
-                                - (usize::from(K) + x_offset_in_bits % u8::BITS as usize));
-
-                        // Copy `x` bits into proof
-                        x_shifted
-                            .to_be_bytes()
-                            .iter()
-                            .zip(proof_bytes)
-                            .for_each(|(from, to)| {
-                                *to |= from;
-                            });
-                    });
-
-                proof
+                Self::find_proof_internal(
+                    &self.table_2,
+                    &self.table_3,
+                    &self.table_4,
+                    &self.table_5,
+                    &self.table_6,
+                    table_6_proof_targets,
+                )
             })
+    }
+
+    #[cfg(feature = "alloc")]
+    #[inline(always)]
+    fn find_proof_internal(
+        table_2: &PrunedTable<K, 2>,
+        table_3: &PrunedTable<K, 3>,
+        table_4: &PrunedTable<K, 4>,
+        table_5: &PrunedTable<K, 5>,
+        table_6: &PrunedTable<K, 6>,
+        table_6_proof_targets: [Position; 2],
+    ) -> [u8; 64 * K as usize / 8] {
+        let mut proof = [0u8; 64 * K as usize / 8];
+
+        table_6_proof_targets
+            .into_iter()
+            .flat_map(|position| {
+                // SAFETY: Internally generated positions that come from the parent table
+                unsafe { table_6.position(position) }
+            })
+            .flat_map(|position| {
+                // SAFETY: Internally generated positions that come from the parent table
+                unsafe { table_5.position(position) }
+            })
+            .flat_map(|position| {
+                // SAFETY: Internally generated positions that come from the parent table
+                unsafe { table_4.position(position) }
+            })
+            .flat_map(|position| {
+                // SAFETY: Internally generated positions that come from the parent table
+                unsafe { table_3.position(position) }
+            })
+            .flat_map(|position| {
+                // SAFETY: Internally generated positions that come from the parent table
+                unsafe { table_2.position(position) }
+            })
+            .map(|position| {
+                // X matches position
+                X::from(u32::from(position))
+            })
+            .enumerate()
+            .for_each(|(offset, x)| {
+                let x_offset_in_bits = usize::from(K) * offset;
+                // Collect bytes where bits of `x` will be written
+                let proof_bytes = &mut proof[x_offset_in_bits / u8::BITS as usize..]
+                    [..(x_offset_in_bits % u8::BITS as usize + usize::from(K))
+                        .div_ceil(u8::BITS as usize)];
+
+                // Bits of `x` already shifted to the correct location as they will appear
+                // in `proof`
+                let x_shifted = u32::from(x)
+                    << (u32::BITS as usize
+                        - (usize::from(K) + x_offset_in_bits % u8::BITS as usize));
+
+                // Copy `x` bits into proof
+                x_shifted
+                    .to_be_bytes()
+                    .iter()
+                    .zip(proof_bytes)
+                    .for_each(|(from, to)| {
+                        *to |= from;
+                    });
+            });
+
+        proof
     }
 
     /// Access table 7's buckets for testing

--- a/crates/subspace-proof-of-space/src/lib.rs
+++ b/crates/subspace-proof-of-space/src/lib.rs
@@ -3,15 +3,9 @@
 #![expect(incomplete_features, reason = "generic_const_exprs")]
 #![warn(rust_2018_idioms, missing_debug_implementations, missing_docs)]
 #![feature(const_trait_impl, generic_const_exprs, step_trait)]
-#![cfg_attr(
-    feature = "alloc",
-    feature(get_mut_unchecked, maybe_uninit_fill)
-)]
+#![cfg_attr(feature = "alloc", feature(get_mut_unchecked, maybe_uninit_fill))]
 #![cfg_attr(any(feature = "alloc", test), feature(portable_simd))]
-#![cfg_attr(
-    feature = "parallel",
-    feature(exact_size_is_empty, sync_unsafe_cell)
-)]
+#![cfg_attr(feature = "parallel", feature(exact_size_is_empty, sync_unsafe_cell))]
 
 pub mod chia;
 pub mod chiapos;

--- a/crates/subspace-proof-of-space/src/lib.rs
+++ b/crates/subspace-proof-of-space/src/lib.rs
@@ -2,19 +2,15 @@
 #![no_std]
 #![expect(incomplete_features, reason = "generic_const_exprs")]
 #![warn(rust_2018_idioms, missing_debug_implementations, missing_docs)]
-#![feature(
-    array_windows,
-    const_trait_impl,
-    exact_size_is_empty,
-    generic_const_exprs,
-    get_mut_unchecked,
-    maybe_uninit_fill,
-    maybe_uninit_slice,
-    maybe_uninit_write_slice,
-    portable_simd,
-    step_trait,
-    sync_unsafe_cell,
-    vec_into_raw_parts
+#![feature(const_trait_impl, generic_const_exprs, step_trait)]
+#![cfg_attr(
+    feature = "alloc",
+    feature(get_mut_unchecked, maybe_uninit_fill)
+)]
+#![cfg_attr(any(feature = "alloc", test), feature(portable_simd))]
+#![cfg_attr(
+    feature = "parallel",
+    feature(exact_size_is_empty, sync_unsafe_cell)
 )]
 
 pub mod chia;

--- a/crates/subspace-service/src/lib.rs
+++ b/crates/subspace-service/src/lib.rs
@@ -1,10 +1,5 @@
 //! Service and ServiceFactory implementation. Specialized wrapper over substrate service.
-#![feature(
-    impl_trait_in_assoc_type,
-    int_roundings,
-    type_alias_impl_trait,
-    type_changing_struct_update
-)]
+#![feature(type_changing_struct_update)]
 
 pub mod config;
 pub mod dsn;
@@ -1309,6 +1304,7 @@ where
             let transaction_pool = transaction_pool.clone();
             let backend = backend.clone();
 
+            #[allow(clippy::result_large_err)]
             Box::new(move |subscription_executor| {
                 let deps = rpc::FullDeps {
                     client: client.clone(),
@@ -1330,6 +1326,7 @@ where
                 rpc::create_full(deps).map_err(Into::into)
             })
         } else {
+            #[allow(clippy::result_large_err)]
             Box::new(|_| Ok(RpcModule::new(())))
         },
         backend: backend.clone(),

--- a/crates/subspace-service/src/lib.rs
+++ b/crates/subspace-service/src/lib.rs
@@ -1,5 +1,4 @@
 //! Service and ServiceFactory implementation. Specialized wrapper over substrate service.
-#![feature(type_changing_struct_update)]
 
 pub mod config;
 pub mod dsn;

--- a/crates/subspace-service/src/mmr/sync.rs
+++ b/crates/subspace-service/src/mmr/sync.rs
@@ -76,8 +76,7 @@ impl<OS: OffchainStorage> MMRStoreReadOps<NodeOf> for OffchainMmrStorage<OS> {
 
 impl<OS: OffchainStorage> MMRStoreWriteOps<NodeOf> for OffchainMmrStorage<OS> {
     fn append(&mut self, pos: u64, elems: Vec<NodeOf>) -> mmr_lib::Result<()> {
-        let mut current_pos = pos;
-        for elem in elems {
+        for (current_pos, elem) in (pos..).zip(elems) {
             let data = elem.encode();
 
             let canon_key = get_offchain_key(current_pos);
@@ -86,8 +85,6 @@ impl<OS: OffchainStorage> MMRStoreWriteOps<NodeOf> for OffchainMmrStorage<OS> {
                 &canon_key,
                 &data,
             );
-
-            current_pos += 1;
         }
 
         Ok(())

--- a/crates/subspace-service/src/sync_from_dsn/snap_sync.rs
+++ b/crates/subspace-service/src/sync_from_dsn/snap_sync.rs
@@ -569,7 +569,7 @@ where
 
             debug!(?tried_peers, "Sync peers: {}", connected_full_peers.len());
 
-            let active_peers_set = HashSet::from_iter(connected_full_peers.into_iter());
+            let active_peers_set = HashSet::from_iter(connected_full_peers);
 
             if let Some(peer_id) = active_peers_set.difference(&tried_peers).next().cloned() {
                 break peer_id;

--- a/crates/subspace-verification/src/lib.rs
+++ b/crates/subspace-verification/src/lib.rs
@@ -1,7 +1,7 @@
 //! Verification primitives for Subspace.
 #![forbid(unsafe_code)]
 #![warn(rust_2018_idioms, missing_debug_implementations, missing_docs)]
-#![feature(portable_simd)]
+#![cfg_attr(feature = "kzg", feature(portable_simd))]
 // `generic_const_exprs` is an incomplete feature
 #![allow(incomplete_features)]
 // TODO: This feature is not actually used in this crate, but is added as a workaround for

--- a/domains/client/domain-operator/src/lib.rs
+++ b/domains/client/domain-operator/src/lib.rs
@@ -58,6 +58,7 @@
 //! [`BlockBuilder`]: ../domain_block_builder/struct.BlockBuilder.html
 //! [`FraudProof`]: ../sp_domains/struct.FraudProof.html
 
+#![cfg_attr(test, feature(more_qualified_paths))]
 
 mod aux_schema;
 mod bundle_processor;

--- a/domains/client/domain-operator/src/lib.rs
+++ b/domains/client/domain-operator/src/lib.rs
@@ -58,7 +58,6 @@
 //! [`BlockBuilder`]: ../domain_block_builder/struct.BlockBuilder.html
 //! [`FraudProof`]: ../sp_domains/struct.FraudProof.html
 
-#![feature(array_windows, assert_matches, box_into_inner, more_qualified_paths)]
 
 mod aux_schema;
 mod bundle_processor;

--- a/domains/client/domain-operator/src/snap_sync.rs
+++ b/domains/client/domain-operator/src/snap_sync.rs
@@ -502,7 +502,7 @@ where
             "Sync peers: {:?}", connected_full_peers
         );
 
-        let active_peers_set = HashSet::from_iter(connected_full_peers.into_iter());
+        let active_peers_set = HashSet::from_iter(connected_full_peers);
 
         if let Some(peer_id) = active_peers_set.difference(tried_peers).next().cloned() {
             tried_peers.insert(peer_id);

--- a/domains/client/domain-operator/src/tests.rs
+++ b/domains/client/domain-operator/src/tests.rs
@@ -68,7 +68,7 @@ use sp_state_machine::backend::AsTrieBackend;
 use sp_subspace_mmr::ConsensusChainMmrLeafProof;
 use sp_transaction_pool::runtime_api::TaggedTransactionQueue;
 use sp_weights::Weight;
-use std::assert_matches::assert_matches;
+use std::assert_matches;
 use std::collections::{BTreeMap, VecDeque};
 use std::future::IntoFuture;
 use std::sync::Arc;

--- a/domains/pallets/evm-tracker/src/create_contract.rs
+++ b/domains/pallets/evm-tracker/src/create_contract.rs
@@ -85,26 +85,20 @@ where
                 pallet_ethereum::Call::transact {
                     transaction: EthereumTransaction::Legacy(transaction),
                     ..
-                } => {
-                    if transaction.action == TransactionAction::Create {
-                        return (true, call_count);
-                    }
+                } if transaction.action == TransactionAction::Create => {
+                    return (true, call_count);
                 }
                 pallet_ethereum::Call::transact {
                     transaction: EthereumTransaction::EIP2930(transaction),
                     ..
-                } => {
-                    if transaction.action == TransactionAction::Create {
-                        return (true, call_count);
-                    }
+                } if transaction.action == TransactionAction::Create => {
+                    return (true, call_count);
                 }
                 pallet_ethereum::Call::transact {
                     transaction: EthereumTransaction::EIP1559(transaction),
                     ..
-                } => {
-                    if transaction.action == TransactionAction::Create {
-                        return (true, call_count);
-                    }
+                } if transaction.action == TransactionAction::Create => {
+                    return (true, call_count);
                 }
                 // Inconclusive, other calls might create contracts.
                 _ => {}

--- a/domains/pallets/messenger/src/lib.rs
+++ b/domains/pallets/messenger/src/lib.rs
@@ -18,7 +18,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![forbid(unsafe_code)]
 #![warn(rust_2018_idioms)]
-#![feature(variant_count, if_let_guard)]
+#![cfg_attr(test, feature(variant_count))]
 
 #[cfg(feature = "runtime-benchmarks")]
 mod benchmarking;

--- a/domains/service/src/domain.rs
+++ b/domains/service/src/domain.rs
@@ -449,6 +449,7 @@ where
 
         let spawn_essential = task_manager.spawn_essential_handle();
         let rpc_deps = provider.deps(deps)?;
+        #[allow(clippy::result_large_err)]
         Box::new(move |subscription_task_executor| {
             let spawn_essential = spawn_essential.clone();
             provider

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2025-10-19"
+channel = "nightly-2026-04-11"
 components = ["rust-src"]
 targets = ["wasm32v1-none"]
 profile = "default"

--- a/shared/subspace-data-retrieval/src/lib.rs
+++ b/shared/subspace-data-retrieval/src/lib.rs
@@ -1,6 +1,6 @@
 //! Fetching data from the archived history of the Subspace Distributed Storage Network.
 
-#![feature(exact_size_is_empty, trusted_len)]
+#![feature(exact_size_is_empty)]
 
 pub mod object_fetcher;
 pub mod piece_fetcher;

--- a/shared/subspace-proof-of-space-gpu/src/cuda.rs
+++ b/shared/subspace-proof-of-space-gpu/src/cuda.rs
@@ -131,8 +131,7 @@ impl CudaDevice {
             .zip(chunks_scratch_gpu)
             .collect::<Vec<_>>();
 
-        chunks_scratch
-            .sort_unstable_by(|(a_out_index, _), (b_out_index, _)| a_out_index.cmp(b_out_index));
+        chunks_scratch.sort_unstable_by_key(|(a_out_index, _)| *a_out_index);
 
         // We don't need all the proofs
         chunks_scratch.truncate(proof_count.min(Record::NUM_CHUNKS));

--- a/shared/subspace-proof-of-space-gpu/src/rocm.rs
+++ b/shared/subspace-proof-of-space-gpu/src/rocm.rs
@@ -124,8 +124,7 @@ impl RocmDevice {
             .zip(chunks_scratch_gpu)
             .collect::<Vec<_>>();
 
-        chunks_scratch
-            .sort_unstable_by(|(a_out_index, _), (b_out_index, _)| a_out_index.cmp(b_out_index));
+        chunks_scratch.sort_unstable_by_key(|(a_out_index, _)| *a_out_index);
 
         // We don't need all the proofs
         chunks_scratch.truncate(proof_count.min(Record::NUM_CHUNKS));

--- a/test/subspace-farmerless-dev-node/src/main.rs
+++ b/test/subspace-farmerless-dev-node/src/main.rs
@@ -79,6 +79,7 @@ fn build_runtime() -> tokio::runtime::Runtime {
         .expect("Tokio runtime must build")
 }
 
+#[expect(clippy::result_large_err, reason = "Comes from Substrate")]
 fn start_consensus_node(
     tokio_handle: tokio::runtime::Handle,
     base_path: PathBuf,

--- a/test/subspace-test-service/src/lib.rs
+++ b/test/subspace-test-service/src/lib.rs
@@ -450,6 +450,7 @@ pub struct MockConsensusNodeRpcConfig {
 }
 
 impl MockConsensusNode {
+    #[expect(clippy::result_large_err, reason = "Comes from Substrate")]
     fn run_with_configuration(
         mut config: Configuration,
         key: Sr25519Keyring,
@@ -656,6 +657,7 @@ impl MockConsensusNode {
     }
 
     /// Run a mock consensus node with finalization depth
+    #[expect(clippy::result_large_err, reason = "Comes from Substrate")]
     pub fn run_with_finalization_depth(
         tokio_handle: tokio::runtime::Handle,
         key: Sr25519Keyring,
@@ -717,6 +719,7 @@ impl MockConsensusNode {
     }
 
     /// Run a mock consensus node with RPC options using the default empty RPC module.
+    #[expect(clippy::result_large_err, reason = "Comes from Substrate")]
     pub fn run_with_rpc_options(
         tokio_handle: tokio::runtime::Handle,
         key: Sr25519Keyring,


### PR DESCRIPTION
Bumps Rust nightly from `nightly-2025-10-19` to `nightly-2026-04-11` — a ~6-month hygiene update aligning with the Abundance project. All Rust code changes and a one-line fix in the polkadot-sdk fork are required for compilation to succeed on the new nightly.

### Commits

Reviewers are encouraged to go **commit-by-commit**.

1. **`de946fda2`** — update Rust nightly to nightly-2026-04-11
   Updates `rust-toolchain.toml` from `nightly-2025-10-19` to `nightly-2026-04-11`.

2. **`633381ae2`** — fix compiler ICE in subspace-proof-of-space find_proof
   The `find_proof()` function in `crates/subspace-proof-of-space/src/chiapos/tables.rs` triggered a compiler ICE due to the `generic_const_exprs` + RPIT + closure-capturing-self combination. Refactored to extract the per-proof logic into a separate non-generic helper method, following Abundance's pattern.

3. **`40659bfdf`** — remove stabilized feature gates for nightly-2026-04-11
   Removes `#![feature(...)]` declarations for features stabilized in the 6-month nightly gap: `array_windows`, `maybe_uninit_slice`, `maybe_uninit_write_slice`, `vec_into_raw_parts`, `assert_matches`, `if_let_guard`, `const_try`, `trusted_len`, `int_roundings`, `iter_collect_into`, `impl_trait_in_assoc_type`, `type_alias_impl_trait`, `box_into_inner`. Updates `assert_matches` imports to the stabilized path.

4. **`d4303e640`** — fix new clippy lints and try block inference for nightly-2026-04-11
   - `clippy::manual_saturating_arithmetic` in archiver
   - `clippy::collapsible_match`, `unnecessary_sort_by`, `useless_conversion`, `unnecessary_cast`, `explicit_counter_loop`
   - `unfulfilled_lint_expectations`: removed stale `#[expect(clippy::double_parens)]`
   - `clippy::result_large_err`: `#[expect]` for substrate-originating error types
   - Try block inference change: explicit `.map_err(ProvingError::RecordReadingError)` for `ReadingError` conversions in `proving.rs`

5. **`43756be00`** — fix additional stabilized features and clippy lints for nightly-2026-04-11
   Additional stabilized features missed in the first pass: `trait_alias`, `type_changing_struct_update`, and conditional gating of `more_qualified_paths` to `#[cfg_attr(test, ...)]`. Re-added `iter_collect_into` (not actually stabilized) and `never_type` to `subspace-farmer-components` (still required). Additional `result_large_err` fixes in `subspace-test-service` and `subspace-farmerless-dev-node`. Rewrote `alice_nonce` loop in fraud-proof tests to avoid `explicit_counter_loop`.

6. **`e729fafb8`** — update polkadot-sdk fork rev for WASM linker fix
   Rust PR [#149868](https://github.com/rust-lang/rust/pull/149868) (merged April 4, 2026) stopped passing `--allow-undefined` to `wasm-ld` on WASM targets. This broke WASM runtime linking for all bare `extern "C"` host function declarations generated by the `#[runtime_interface]` proc macro.

   Fork fix ([commit](https://github.com/autonomys/polkadot-sdk/commit/22ebae7f5d86a59f8259f562e3445dd2a4ab961b)) adds `#[cfg_attr(target_family = "wasm", link(wasm_import_module = "env"))]` to the generated `extern "C"` block in `sp-runtime-interface-proc-macro`. This explicitly marks the imports as WASM imports from the `"env"` module, matching what the Substrate executor already expects.

   Verified to produce **byte-identical** `runtime_version` and `runtime_apis` custom sections compared to the previous behavior, preserving runtime upgrade and client compatibility. Verification steps performed:
   - WASM imports: 45 vs 45, byte-identical, all in `"env"` module
   - WASM exports: 97 vs 97, byte-identical
   - `runtime_version` and `runtime_apis` custom sections: byte-identical
   - Substrate executor source confirms it requires `"env"` module and rejects anything else
   - Runtime integrity tests and full test suite pass

7. **`c3851a0db`** — cargo fmt fixes for nightly-2026-04-11
   Formatting adjustments from rustfmt on the new nightly.

### Code contributor checklist
- [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)