### PR TITLE
deps: bump polkadot-sdk fork to wasmtime 36.0.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,15 +192,6 @@ dependencies = [
 
 [[package]]
 name = "addr2line"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
-dependencies = [
- "gimli 0.31.1",
-]
-
-[[package]]
-name = "addr2line"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
@@ -1161,7 +1152,7 @@ version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
 dependencies = [
- "addr2line 0.25.1",
+ "addr2line",
  "cfg-if",
  "libc",
  "miniz_oxide",
@@ -1213,7 +1204,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 [[package]]
 name = "binary-merkle-tree"
 version = "16.1.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "hash-db",
  "log",
@@ -2072,36 +2063,36 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.122.0"
+version = "0.123.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ae7b60ec3fd7162427d3b3801520a1908bef7c035b52983cd3ca11b8e7deb51"
+checksum = "de2be1bdbf929c2a2242cbbe15d6583c56f1cc723c6c8452d0179362de28c9d5"
 dependencies = [
  "cranelift-assembler-x64-meta",
 ]
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.122.0"
+version = "0.123.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6511c200fed36452697b4b6b161eae57d917a2044e6333b1c1389ed63ccadeee"
+checksum = "9a0336914de11298290783a95a9a7154b894da601659eb5f8f8bc62d1bea98f8"
 dependencies = [
  "cranelift-srcgen",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.122.0"
+version = "0.123.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f7086a645aa58bae979312f64e3029ac760ac1b577f5cd2417844842a2ca07f"
+checksum = "fb972cba51a52c1b2a329fec993b911e4d1f9cfab3795811a319b6746c28e014"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.122.0"
+version = "0.123.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5225b4dec45f3f3dbf383f12560fac5ce8d780f399893607e21406e12e77f491"
+checksum = "642c920666bfed9aebca39d8c6e7cb76f09314cc7a4074b1db5edcccdde771b9"
 dependencies = [
  "serde",
  "serde_derive",
@@ -2109,9 +2100,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.122.0"
+version = "0.123.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "858fb3331e53492a95979378d6df5208dd1d0d315f19c052be8115f4efc888e0"
+checksum = "0e1231caaeee3d2363d9b2dba9d6c1f7ff835b8ede6612fba98120af73df44bd"
 dependencies = [
  "bumpalo",
  "cranelift-assembler-x64",
@@ -2122,7 +2113,7 @@ dependencies = [
  "cranelift-control",
  "cranelift-entity",
  "cranelift-isle",
- "gimli 0.31.1",
+ "gimli 0.32.3",
  "hashbrown 0.15.5",
  "log",
  "pulley-interpreter",
@@ -2136,36 +2127,37 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.122.0"
+version = "0.123.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456715b9d5f12398f156d5081096e7b5d039f01b9ecc49790a011c8e43e65b5f"
+checksum = "eb83e89be8b413e4f7a4215a02d5c5f3e6f04b1060f5db293dd1007b2871dcf5"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
  "cranelift-srcgen",
+ "heck 0.5.0",
  "pulley-interpreter",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.122.0"
+version = "0.123.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0306041099499833f167a0ddb707e1e54100f1a84eab5631bc3dad249708f482"
+checksum = "9d14f8068a98f0a85ffa63dc5fe73cb486a955adbe7311465d13cde54c656d5f"
 
 [[package]]
 name = "cranelift-control"
-version = "0.122.0"
+version = "0.123.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1672945e1f9afc2297f49c92623f5eabc64398e2cb0d824f8f72a2db2df5af23"
+checksum = "c070aee9312b9736028e99b58d45e1099683386082af38529d5e2ce8c76648f3"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.122.0"
+version = "0.123.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa3cd55eb5f3825b9ae5de1530887907360a6334caccdc124c52f6d75246c98a"
+checksum = "f2d619bb3d14251e96dc9b6a846d6955d78048a168cc3876eb2b789b855c1c22"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -2174,9 +2166,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.122.0"
+version = "0.123.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "781f9905f8139b8de22987b66b522b416fe63eb76d823f0b3a8c02c8fd9500c7"
+checksum = "2350fcff24d78be5e4201e1eeb4b306e474b9f21e452722b21ffc4f773e8d49a"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -2186,15 +2178,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.122.0"
+version = "0.123.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a05337a2b02c3df00b4dd9a263a027a07b3dff49f61f7da3b5d195c21eaa633d"
+checksum = "8bdc2b14d7491c53c2989b967b4c07511374733abbc01a895fb01ea31e97bfc8"
 
 [[package]]
 name = "cranelift-native"
-version = "0.122.0"
+version = "0.123.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eee7a496dd66380082c9c5b6f2d5fa149cec0ec383feec5caf079ca2b3671c2"
+checksum = "e98dbe1326d0001a17b3b0675e3adafcfbd0e7f25f1f845a2f1bb9ce3029f359"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -2203,9 +2195,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.122.0"
+version = "0.123.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b530783809a55cb68d070e0de60cfbb3db0dc94c8850dd5725411422bedcf6bb"
+checksum = "36d7af563cd300c8a1e4e64387929b40e32867112143f0a0e1ce90f977ce4a41"
 
 [[package]]
 name = "crc32fast"
@@ -2411,7 +2403,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-parachain-inherent"
 version = "0.22.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2422,7 +2414,7 @@ dependencies = [
  "sc-client-api",
  "sc-consensus-babe",
  "sc-network-types",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342)",
  "sp-inherents",
  "sp-runtime",
  "sp-state-machine",
@@ -2433,7 +2425,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system"
 version = "0.25.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "array-bytes",
  "bytes",
@@ -2471,7 +2463,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system-proc-macro"
 version = "0.7.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
@@ -2482,7 +2474,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-core"
 version = "0.23.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "parity-scale-codec",
  "polkadot-core-primitives",
@@ -2499,7 +2491,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-parachain-inherent"
 version = "0.23.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2513,7 +2505,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-proof-size-hostfunction"
 version = "0.16.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "sp-externalities",
  "sp-runtime-interface",
@@ -2523,7 +2515,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-storage-weight-reclaim"
 version = "16.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-proof-size-hostfunction",
@@ -2540,7 +2532,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-interface"
 version = "0.28.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2560,7 +2552,7 @@ dependencies = [
 [[package]]
 name = "cumulus-test-relay-sproof-builder"
 version = "0.24.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
@@ -3690,7 +3682,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4146,7 +4138,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342)",
 ]
 
 [[package]]
@@ -4290,7 +4282,7 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 [[package]]
 name = "fork-tree"
 version = "13.0.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -4417,7 +4409,7 @@ checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 [[package]]
 name = "frame-benchmarking"
 version = "45.0.3"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -4441,7 +4433,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "53.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "Inflector",
  "array-bytes",
@@ -4520,7 +4512,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-solution-type"
 version = "16.1.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
@@ -4531,7 +4523,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-support"
 version = "45.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "frame-election-provider-solution-type",
  "frame-support",
@@ -4548,7 +4540,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "45.0.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "aquamarine",
  "frame-support",
@@ -4578,7 +4570,7 @@ dependencies = [
 [[package]]
 name = "frame-storage-access-test-runtime"
 version = "0.6.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "parity-scale-codec",
@@ -4592,7 +4584,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "45.1.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "aquamarine",
  "array-bytes",
@@ -4633,7 +4625,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "36.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -4646,14 +4638,14 @@ dependencies = [
  "proc-macro-warning",
  "proc-macro2",
  "quote",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342)",
  "syn 2.0.117",
 ]
 
 [[package]]
 name = "frame-support-procedural-tools"
 version = "13.0.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate 3.5.0",
@@ -4665,7 +4657,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "12.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4675,7 +4667,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "45.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "cfg-if",
  "docify",
@@ -4694,7 +4686,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "45.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4708,7 +4700,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "40.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "docify",
  "parity-scale-codec",
@@ -4718,7 +4710,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.51.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -5027,7 +5019,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 dependencies = [
  "fallible-iterator",
- "indexmap",
  "stable_deref_trait",
 ]
 
@@ -5036,6 +5027,11 @@ name = "gimli"
 version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+dependencies = [
+ "fallible-iterator",
+ "indexmap",
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "glob"
@@ -5872,7 +5868,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7244,7 +7240,7 @@ dependencies = [
 [[package]]
 name = "mmr-gadget"
 version = "50.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "futures",
  "log",
@@ -7263,7 +7259,7 @@ dependencies = [
 [[package]]
 name = "mmr-rpc"
 version = "44.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -7614,7 +7610,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7754,9 +7750,6 @@ version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
- "crc32fast",
- "hashbrown 0.15.5",
- "indexmap",
  "memchr",
 ]
 
@@ -7766,6 +7759,9 @@ version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
+ "crc32fast",
+ "hashbrown 0.15.5",
+ "indexmap",
  "memchr",
 ]
 
@@ -7894,7 +7890,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-conversion"
 version = "27.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7912,7 +7908,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "45.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7927,7 +7923,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "45.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7960,7 +7956,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "45.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7983,7 +7979,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "46.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8015,7 +8011,7 @@ dependencies = [
 [[package]]
 name = "pallet-broker"
 version = "0.24.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -8033,7 +8029,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "45.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8050,7 +8046,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "45.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8247,7 +8243,7 @@ dependencies = [
 [[package]]
 name = "pallet-message-queue"
 version = "48.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -8290,7 +8286,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr"
 version = "45.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -8302,7 +8298,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "45.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -8313,7 +8309,7 @@ dependencies = [
 [[package]]
 name = "pallet-preimage"
 version = "45.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8362,7 +8358,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "46.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8379,7 +8375,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "45.2.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8401,7 +8397,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "45.1.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -8482,7 +8478,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "45.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8497,7 +8493,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "44.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8526,7 +8522,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "45.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8542,7 +8538,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "48.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -8558,7 +8554,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "45.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -8591,7 +8587,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "45.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8951,7 +8947,7 @@ dependencies = [
 [[package]]
 name = "polkadot-core-primitives"
 version = "21.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -8962,7 +8958,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-metrics"
 version = "28.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "bs58",
  "futures",
@@ -8979,7 +8975,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-network-protocol"
 version = "28.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -9004,7 +9000,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-primitives"
 version = "23.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "bitvec",
  "bounded-vec",
@@ -9028,7 +9024,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-types"
 version = "28.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "async-trait",
  "derive_more 0.99.20",
@@ -9056,7 +9052,7 @@ dependencies = [
 [[package]]
 name = "polkadot-overseer"
 version = "28.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "async-trait",
  "futures",
@@ -9076,7 +9072,7 @@ dependencies = [
 [[package]]
 name = "polkadot-parachain-primitives"
 version = "20.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "array-bytes",
  "bounded-collections",
@@ -9093,7 +9089,7 @@ dependencies = [
 [[package]]
 name = "polkadot-primitives"
 version = "22.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "bitvec",
  "bounded-collections",
@@ -9122,7 +9118,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-metrics"
 version = "25.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "bs58",
  "frame-benchmarking",
@@ -9134,7 +9130,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-parachains"
 version = "24.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "bitflags 1.3.2",
  "bitvec",
@@ -9182,7 +9178,7 @@ dependencies = [
 [[package]]
 name = "polkadot-sdk-frame"
 version = "0.14.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9217,7 +9213,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-table"
 version = "23.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
@@ -9433,7 +9429,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342)",
  "syn 2.0.117",
 ]
 
@@ -9704,7 +9700,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck 0.4.1",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "once_cell",
@@ -9724,7 +9720,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck 0.4.1",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "petgraph 0.8.3",
@@ -9756,7 +9752,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -9769,7 +9765,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -9795,9 +9791,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "35.0.0"
+version = "36.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b89c4319786b16c1a6a38ee04788d32c669b61ba4b69da2162c868c18be99c1b"
+checksum = "329f575a931601f71fbcb3b31d32d16273da5ba7f532fc10be2e432e710b02de"
 dependencies = [
  "cranelift-bitset",
  "log",
@@ -9807,9 +9803,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-macros"
-version = "35.0.0"
+version = "36.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "938543690519c20c3a480d20a8efcc8e69abeb44093ab1df4e7c1f81f26c677a"
+checksum = "8bccae89ed67a40989e780105fab43e6c71a077b9fc8ae4c805ff5f73d2a79c8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10433,7 +10429,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10446,7 +10442,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10504,7 +10500,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 0.26.11",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10594,7 +10590,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "35.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "log",
  "sp-core",
@@ -10605,7 +10601,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.55.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "async-trait",
  "futures",
@@ -10637,7 +10633,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.53.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "futures",
  "log",
@@ -10659,7 +10655,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.48.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -10674,7 +10670,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "48.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "array-bytes",
  "docify",
@@ -10689,7 +10685,7 @@ dependencies = [
  "serde_json",
  "sp-blockchain",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342)",
  "sp-genesis-builder",
  "sp-io",
  "sp-runtime",
@@ -10700,7 +10696,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "12.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
@@ -10711,7 +10707,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.57.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "array-bytes",
  "bip39",
@@ -10753,7 +10749,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "44.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "fnv",
  "futures",
@@ -10779,7 +10775,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.51.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -10806,7 +10802,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.54.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "async-trait",
  "futures",
@@ -10829,7 +10825,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.55.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -10854,7 +10850,7 @@ dependencies = [
  "sp-consensus-babe",
  "sp-consensus-slots",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342)",
  "sp-inherents",
  "sp-keystore",
  "sp-runtime",
@@ -10866,7 +10862,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.54.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -10879,7 +10875,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.54.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "async-trait",
  "futures",
@@ -11009,7 +11005,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.47.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.5",
@@ -11032,7 +11028,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.43.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "polkavm",
  "sc-allocator",
@@ -11045,7 +11041,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-polkavm"
 version = "0.40.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "log",
  "polkavm",
@@ -11056,7 +11052,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.43.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "anyhow",
  "log",
@@ -11072,7 +11068,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.54.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "console",
  "futures",
@@ -11088,7 +11084,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "39.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "array-bytes",
  "parking_lot 0.12.5",
@@ -11102,7 +11098,7 @@ dependencies = [
 [[package]]
 name = "sc-mixnet"
 version = "0.25.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "array-bytes",
  "arrayvec 0.7.6",
@@ -11130,7 +11126,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.55.2"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -11179,7 +11175,7 @@ dependencies = [
 [[package]]
 name = "sc-network-common"
 version = "0.52.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "bitflags 1.3.2",
  "parity-scale-codec",
@@ -11189,7 +11185,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.55.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "ahash 0.8.12",
  "futures",
@@ -11208,7 +11204,7 @@ dependencies = [
 [[package]]
 name = "sc-network-light"
 version = "0.54.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -11229,7 +11225,7 @@ dependencies = [
 [[package]]
 name = "sc-network-sync"
 version = "0.54.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -11264,7 +11260,7 @@ dependencies = [
 [[package]]
 name = "sc-network-transactions"
 version = "0.54.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "array-bytes",
  "futures",
@@ -11283,7 +11279,7 @@ dependencies = [
 [[package]]
 name = "sc-network-types"
 version = "0.20.2"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "bs58",
  "bytes",
@@ -11304,7 +11300,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "50.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "bytes",
  "fnv",
@@ -11367,7 +11363,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.20.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -11376,7 +11372,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "50.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -11408,7 +11404,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.54.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -11428,7 +11424,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "27.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "dyn-clone",
  "forwarded-header-value",
@@ -11452,7 +11448,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-spec-v2"
 version = "0.55.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "array-bytes",
  "futures",
@@ -11485,13 +11481,13 @@ dependencies = [
 [[package]]
 name = "sc-runtime-utilities"
 version = "0.7.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "parity-scale-codec",
  "sc-executor",
  "sc-executor-common",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342)",
  "sp-state-machine",
  "sp-wasm-interface",
  "thiserror 1.0.69",
@@ -11500,7 +11496,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.56.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "async-trait",
  "directories",
@@ -11564,7 +11560,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.41.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -11575,7 +11571,7 @@ dependencies = [
 [[package]]
 name = "sc-storage-monitor"
 version = "0.27.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "clap",
  "fs4 0.7.0",
@@ -11633,7 +11629,7 @@ dependencies = [
 [[package]]
 name = "sc-sysinfo"
 version = "46.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "derive_more 0.99.20",
  "futures",
@@ -11646,14 +11642,14 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342)",
  "sp-io",
 ]
 
 [[package]]
 name = "sc-telemetry"
 version = "30.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "chrono",
  "futures",
@@ -11672,7 +11668,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "44.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "chrono",
  "console",
@@ -11700,7 +11696,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "11.1.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
@@ -11711,7 +11707,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "44.1.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "async-trait",
  "futures",
@@ -11728,7 +11724,7 @@ dependencies = [
  "sp-api",
  "sp-blockchain",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342)",
  "sp-runtime",
  "sp-tracing",
  "sp-transaction-pool",
@@ -11743,7 +11739,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "43.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "async-trait",
  "futures",
@@ -11761,7 +11757,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "20.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "async-channel 1.9.0",
  "futures",
@@ -12602,7 +12598,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "40.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "docify",
  "hash-db",
@@ -12624,7 +12620,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "26.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "Inflector",
  "blake2 0.10.6",
@@ -12638,7 +12634,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "44.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12650,7 +12646,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "28.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "docify",
  "integer-sqrt",
@@ -12664,7 +12660,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "40.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12689,7 +12685,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "40.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "sp-api",
  "sp-inherents",
@@ -12710,7 +12706,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "43.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -12729,7 +12725,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.46.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "async-trait",
  "futures",
@@ -12743,7 +12739,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.46.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -12759,7 +12755,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.46.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -12777,7 +12773,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-beefy"
 version = "28.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12785,7 +12781,7 @@ dependencies = [
  "sp-api",
  "sp-application-crypto",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342)",
  "sp-io",
  "sp-keystore",
  "sp-mmr-primitives",
@@ -12797,7 +12793,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-grandpa"
 version = "27.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -12814,7 +12810,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.46.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12853,7 +12849,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "39.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "ark-vrf",
  "array-bytes",
@@ -12884,7 +12880,7 @@ dependencies = [
  "secrecy 0.8.0",
  "serde",
  "sha2 0.10.9",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342)",
  "sp-debug-derive",
  "sp-externalities",
  "sp-std",
@@ -12914,7 +12910,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing"
 version = "0.1.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -12927,17 +12923,17 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "quote",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342)",
  "syn 2.0.117",
 ]
 
 [[package]]
 name = "sp-database"
 version = "10.0.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.5",
@@ -12946,7 +12942,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "14.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -13099,7 +13095,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.31.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -13109,7 +13105,7 @@ dependencies = [
 [[package]]
 name = "sp-genesis-builder"
 version = "0.21.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -13121,7 +13117,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "40.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -13134,7 +13130,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "44.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "bytes",
  "docify",
@@ -13146,7 +13142,7 @@ dependencies = [
  "rustversion",
  "secp256k1 0.28.2",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342)",
  "sp-externalities",
  "sp-keystore",
  "sp-runtime-interface",
@@ -13160,7 +13156,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "45.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "sp-core",
  "sp-runtime",
@@ -13170,7 +13166,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.45.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.5",
@@ -13181,7 +13177,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "11.1.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "thiserror 1.0.69",
  "zstd 0.12.4",
@@ -13229,7 +13225,7 @@ dependencies = [
 [[package]]
 name = "sp-metadata-ir"
 version = "0.12.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "frame-metadata",
  "parity-scale-codec",
@@ -13239,7 +13235,7 @@ dependencies = [
 [[package]]
 name = "sp-mixnet"
 version = "0.18.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -13250,7 +13246,7 @@ dependencies = [
 [[package]]
 name = "sp-mmr-primitives"
 version = "40.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -13267,7 +13263,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "40.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -13288,7 +13284,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "40.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -13298,7 +13294,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "13.0.2"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "backtrace",
  "regex",
@@ -13307,7 +13303,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "37.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "rustc-hash 1.1.0",
  "serde",
@@ -13317,7 +13313,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "45.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "binary-merkle-tree",
  "bytes",
@@ -13348,7 +13344,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "33.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -13366,7 +13362,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "20.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "Inflector",
  "expander",
@@ -13379,7 +13375,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "42.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -13393,7 +13389,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "42.2.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -13406,7 +13402,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.49.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "hash-db",
  "log",
@@ -13426,7 +13422,7 @@ dependencies = [
 [[package]]
 name = "sp-statement-store"
 version = "24.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "aes-gcm",
  "curve25519-dalek",
@@ -13439,7 +13435,7 @@ dependencies = [
  "sp-api",
  "sp-application-crypto",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342)",
  "sp-externalities",
  "sp-runtime",
  "sp-runtime-interface",
@@ -13450,12 +13446,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "14.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 
 [[package]]
 name = "sp-storage"
 version = "22.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -13485,7 +13481,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "40.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -13497,7 +13493,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "19.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "parity-scale-codec",
  "regex",
@@ -13509,7 +13505,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "40.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -13518,7 +13514,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "40.1.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -13533,7 +13529,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "42.0.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "ahash 0.8.12",
  "foldhash 0.1.5",
@@ -13558,7 +13554,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "43.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -13575,7 +13571,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "15.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "parity-scale-codec",
  "proc-macro-warning",
@@ -13587,7 +13583,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "24.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -13599,7 +13595,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "33.2.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "bounded-collections",
  "parity-scale-codec",
@@ -13677,7 +13673,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 [[package]]
 name = "staging-xcm"
 version = "21.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "array-bytes",
  "bounded-collections",
@@ -13698,7 +13694,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-builder"
 version = "25.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "environmental",
  "frame-support",
@@ -13722,7 +13718,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-executor"
 version = "24.0.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -14744,12 +14740,12 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "11.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "49.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "docify",
  "frame-system-rpc-runtime-api",
@@ -14769,7 +14765,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.17.7"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "http-body-util",
  "hyper",
@@ -14783,7 +14779,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-client"
 version = "2.0.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "array-bytes",
  "async-trait",
@@ -14808,7 +14804,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "31.1.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "build-helper",
  "cargo_metadata",
@@ -15171,7 +15167,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -15190,7 +15186,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -15676,7 +15672,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum"
 version = "23.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "coarsetime",
  "polkadot-primitives",
@@ -15687,7 +15683,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "expander",
  "proc-macro-crate 3.5.0",
@@ -16245,12 +16241,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.235.0"
+version = "0.236.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3bc393c395cb621367ff02d854179882b9a351b4e0c93d1397e6090b53a5c2a"
+checksum = "724fccfd4f3c24b7e589d333fc0429c68042897a7e8a5f8694f31792471841e7"
 dependencies = [
  "leb128fmt",
- "wasmparser 0.235.0",
+ "wasmparser 0.236.1",
 ]
 
 [[package]]
@@ -16391,9 +16387,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.235.0"
+version = "0.236.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "161296c618fa2d63f6ed5fffd1112937e803cb9ec71b32b01a76321555660917"
+checksum = "a9b1e81f3eb254cf7404a82cee6926a4a3ccc5aad80cc3d43608a070c67aa1d7"
 dependencies = [
  "bitflags 2.11.0",
  "hashbrown 0.15.5",
@@ -16416,29 +16412,29 @@ dependencies = [
 
 [[package]]
 name = "wasmprinter"
-version = "0.235.0"
+version = "0.236.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75aa8e9076de6b9544e6dab4badada518cca0bf4966d35b131bbd057aed8fa0a"
+checksum = "2df225df06a6df15b46e3f73ca066ff92c2e023670969f7d50ce7d5e695abbb1"
 dependencies = [
  "anyhow",
  "termcolor",
- "wasmparser 0.235.0",
+ "wasmparser 0.236.1",
 ]
 
 [[package]]
 name = "wasmtime"
-version = "35.0.0"
+version = "36.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6fe976922a16af3b0d67172c473d1fd4f1aa5d0af9c8ba6538c741f3af686f4"
+checksum = "507d213104e83a7519d91af444a8b19c04281f2eef162d448ee7a894ac1c827d"
 dependencies = [
- "addr2line 0.24.2",
+ "addr2line",
  "anyhow",
  "bitflags 2.11.0",
  "bumpalo",
  "cc",
  "cfg-if",
  "fxprof-processed-profile",
- "gimli 0.31.1",
+ "gimli 0.32.3",
  "hashbrown 0.15.5",
  "indexmap",
  "ittapi",
@@ -16446,7 +16442,7 @@ dependencies = [
  "log",
  "mach2",
  "memfd",
- "object 0.36.7",
+ "object 0.37.3",
  "once_cell",
  "postcard",
  "pulley-interpreter",
@@ -16457,7 +16453,7 @@ dependencies = [
  "serde_json",
  "smallvec",
  "target-lexicon",
- "wasmparser 0.235.0",
+ "wasmparser 0.236.1",
  "wasmtime-environ",
  "wasmtime-internal-asm-macros",
  "wasmtime-internal-cache",
@@ -16470,48 +16466,48 @@ dependencies = [
  "wasmtime-internal-unwinder",
  "wasmtime-internal-versioned-export-macros",
  "wasmtime-internal-winch",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "wasmtime-environ"
-version = "35.0.0"
+version = "36.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44b6264a78d806924abbc76bbc75eac24976bc83bdfb938e5074ae551242436f"
+checksum = "9784b325c3b85562ac6d7f81c8348c42af1f137d98dd4fc6631860e4e68bb655"
 dependencies = [
  "anyhow",
  "cpp_demangle",
  "cranelift-bitset",
  "cranelift-entity",
- "gimli 0.31.1",
+ "gimli 0.32.3",
  "indexmap",
  "log",
- "object 0.36.7",
+ "object 0.37.3",
  "postcard",
  "rustc-demangle",
  "serde",
  "serde_derive",
  "smallvec",
  "target-lexicon",
- "wasm-encoder 0.235.0",
- "wasmparser 0.235.0",
+ "wasm-encoder 0.236.1",
+ "wasmparser 0.236.1",
  "wasmprinter",
 ]
 
 [[package]]
 name = "wasmtime-internal-asm-macros"
-version = "35.0.0"
+version = "36.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6775a9b516559716e5710e95a8014ca0adcc81e5bf4d3ad7899d89ae40094d1a"
+checksum = "bcaa9336cd5ba934ba734dfdfe35f5245c3c74b4e34f9af9e114fad892d81b3d"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "wasmtime-internal-cache"
-version = "35.0.0"
+version = "36.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138e33ad4bd120f3b1c77d6d0dcdce0de8239555495befcda89393a40ba5e324"
+checksum = "e297746bc001fd919f8f9bb3d28ed1a01fb1ff10a5ccd9720e649b5807bf2b68"
 dependencies = [
  "anyhow",
  "base64",
@@ -16523,15 +16519,15 @@ dependencies = [
  "serde_derive",
  "sha2 0.10.9",
  "toml 0.8.23",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
  "zstd 0.13.3",
 ]
 
 [[package]]
 name = "wasmtime-internal-cranelift"
-version = "35.0.0"
+version = "36.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ec9ad7565e6a8de7cb95484e230ff689db74a4a085219e0da0cbd637a29c01c"
+checksum = "e7d938ae501275f44e7e5532ae4bb720542b429357014d33842e128c46fb9b54"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -16540,15 +16536,15 @@ dependencies = [
  "cranelift-entity",
  "cranelift-frontend",
  "cranelift-native",
- "gimli 0.31.1",
+ "gimli 0.32.3",
  "itertools 0.14.0",
  "log",
- "object 0.36.7",
+ "object 0.37.3",
  "pulley-interpreter",
  "smallvec",
  "target-lexicon",
  "thiserror 2.0.18",
- "wasmparser 0.235.0",
+ "wasmparser 0.236.1",
  "wasmtime-environ",
  "wasmtime-internal-math",
  "wasmtime-internal-versioned-export-macros",
@@ -16556,9 +16552,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-fiber"
-version = "35.0.0"
+version = "36.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b636ff8b220ebaf29dfe3b23770e4b2bad317b9683e3bf7345e162387385b39"
+checksum = "c1443b0914ff848ee7920e0f232368168e2819b739c54f3c352f0559b6164343"
 dependencies = [
  "anyhow",
  "cc",
@@ -16567,66 +16563,66 @@ dependencies = [
  "rustix 1.1.4",
  "wasmtime-internal-asm-macros",
  "wasmtime-internal-versioned-export-macros",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "wasmtime-internal-jit-debug"
-version = "35.0.0"
+version = "36.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61d8693995ab3df48e88777b6ee3b2f441f2c4f895ab938996cdac3db26f256c"
+checksum = "861d6f2a1652e95ca10b02552934b3bd460d7416b285fe10d7ca8c0a2b90dc3e"
 dependencies = [
  "cc",
- "object 0.36.7",
+ "object 0.37.3",
  "rustix 1.1.4",
  "wasmtime-internal-versioned-export-macros",
 ]
 
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
-version = "35.0.0"
+version = "36.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4417e06b7f80baff87d9770852c757a39b8d7f11d78b2620ca992b8725f16f50"
+checksum = "b1caeb3140c46319fecf09d93dc38a373eb535fd478e401a9fb2ac2da30fe5f6"
 dependencies = [
  "anyhow",
  "cfg-if",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "wasmtime-internal-math"
-version = "35.0.0"
+version = "36.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7710d5c4ecdaa772927fd11e5dc30a9a62d1fc8fe933e11ad5576ad596ab6612"
+checksum = "7c631615929951a4076aae64da7d6cad88668d292f19672606392c24ae9c5a00"
 dependencies = [
  "libm",
 ]
 
 [[package]]
 name = "wasmtime-internal-slab"
-version = "35.0.0"
+version = "36.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6ab22fabe1eed27ab01fd47cd89deacf43ad222ed7fd169ba6f4dd1fbddc53b"
+checksum = "7b28104d57b5bdb5d8facb3a8418463ec6c2cb40bb4adf9833b727ebf6a254eb"
 
 [[package]]
 name = "wasmtime-internal-unwinder"
-version = "35.0.0"
+version = "36.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "307708f302f5dcf19c1bbbfb3d9f2cbc837dd18088a7988747b043a46ba38ecc"
+checksum = "0dd89f2db7377869aeaf66b71f56def8df54b9482e4f4e5533ccec2505f5c691"
 dependencies = [
  "anyhow",
  "cfg-if",
  "cranelift-codegen",
  "log",
- "object 0.36.7",
+ "object 0.37.3",
 ]
 
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
-version = "35.0.0"
+version = "36.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "342b0466f92b7217a4de9e114175fedee1907028567d2548bcd42f71a8b5b016"
+checksum = "a9cdb9c2e3965ee15629d067203cb800e9822664d04335dadc6fe1788d4fc335"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -16635,16 +16631,16 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-winch"
-version = "35.0.0"
+version = "36.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2012e7384c25b91aab2f1b6a1e1cbab9d0f199bbea06cc873597a3f047f05730"
+checksum = "53f693c8db710f20b927bcee025acd345acf599d055b63f122613d52f5553a5f"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
- "gimli 0.31.1",
- "object 0.36.7",
+ "gimli 0.32.3",
+ "object 0.37.3",
  "target-lexicon",
- "wasmparser 0.235.0",
+ "wasmparser 0.236.1",
  "wasmtime-environ",
  "wasmtime-internal-cranelift",
  "winch-codegen",
@@ -16756,7 +16752,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -16767,19 +16763,19 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "35.0.0"
+version = "36.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "839a334ef7c62d8368dbd427e767a6fbb1ba08cc12ecce19cbb666c10613b585"
+checksum = "4332c8656af179fb8fc3ae5114c738c29399ee97b638d431725201c17f99294e"
 dependencies = [
  "anyhow",
  "cranelift-assembler-x64",
  "cranelift-codegen",
- "gimli 0.31.1",
+ "gimli 0.32.3",
  "regalloc2 0.12.2",
  "smallvec",
  "target-lexicon",
  "thiserror 2.0.18",
- "wasmparser 0.235.0",
+ "wasmparser 0.236.1",
  "wasmtime-environ",
  "wasmtime-internal-cranelift",
  "wasmtime-internal-math",
@@ -17475,7 +17471,7 @@ dependencies = [
 [[package]]
 name = "xcm-procedural"
 version = "11.0.2"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=22ebae7f5d86a59f8259f562e3445dd2a4ab961b#22ebae7f5d86a59f8259f562e3445dd2a4ab961b"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
 dependencies = [
  "Inflector",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ core_affinity = "0.8.1"
 cpufeatures = "0.3.0"
 criterion = { version = "0.8.2", default-features = false }
 cross-domain-message-gossip = { version = "0.1.0", path = "domains/client/cross-domain-message-gossip" }
-cumulus-primitives-proof-size-hostfunction = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
+cumulus-primitives-proof-size-hostfunction = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
 derive_more = { version = "2.1.1", default-features = false }
 domain-block-builder = { version = "0.1.0", path = "domains/client/block-builder", default-features = false }
 domain-block-preprocessor = { version = "0.1.0", path = "domains/client/block-preprocessor", default-features = false }
@@ -89,13 +89,13 @@ fp-account = { version = "1.0.0-dev", git = "https://github.com/polkadot-evm/fro
 fp-evm = { version = "3.0.0-dev", git = "https://github.com/polkadot-evm/frontier", rev = "9d49e36ed5bac38241594f8ba055fdb94991483a", default-features = false }
 fp-rpc = { version = "3.0.0-dev", git = "https://github.com/polkadot-evm/frontier", rev = "9d49e36ed5bac38241594f8ba055fdb94991483a", default-features = false }
 fp-self-contained = { version = "1.0.0-dev", git = "https://github.com/polkadot-evm/frontier", rev = "9d49e36ed5bac38241594f8ba055fdb94991483a", default-features = false }
-frame-benchmarking = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
-frame-benchmarking-cli = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
-frame-executive = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
-frame-support = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
-frame-system = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
-frame-system-benchmarking = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
-frame-system-rpc-runtime-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
+frame-benchmarking = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
+frame-benchmarking-cli = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
+frame-executive = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
+frame-support = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
+frame-system = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
+frame-system-benchmarking = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
+frame-system-rpc-runtime-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
 fs2 = "0.4.3"
 fs4 = "1.1.0"
 futures = "0.3.31"
@@ -114,8 +114,8 @@ log = { version = "0.4.22", default-features = false }
 memmap2 = "0.9.5"
 memory-db = { version = "0.34.0", default-features = false }
 mimalloc = "0.1.50"
-mmr-gadget = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
-mmr-rpc = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
+mmr-gadget = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
+mmr-rpc = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
 multihash = "0.19.5"
 nohash-hasher = "0.2.0"
 num-traits = { version = "0.2.18", default-features = false }
@@ -123,10 +123,10 @@ num_cpus = "1.16.0"
 num_enum = { version = "0.7.6", default-features = false }
 ouroboros = "0.18.4"
 pallet-auto-id = { version = "0.1.0", path = "domains/pallets/auto-id", default-features = false }
-pallet-balances = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
+pallet-balances = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
 pallet-block-fees = { version = "0.1.0", path = "domains/pallets/block-fees", default-features = false }
-pallet-collective = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
-pallet-democracy = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
+pallet-collective = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
+pallet-democracy = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
 pallet-domain-id = { version = "0.1.0", path = "domains/pallets/domain-id", default-features = false }
 pallet-domain-sudo = { version = "0.1.0", path = "domains/pallets/domain-sudo", default-features = false }
 pallet-domains = { version = "0.1.0", path = "crates/pallet-domains", default-features = false }
@@ -138,23 +138,23 @@ pallet-evm-precompile-sha3fips = { version = "2.0.0-dev", git = "https://github.
 pallet-evm-precompile-simple = { version = "2.0.0-dev", git = "https://github.com/polkadot-evm/frontier", rev = "9d49e36ed5bac38241594f8ba055fdb94991483a", default-features = false }
 pallet-evm-tracker = { version = "0.1.0", path = "domains/pallets/evm-tracker", default-features = false }
 pallet-messenger = { version = "0.1.0", path = "domains/pallets/messenger", default-features = false }
-pallet-mmr = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
-pallet-multisig = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
-pallet-preimage = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
+pallet-mmr = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
+pallet-multisig = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
+pallet-preimage = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
 pallet-rewards = { version = "0.1.0", path = "crates/pallet-rewards", default-features = false }
 pallet-runtime-configs = { version = "0.1.0", path = "crates/pallet-runtime-configs", default-features = false }
-pallet-scheduler = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
+pallet-scheduler = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
 pallet-storage-overlay-checks = { version = "0.1.0", path = "domains/test/pallets/storage_overlay_checks", default-features = false }
 pallet-subspace = { version = "0.1.0", path = "crates/pallet-subspace", default-features = false }
 pallet-subspace-mmr = { version = "0.1.0", path = "crates/pallet-subspace-mmr", default-features = false }
-pallet-sudo = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
-pallet-timestamp = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
+pallet-sudo = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
+pallet-timestamp = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
 pallet-transaction-fees = { version = "0.1.0", path = "crates/pallet-transaction-fees", default-features = false }
-pallet-transaction-payment = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
-pallet-transaction-payment-rpc = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
-pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
+pallet-transaction-payment = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
+pallet-transaction-payment-rpc = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
+pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
 pallet-transporter = { version = "0.1.0", path = "domains/pallets/transporter", default-features = false }
-pallet-utility = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
+pallet-utility = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
 parity-scale-codec = { version = "3.7.5", default-features = false }
 parking_lot = "0.12.2"
 pem = "3.0.4"
@@ -172,42 +172,42 @@ ring = "0.17.8"
 rlp = "0.6"
 rs_merkle = { version = "1.4.2", default-features = false }
 rust-kzg-blst = { git = "https://github.com/grandinetech/rust-kzg", rev = "8f5f1a0f73b3c529c77cb880ff8d265830c7d7ac", default-features = false }
-sc-basic-authorship = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
-sc-block-builder = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
-sc-chain-spec = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
-sc-cli = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
-sc-client-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
-sc-client-db = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
-sc-consensus = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
-sc-consensus-slots = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
+sc-basic-authorship = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
+sc-block-builder = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
+sc-chain-spec = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
+sc-cli = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
+sc-client-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
+sc-client-db = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
+sc-consensus = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
+sc-consensus-slots = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
 sc-consensus-subspace = { version = "0.1.0", path = "crates/sc-consensus-subspace" }
 sc-consensus-subspace-rpc = { version = "0.1.0", path = "crates/sc-consensus-subspace-rpc" }
 sc-domains = { version = "0.1.0", path = "crates/sc-domains" }
-sc-executor = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
-sc-informant = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
-sc-keystore = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
-sc-network = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
-sc-network-common = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
-sc-network-gossip = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
-sc-network-sync = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
-sc-network-transactions = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
-sc-offchain = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
+sc-executor = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
+sc-informant = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
+sc-keystore = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
+sc-network = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
+sc-network-common = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
+sc-network-gossip = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
+sc-network-sync = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
+sc-network-transactions = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
+sc-offchain = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
 sc-proof-of-time = { version = "0.1.0", path = "crates/sc-proof-of-time" }
-sc-rpc = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
-sc-rpc-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
-sc-rpc-server = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
-sc-service = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
-sc-state-db = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
-sc-storage-monitor = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
+sc-rpc = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
+sc-rpc-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
+sc-rpc-server = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
+sc-service = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
+sc-state-db = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
+sc-storage-monitor = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
 sc-subspace-block-relay = { version = "0.1.0", path = "crates/sc-subspace-block-relay" }
 sc-subspace-chain-specs = { version = "0.1.0", path = "crates/sc-subspace-chain-specs" }
 sc-subspace-sync-common = { version = "0.1.0", path = "shared/sc-subspace-sync-common", default-features = false }
-sc-sysinfo = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
-sc-telemetry = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
-sc-tracing = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
-sc-transaction-pool = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
-sc-transaction-pool-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
-sc-utils = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
+sc-sysinfo = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
+sc-telemetry = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
+sc-tracing = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
+sc-transaction-pool = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
+sc-transaction-pool-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
+sc-utils = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
 scale-info = { version = "2.11.6", default-features = false }
 schnellru = "0.2.4"
 schnorrkel = { version = "0.11.4", default-features = false }
@@ -216,48 +216,48 @@ serde = { version = "1.0.216", default-features = false }
 serde-big-array = "0.5.1"
 serde_json = "1.0.133"
 sha2 = { version = "0.11.0", default-features = false }
-sp-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
-sp-application-crypto = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
-sp-arithmetic = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
+sp-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
+sp-application-crypto = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
+sp-arithmetic = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
 sp-auto-id = { version = "0.1.0", path = "domains/primitives/auto-id", default-features = false }
-sp-block-builder = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
+sp-block-builder = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
 sp-block-fees = { version = "0.1.0", path = "domains/primitives/block-fees", default-features = false }
-sp-blockchain = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
-sp-consensus = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
-sp-consensus-slots = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
+sp-blockchain = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
+sp-consensus = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
+sp-consensus-slots = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
 sp-consensus-subspace = { version = "0.1.0", path = "crates/sp-consensus-subspace", default-features = false }
-sp-core = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
+sp-core = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
 sp-domain-digests = { version = "0.1.0", path = "domains/primitives/digests", default-features = false }
 sp-domain-sudo = { version = "0.1.0", path = "domains/primitives/domain-sudo", default-features = false }
 sp-domains = { version = "0.1.0", path = "crates/sp-domains", default-features = false }
 sp-domains-fraud-proof = { version = "0.1.0", path = "crates/sp-domains-fraud-proof", default-features = false }
 sp-evm-tracker = { version = "0.1.0", path = "domains/primitives/evm-tracker", default-features = false }
 sp-executive = { version = "0.1.0", path = "domains/primitives/executive", default-features = false }
-sp-externalities = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
+sp-externalities = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
 sp-evm-precompiles = { version = "0.1.0", path = "domains/primitives/evm-precompiles", default-features = false }
-sp-genesis-builder = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
-sp-inherents = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
-sp-io = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
-sp-keyring = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
-sp-keystore = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
+sp-genesis-builder = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
+sp-inherents = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
+sp-io = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
+sp-keyring = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
+sp-keystore = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
 sp-messenger = { version = "0.1.0", path = "domains/primitives/messenger", default-features = false }
 sp-messenger-host-functions = { version = "0.1.0", path = "domains/primitives/messenger-host-functions", default-features = false }
-sp-mmr-primitives = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
+sp-mmr-primitives = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
 sp-objects = { version = "0.1.0", path = "crates/sp-objects", default-features = false }
-sp-offchain = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
-sp-runtime = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
-sp-runtime-interface = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
-sp-session = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
-sp-state-machine = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
-sp-std = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
-sp-storage = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
+sp-offchain = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
+sp-runtime = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
+sp-runtime-interface = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
+sp-session = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
+sp-state-machine = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
+sp-std = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
+sp-storage = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
 sp-subspace-mmr = { version = "0.1.0", path = "crates/sp-subspace-mmr", default-features = false }
-sp-timestamp = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
-sp-tracing = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
-sp-transaction-pool = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
-sp-trie = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
-sp-version = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
-sp-weights = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b", default-features = false }
+sp-timestamp = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
+sp-tracing = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
+sp-transaction-pool = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
+sp-trie = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
+sp-version = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
+sp-weights = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
 spin = "0.10.0"
 sppark = { version = "0.1.8", git = "https://github.com/autonomys/sppark", rev = "b2a181eb99c8200f1a604f04122551ea39fbf63f" }
 ss58-registry = "1.51.0"
@@ -286,11 +286,11 @@ subspace-test-runtime = { version = "0.1.0", path = "test/subspace-test-runtime"
 subspace-test-service = { version = "0.1.0", path = "test/subspace-test-service" }
 subspace-verification = { version = "0.1.0", path = "crates/subspace-verification", default-features = false }
 substrate-bip39 = "=0.6.0"
-substrate-build-script-utils = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
-substrate-frame-rpc-system = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
-substrate-prometheus-endpoint = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
-substrate-test-client = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
-substrate-wasm-builder = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
+substrate-build-script-utils = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
+substrate-frame-rpc-system = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
+substrate-prometheus-endpoint = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
+substrate-test-client = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
+substrate-wasm-builder = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
 supports-color = "3.0.1"
 tempfile = "3.13.0"
 thiserror = { version = "2.0.0", default-features = false }
@@ -389,51 +389,51 @@ lto = "fat"
 # Reason: We need to patch substrate dependency of frontier to our fork
 # TODO: Remove if/when we are using upstream substrate instead of fork
 [patch."https://github.com/paritytech/polkadot-sdk.git"]
-cumulus-primitives-storage-weight-reclaim = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
-frame-benchmarking = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
-frame-support = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
-frame-system = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
-sc-block-builder = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
-sc-client-db = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
-sc-consensus = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
-sc-consensus-slots = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
-sc-client-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
-sc-network = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
-sc-network-common = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
-sc-network-sync = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
-sc-rpc = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
-sc-service = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
-sc-telemetry = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
-sc-transaction-pool = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
-sc-transaction-pool-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
-sc-utils = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
-sp-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
-sp-application-crypto = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
-sp-arithmetic = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
-sp-block-builder = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
-sp-blockchain = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
-sp-consensus = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
-sp-consensus-slots = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
-sp-core = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
-sp-crypto-hashing = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
-sp-database = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
-sp-debug-derive = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
-sp-externalities = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
-sp-inherents = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
-sp-io = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
-sp-keystore = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
-sp-runtime = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
-sp-runtime-interface = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
-sp-state-machine = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
-sp-std = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
-sp-storage = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
-sp-timestamp = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
-sp-trie = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
-sp-version = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
-sp-weights = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
-staging-xcm = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
-substrate-prometheus-endpoint = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
-xcm-procedural = { git = "https://github.com/subspace/polkadot-sdk", rev = "22ebae7f5d86a59f8259f562e3445dd2a4ab961b" }
+cumulus-primitives-storage-weight-reclaim = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
+frame-benchmarking = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
+frame-support = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
+frame-system = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
+sc-block-builder = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
+sc-client-db = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
+sc-consensus = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
+sc-consensus-slots = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
+sc-client-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
+sc-network = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
+sc-network-common = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
+sc-network-sync = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
+sc-rpc = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
+sc-service = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
+sc-telemetry = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
+sc-transaction-pool = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
+sc-transaction-pool-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
+sc-utils = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
+sp-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
+sp-application-crypto = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
+sp-arithmetic = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
+sp-block-builder = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
+sp-blockchain = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
+sp-consensus = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
+sp-consensus-slots = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
+sp-core = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
+sp-crypto-hashing = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
+sp-database = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
+sp-debug-derive = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
+sp-externalities = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
+sp-inherents = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
+sp-io = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
+sp-keystore = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
+sp-runtime = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
+sp-runtime-interface = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
+sp-state-machine = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
+sp-std = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
+sp-storage = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
+sp-timestamp = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
+sp-trie = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
+sp-version = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
+sp-weights = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
+staging-xcm = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
+substrate-prometheus-endpoint = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
+xcm-procedural = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
 
 [patch."https://github.com/subspace/polkadot-sdk.git"]
 # De-duplicate extra copy that comes from Substrate repo


### PR DESCRIPTION
Bumps our polkadot-sdk fork pin to a new commit on top of subspace-v14 that mirrors paritytech/polkadot-sdk#11793 (the 35.0.0 -> 36.0.7 wasmtime bump that landed on upstream master 2026-04-17), going one patch higher to also pick up the table-allocation panic fix at 36.0.8. Cargo resolves to wasmtime 36.0.10 (latest in the 36.x line, satisfies ^36.0.8).

Closes four wasmtime advisories applicable to substrate's default executor config (cranelift + pooling-allocator, no winch):
- GHSA-jhxm-h53p-jm7w aarch64 Cranelift miscompile (critical)
- GHSA-vc8c-j3xm-xj73 x86-64 f64.copysign segfault
- GHSA-6wgr-89rj-399p pooling allocator data leakage
- GHSA-p8xm-42r7-89xg oversized table allocation panic

The aarch64 Cranelift one is the real reason to ship this. It's a miscompile (not a sandbox-escape concern per se) that can produce incorrect machine code on aarch64 in edge cases, which is a determinism risk for nodes running on Apple Silicon / aarch64 Linux / AWS Graviton.

Upstream substrate didn't backport this to stable2512, so we're applying the equivalent change locally on our fork.

Fork commit: subspace/polkadot-sdk@d008c68f08e on the new subspace-v15 branch (one commit ahead of subspace-v14).

Verified end-to-end with runtime upgrades against baseline releases: `mainnet-2026-mar-09` (client), `runtime-mainnet-2026-feb-02` (consensus runtime), `domain-genesis-storage-mainnet-2026-feb-02` (domain genesis).

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)