### PR TITLE
deps: bump libp2p fork to subspace-v12 (lift wasm-bindgen-futures pin)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -356,7 +356,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -367,7 +367,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3682,7 +3682,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5601,7 +5601,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -5619,7 +5619,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -5987,7 +5987,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6211,10 +6211,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.85"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -6506,7 +6508,7 @@ dependencies = [
 [[package]]
 name = "libp2p"
 version = "0.57.0"
-source = "git+https://github.com/subspace/rust-libp2p?rev=ff73560df0e32040c36689db9906e6e6e585140c#ff73560df0e32040c36689db9906e6e6e585140c"
+source = "git+https://github.com/subspace/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
 dependencies = [
  "bytes",
  "either",
@@ -6552,7 +6554,7 @@ dependencies = [
 [[package]]
 name = "libp2p-allow-block-list"
 version = "0.7.0"
-source = "git+https://github.com/subspace/rust-libp2p?rev=ff73560df0e32040c36689db9906e6e6e585140c#ff73560df0e32040c36689db9906e6e6e585140c"
+source = "git+https://github.com/subspace/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
 dependencies = [
  "libp2p-core 0.44.0",
  "libp2p-identity",
@@ -6562,7 +6564,7 @@ dependencies = [
 [[package]]
 name = "libp2p-autonat"
 version = "0.16.0"
-source = "git+https://github.com/subspace/rust-libp2p?rev=ff73560df0e32040c36689db9906e6e6e585140c#ff73560df0e32040c36689db9906e6e6e585140c"
+source = "git+https://github.com/subspace/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
 dependencies = [
  "asynchronous-codec 0.7.0",
  "either",
@@ -6595,7 +6597,7 @@ dependencies = [
 [[package]]
 name = "libp2p-connection-limits"
 version = "0.7.0"
-source = "git+https://github.com/subspace/rust-libp2p?rev=ff73560df0e32040c36689db9906e6e6e585140c#ff73560df0e32040c36689db9906e6e6e585140c"
+source = "git+https://github.com/subspace/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
 dependencies = [
  "libp2p-core 0.44.0",
  "libp2p-identity",
@@ -6629,7 +6631,7 @@ dependencies = [
 [[package]]
 name = "libp2p-core"
 version = "0.44.0"
-source = "git+https://github.com/subspace/rust-libp2p?rev=ff73560df0e32040c36689db9906e6e6e585140c#ff73560df0e32040c36689db9906e6e6e585140c"
+source = "git+https://github.com/subspace/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
 dependencies = [
  "either",
  "fnv",
@@ -6668,7 +6670,7 @@ dependencies = [
 [[package]]
 name = "libp2p-dns"
 version = "0.45.0"
-source = "git+https://github.com/subspace/rust-libp2p?rev=ff73560df0e32040c36689db9906e6e6e585140c#ff73560df0e32040c36689db9906e6e6e585140c"
+source = "git+https://github.com/subspace/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
 dependencies = [
  "futures",
  "hickory-resolver 0.26.1",
@@ -6682,7 +6684,7 @@ dependencies = [
 [[package]]
 name = "libp2p-gossipsub"
 version = "0.50.0"
-source = "git+https://github.com/subspace/rust-libp2p?rev=ff73560df0e32040c36689db9906e6e6e585140c#ff73560df0e32040c36689db9906e6e6e585140c"
+source = "git+https://github.com/subspace/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
 dependencies = [
  "async-channel 2.5.0",
  "asynchronous-codec 0.7.0",
@@ -6733,7 +6735,7 @@ dependencies = [
 [[package]]
 name = "libp2p-identify"
 version = "0.48.0"
-source = "git+https://github.com/subspace/rust-libp2p?rev=ff73560df0e32040c36689db9906e6e6e585140c#ff73560df0e32040c36689db9906e6e6e585140c"
+source = "git+https://github.com/subspace/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
 dependencies = [
  "asynchronous-codec 0.7.0",
  "either",
@@ -6753,7 +6755,7 @@ dependencies = [
 [[package]]
 name = "libp2p-identity"
 version = "0.2.14"
-source = "git+https://github.com/subspace/rust-libp2p?rev=ff73560df0e32040c36689db9906e6e6e585140c#ff73560df0e32040c36689db9906e6e6e585140c"
+source = "git+https://github.com/subspace/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
 dependencies = [
  "bs58",
  "ed25519-dalek",
@@ -6797,7 +6799,7 @@ dependencies = [
 [[package]]
 name = "libp2p-kad"
 version = "0.49.0"
-source = "git+https://github.com/subspace/rust-libp2p?rev=ff73560df0e32040c36689db9906e6e6e585140c#ff73560df0e32040c36689db9906e6e6e585140c"
+source = "git+https://github.com/subspace/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
 dependencies = [
  "asynchronous-codec 0.7.0",
  "bytes",
@@ -6842,7 +6844,7 @@ dependencies = [
 [[package]]
 name = "libp2p-mdns"
 version = "0.49.0"
-source = "git+https://github.com/subspace/rust-libp2p?rev=ff73560df0e32040c36689db9906e6e6e585140c#ff73560df0e32040c36689db9906e6e6e585140c"
+source = "git+https://github.com/subspace/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
 dependencies = [
  "futures",
  "hickory-proto 0.26.1",
@@ -6877,7 +6879,7 @@ dependencies = [
 [[package]]
 name = "libp2p-metrics"
 version = "0.18.0"
-source = "git+https://github.com/subspace/rust-libp2p?rev=ff73560df0e32040c36689db9906e6e6e585140c#ff73560df0e32040c36689db9906e6e6e585140c"
+source = "git+https://github.com/subspace/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
 dependencies = [
  "futures",
  "libp2p-core 0.44.0",
@@ -6917,7 +6919,7 @@ dependencies = [
 [[package]]
 name = "libp2p-noise"
 version = "0.47.0"
-source = "git+https://github.com/subspace/rust-libp2p?rev=ff73560df0e32040c36689db9906e6e6e585140c#ff73560df0e32040c36689db9906e6e6e585140c"
+source = "git+https://github.com/subspace/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
 dependencies = [
  "asynchronous-codec 0.7.0",
  "bytes",
@@ -6954,7 +6956,7 @@ dependencies = [
 [[package]]
 name = "libp2p-ping"
 version = "0.48.0"
-source = "git+https://github.com/subspace/rust-libp2p?rev=ff73560df0e32040c36689db9906e6e6e585140c#ff73560df0e32040c36689db9906e6e6e585140c"
+source = "git+https://github.com/subspace/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
 dependencies = [
  "futures",
  "futures-timer",
@@ -6969,7 +6971,7 @@ dependencies = [
 [[package]]
 name = "libp2p-plaintext"
 version = "0.44.0"
-source = "git+https://github.com/subspace/rust-libp2p?rev=ff73560df0e32040c36689db9906e6e6e585140c#ff73560df0e32040c36689db9906e6e6e585140c"
+source = "git+https://github.com/subspace/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
 dependencies = [
  "asynchronous-codec 0.7.0",
  "bytes",
@@ -7005,7 +7007,7 @@ dependencies = [
 [[package]]
 name = "libp2p-quic"
 version = "0.14.0"
-source = "git+https://github.com/subspace/rust-libp2p?rev=ff73560df0e32040c36689db9906e6e6e585140c#ff73560df0e32040c36689db9906e6e6e585140c"
+source = "git+https://github.com/subspace/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
 dependencies = [
  "futures",
  "futures-timer",
@@ -7042,7 +7044,7 @@ dependencies = [
 [[package]]
 name = "libp2p-request-response"
 version = "0.30.0"
-source = "git+https://github.com/subspace/rust-libp2p?rev=ff73560df0e32040c36689db9906e6e6e585140c#ff73560df0e32040c36689db9906e6e6e585140c"
+source = "git+https://github.com/subspace/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
 dependencies = [
  "futures",
  "futures-bounded",
@@ -7078,7 +7080,7 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm"
 version = "0.48.0"
-source = "git+https://github.com/subspace/rust-libp2p?rev=ff73560df0e32040c36689db9906e6e6e585140c#ff73560df0e32040c36689db9906e6e6e585140c"
+source = "git+https://github.com/subspace/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
 dependencies = [
  "either",
  "fnv",
@@ -7111,7 +7113,7 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm-derive"
 version = "0.36.0"
-source = "git+https://github.com/subspace/rust-libp2p?rev=ff73560df0e32040c36689db9906e6e6e585140c#ff73560df0e32040c36689db9906e6e6e585140c"
+source = "git+https://github.com/subspace/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
 dependencies = [
  "heck 0.5.0",
  "quote",
@@ -7121,7 +7123,7 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm-test"
 version = "0.7.0"
-source = "git+https://github.com/subspace/rust-libp2p?rev=ff73560df0e32040c36689db9906e6e6e585140c#ff73560df0e32040c36689db9906e6e6e585140c"
+source = "git+https://github.com/subspace/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
 dependencies = [
  "async-trait",
  "futures",
@@ -7153,7 +7155,7 @@ dependencies = [
 [[package]]
 name = "libp2p-tcp"
 version = "0.45.0"
-source = "git+https://github.com/subspace/rust-libp2p?rev=ff73560df0e32040c36689db9906e6e6e585140c#ff73560df0e32040c36689db9906e6e6e585140c"
+source = "git+https://github.com/subspace/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
 dependencies = [
  "futures",
  "futures-timer",
@@ -7186,7 +7188,7 @@ dependencies = [
 [[package]]
 name = "libp2p-tls"
 version = "0.7.0"
-source = "git+https://github.com/subspace/rust-libp2p?rev=ff73560df0e32040c36689db9906e6e6e585140c#ff73560df0e32040c36689db9906e6e6e585140c"
+source = "git+https://github.com/subspace/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
 dependencies = [
  "futures",
  "futures-rustls",
@@ -7218,7 +7220,7 @@ dependencies = [
 [[package]]
 name = "libp2p-upnp"
 version = "0.7.0"
-source = "git+https://github.com/subspace/rust-libp2p?rev=ff73560df0e32040c36689db9906e6e6e585140c#ff73560df0e32040c36689db9906e6e6e585140c"
+source = "git+https://github.com/subspace/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
 dependencies = [
  "futures",
  "futures-timer",
@@ -7266,7 +7268,7 @@ dependencies = [
 [[package]]
 name = "libp2p-yamux"
 version = "0.48.0"
-source = "git+https://github.com/subspace/rust-libp2p?rev=ff73560df0e32040c36689db9906e6e6e585140c#ff73560df0e32040c36689db9906e6e6e585140c"
+source = "git+https://github.com/subspace/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
 dependencies = [
  "either",
  "futures",
@@ -7920,7 +7922,7 @@ dependencies = [
 [[package]]
 name = "multistream-select"
 version = "0.14.0"
-source = "git+https://github.com/subspace/rust-libp2p?rev=ff73560df0e32040c36689db9906e6e6e585140c#ff73560df0e32040c36689db9906e6e6e585140c"
+source = "git+https://github.com/subspace/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
 dependencies = [
  "bytes",
  "futures",
@@ -8117,7 +8119,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8245,7 +8247,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 3.5.0",
+ "proc-macro-crate 1.1.3",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -10241,7 +10243,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck 0.4.1",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "log",
  "multimap",
  "once_cell",
@@ -10261,7 +10263,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck 0.4.1",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "log",
  "multimap",
  "petgraph 0.8.3",
@@ -10276,7 +10278,7 @@ dependencies = [
 [[package]]
 name = "prost-codec"
 version = "0.4.0"
-source = "git+https://github.com/subspace/rust-libp2p?rev=ff73560df0e32040c36689db9906e6e6e585140c#ff73560df0e32040c36689db9906e6e6e585140c"
+source = "git+https://github.com/subspace/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
 dependencies = [
  "asynchronous-codec 0.7.0",
  "bytes",
@@ -10305,7 +10307,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -10318,7 +10320,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -10421,7 +10423,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -10458,9 +10460,9 @@ dependencies = [
  "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10995,7 +10997,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11110,7 +11112,7 @@ dependencies = [
 [[package]]
 name = "rw-stream-sink"
 version = "0.5.0"
-source = "git+https://github.com/subspace/rust-libp2p?rev=ff73560df0e32040c36689db9906e6e6e585140c#ff73560df0e32040c36689db9906e6e6e585140c"
+source = "git+https://github.com/subspace/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
 dependencies = [
  "futures",
  "pin-project",
@@ -13161,7 +13163,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -15752,7 +15754,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -15771,7 +15773,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -16767,9 +16769,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.108"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -16780,23 +16782,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.58"
+version = "0.4.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a6e77fd0ae8029c9ea0063f87c46fde723e7d887703d74ad2616d792e51e6f"
+checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.108"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -16804,9 +16802,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.108"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -16817,9 +16815,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.108"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]
@@ -17233,9 +17231,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.85"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
+checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -17337,7 +17335,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,8 +107,8 @@ hwlocality = "1.0.0-alpha.12"
 jsonrpsee = "0.24.10"
 kzg = { git = "https://github.com/grandinetech/rust-kzg", rev = "8f5f1a0f73b3c529c77cb880ff8d265830c7d7ac", default-features = false }
 libc = "0.2.186"
-libp2p = { version = "0.57.0", git = "https://github.com/subspace/rust-libp2p", rev = "ff73560df0e32040c36689db9906e6e6e585140c", default-features = false }
-libp2p-swarm-test = { version = "0.7.0", git = "https://github.com/subspace/rust-libp2p", rev = "ff73560df0e32040c36689db9906e6e6e585140c" }
+libp2p = { version = "0.57.0", git = "https://github.com/subspace/rust-libp2p", rev = "676c687c2f7a6e92f8f4f77a6934022aec3ba16c", default-features = false }
+libp2p-swarm-test = { version = "0.7.0", git = "https://github.com/subspace/rust-libp2p", rev = "676c687c2f7a6e92f8f4f77a6934022aec3ba16c" }
 libsecp256k1 = "0.7.1"
 log = { version = "0.4.22", default-features = false }
 memmap2 = "0.9.5"
@@ -446,12 +446,12 @@ substrate-bip39 = "=0.6.0"
 # This is a hack: patches to the same repository are rejected by `cargo`. But it considers
 # "subspace/rust-libp2p" and "autonomys/rust-libp2p" to be different repositories, even though
 # they're redirected to the same place by GitHub, so it allows this patch.
-libp2p = { git = "https://github.com/subspace/rust-libp2p", rev = "ff73560df0e32040c36689db9906e6e6e585140c" }
-libp2p-identity = { git = "https://github.com/subspace/rust-libp2p", rev = "ff73560df0e32040c36689db9906e6e6e585140c" }
-libp2p-kad = { git = "https://github.com/subspace/rust-libp2p", rev = "ff73560df0e32040c36689db9906e6e6e585140c" }
-multistream-select = { git = "https://github.com/subspace/rust-libp2p", rev = "ff73560df0e32040c36689db9906e6e6e585140c" }
+libp2p = { git = "https://github.com/subspace/rust-libp2p", rev = "676c687c2f7a6e92f8f4f77a6934022aec3ba16c" }
+libp2p-identity = { git = "https://github.com/subspace/rust-libp2p", rev = "676c687c2f7a6e92f8f4f77a6934022aec3ba16c" }
+libp2p-kad = { git = "https://github.com/subspace/rust-libp2p", rev = "676c687c2f7a6e92f8f4f77a6934022aec3ba16c" }
+multistream-select = { git = "https://github.com/subspace/rust-libp2p", rev = "676c687c2f7a6e92f8f4f77a6934022aec3ba16c" }
 
 [patch.crates-io]
 # Patch away `libp2p-identity` in our dependency tree with the git version.
-# For details see: https://github.com/subspace/rust-libp2p/blob/ff73560df0e32040c36689db9906e6e6e585140c/Cargo.toml#L140-L145
-libp2p-identity = { git = "https://github.com/subspace/rust-libp2p", rev = "ff73560df0e32040c36689db9906e6e6e585140c" }
+# For details see: https://github.com/subspace/rust-libp2p/blob/676c687c2f7a6e92f8f4f77a6934022aec3ba16c/Cargo.toml#L140-L145
+libp2p-identity = { git = "https://github.com/subspace/rust-libp2p", rev = "676c687c2f7a6e92f8f4f77a6934022aec3ba16c" }


### PR DESCRIPTION
Bumps our libp2p fork pin v11 (ff73560d) -> v12 (676c687c). The v12 commit lifts the upstream `wasm-bindgen-futures = "=0.4.58"` workspace pin to "0.4". Subspace doesn't build libp2p for WASM, so the gloo-timers 0.2.6 concern that motivates the upstream pin doesn't apply to us. See nazar-pc's review of libp2p/rust-libp2p#6450.

Reverses the downgrade cascade from #3849:
- wasm-bindgen-futures 0.4.58 -> 0.4.72
- wasm-bindgen / -macro / -macro-support / -shared 0.2.108 -> 0.2.122
- web-sys 0.3.85 -> 0.3.99
- js-sys 0.3.85 -> 0.3.99

Fork commit: subspace/rust-libp2p@676c687c (subspace-v12 branch). 

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)