### PR TITLE
Bump client versions to 0.1.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13932,7 +13932,7 @@ dependencies = [
 
 [[package]]
 name = "subspace-bootstrap-node"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "clap",
  "futures",
@@ -14030,7 +14030,7 @@ dependencies = [
 
 [[package]]
 name = "subspace-farmer"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "anyhow",
  "async-lock",
@@ -14141,7 +14141,7 @@ dependencies = [
 
 [[package]]
 name = "subspace-gateway"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -14311,7 +14311,7 @@ dependencies = [
 
 [[package]]
 name = "subspace-node"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "auto-id-domain-runtime",
  "bip39",

--- a/crates/subspace-bootstrap-node/Cargo.toml
+++ b/crates/subspace-bootstrap-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subspace-bootstrap-node"
-version = "0.1.8"
+version = "0.1.9"
 authors = [
     "Nazar Mokrynskyi <nazar@mokrynskyi.com>",
     "Shamil Gadelshin <shamilgadelshin@gmail.com>"

--- a/crates/subspace-farmer/Cargo.toml
+++ b/crates/subspace-farmer/Cargo.toml
@@ -2,7 +2,7 @@
 name = "subspace-farmer"
 description = "Farmer for the Subspace Network Blockchain"
 license = "0BSD"
-version = "0.1.8"
+version = "0.1.9"
 authors = ["Nazar Mokrynskyi <nazar@mokrynskyi.com>"]
 edition.workspace = true
 include = [

--- a/crates/subspace-gateway/Cargo.toml
+++ b/crates/subspace-gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subspace-gateway"
-version = "0.1.8"
+version = "0.1.9"
 authors = [
     "Teor <teor@riseup.net>",
     "Shamil Gadelshin <shamilgadelshin@gmail.com>"

--- a/crates/subspace-node/Cargo.toml
+++ b/crates/subspace-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subspace-node"
-version = "0.1.8"
+version = "0.1.9"
 authors = ["Subspace Labs <https://subspace.network>"]
 description = "A Subspace Network Blockchain node."
 edition.workspace = true


### PR DESCRIPTION
## Summary
- Bump subspace-node, subspace-farmer, subspace-gateway, and subspace-bootstrap-node from 0.1.8 to 0.1.9 in preparation for the next Chronos pre-release.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)