### PR TITLE
ci: enable Dependabot version updates for cargo and github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,6 +44,17 @@ updates:
       prefix: ci
       include: scope
     groups:
-      github-actions:
+      github-actions-patch:
         patterns:
           - "*"
+        update-types:
+          - patch
+      github-actions-minor:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+    # Major bumps fall outside the groups so each gets its own PR —
+    # action majors regularly carry breaking changes (e.g. checkout
+    # v3→v4 changed the bundled node version), and deserve isolated
+    # review for the same reason cargo majors do.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,49 @@
+# Dependabot version-update configuration.
+#
+# Security alerts (CVE detection in the Security tab) and Dependabot
+# security-update PRs are separate features that have to be turned on
+# by a repo/org admin in Settings → Code security & analysis. This file
+# only governs scheduled version-update PRs.
+#
+# Docs: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+version: 2
+updates:
+  # Rust dependencies — driven by `[workspace.dependencies]` at the
+  # workspace root, so one entry covers every crate in the workspace.
+  # Many deps are git-pinned (libp2p fork, substrate fork) and will
+  # simply be skipped.
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: deps
+      include: scope
+    groups:
+      cargo-patch:
+        update-types:
+          - patch
+      cargo-minor:
+        update-types:
+          - minor
+    # Major bumps are intentionally left out of groups so they each get
+    # their own PR — breaking changes deserve isolated review.
+
+  # GitHub Actions used by workflows under .github/workflows/.
+  # All actions in the repo are SHA-pinned with a `# vX.Y.Z` comment;
+  # Dependabot understands this format and updates both the pin and
+  # the comment together.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    commit-message:
+      prefix: ci
+      include: scope
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
This sets up Dependabot version-update PRs for the two ecosystems in the repo — the Cargo workspace and the GitHub Actions used in our workflows. Patch and minor bumps in each ecosystem are bundled into one PR per group per week so we don't get a wall of separate PRs; major bumps stay separate so each gets its own review.

### Code contributor checklist:
- [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)