### PR TITLE
deps: unify libp2p on autonomys/rust-libp2p v12

### DIFF
--- a/.github/workflows/rustsec-audit.yml
+++ b/.github/workflows/rustsec-audit.yml
@@ -10,6 +10,7 @@ on:
     paths:
       - "**/Cargo.toml"
       - "**/Cargo.lock"
+      - ".github/workflows/rustsec-audit.yml"
   schedule:
     - cron: "40 13 * * 0"
 jobs:
@@ -20,9 +21,6 @@ jobs:
       - uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 #v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          # TODO: Remove first once Substrate upgrades litep2p and we no longer have rustls 0.20.9 in our dependencies
-          # TODO: Remove second once Substrate upgrades litep2p and sc-network and we no longer have ring 0.16 in our dependencies
-          # TODO: Remove third once Substrate upgrades wasmtime and we no longer have wasmtime <= 9 in our dependencies
-          # TODO: Remove fourth once Substrate upgrades wasmtime and we no longer have wasmtime <= 23 in our dependencies
-          # TODO: Remove fifth once Substrate upgrades wasmtime and we no longer have wasmtime < 24.0.5 in our dependencies (RUSTSEC-2025-0118)
-          ignore: RUSTSEC-2024-0336, RUSTSEC-2025-0009, RUSTSEC-2023-0091, RUSTSEC-2024-0438, RUSTSEC-2025-0118
+          # TODO: Remove once litep2p moves to hickory-proto 0.26; no patched hickory 0.25.x exists and only litep2p still pulls hickory 0.25.x.
+          #   RUSTSEC-2026-0119: DNS message-encoding CPU exhaustion. RUSTSEC-2026-0118: NSEC3 loop, only reachable with hickory dnssec features we do not enable.
+          ignore: RUSTSEC-2026-0119, RUSTSEC-2026-0118

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -356,7 +356,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -367,7 +367,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1204,7 +1204,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 [[package]]
 name = "binary-merkle-tree"
 version = "16.1.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "hash-db",
  "log",
@@ -2403,7 +2403,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-parachain-inherent"
 version = "0.22.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2414,7 +2414,7 @@ dependencies = [
  "sc-client-api",
  "sc-consensus-babe",
  "sc-network-types",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c)",
  "sp-inherents",
  "sp-runtime",
  "sp-state-machine",
@@ -2425,7 +2425,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system"
 version = "0.25.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "array-bytes",
  "bytes",
@@ -2463,7 +2463,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system-proc-macro"
 version = "0.7.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
@@ -2474,7 +2474,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-core"
 version = "0.23.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "parity-scale-codec",
  "polkadot-core-primitives",
@@ -2491,7 +2491,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-parachain-inherent"
 version = "0.23.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2505,7 +2505,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-proof-size-hostfunction"
 version = "0.16.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "sp-externalities",
  "sp-runtime-interface",
@@ -2515,7 +2515,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-storage-weight-reclaim"
 version = "16.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-proof-size-hostfunction",
@@ -2532,7 +2532,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-interface"
 version = "0.28.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2552,7 +2552,7 @@ dependencies = [
 [[package]]
 name = "cumulus-test-relay-sproof-builder"
 version = "0.24.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
@@ -2758,7 +2758,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3682,7 +3682,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4138,7 +4138,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c)",
 ]
 
 [[package]]
@@ -4282,7 +4282,7 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 [[package]]
 name = "fork-tree"
 version = "13.0.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -4409,7 +4409,7 @@ checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 [[package]]
 name = "frame-benchmarking"
 version = "45.0.3"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -4433,7 +4433,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "53.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "Inflector",
  "array-bytes",
@@ -4512,7 +4512,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-solution-type"
 version = "16.1.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
@@ -4523,7 +4523,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-support"
 version = "45.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "frame-election-provider-solution-type",
  "frame-support",
@@ -4540,7 +4540,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "45.0.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "aquamarine",
  "frame-support",
@@ -4570,7 +4570,7 @@ dependencies = [
 [[package]]
 name = "frame-storage-access-test-runtime"
 version = "0.6.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "parity-scale-codec",
@@ -4584,7 +4584,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "45.1.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "aquamarine",
  "array-bytes",
@@ -4625,7 +4625,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "36.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -4638,14 +4638,14 @@ dependencies = [
  "proc-macro-warning",
  "proc-macro2",
  "quote",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c)",
  "syn 2.0.117",
 ]
 
 [[package]]
 name = "frame-support-procedural-tools"
 version = "13.0.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate 3.5.0",
@@ -4657,7 +4657,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "12.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4667,7 +4667,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "45.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "cfg-if",
  "docify",
@@ -4686,7 +4686,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "45.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4700,7 +4700,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "40.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "docify",
  "parity-scale-codec",
@@ -4710,7 +4710,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.51.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -4783,7 +4783,6 @@ name = "futures-bounded"
 version = "0.3.0"
 source = "git+https://github.com/thomaseizinger/rust-futures-bounded?rev=012803d343b5c604e65d3c238a8cd7a145616447#012803d343b5c604e65d3c238a8cd7a145616447"
 dependencies = [
- "futures-timer",
  "futures-util",
  "tokio",
 ]
@@ -5208,15 +5207,6 @@ dependencies = [
 
 [[package]]
 name = "hashlink"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
-dependencies = [
- "hashbrown 0.14.5",
-]
-
-[[package]]
-name = "hashlink"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
@@ -5320,7 +5310,6 @@ dependencies = [
  "once_cell",
  "rand 0.9.4",
  "ring",
- "socket2 0.5.10",
  "thiserror 2.0.18",
  "tinyvec",
  "tokio",
@@ -5780,27 +5769,6 @@ dependencies = [
 
 [[package]]
 name = "igd-next"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "516893339c97f6011282d5825ac94fc1c7aad5cad26bdc2d0cee068c0bf97f97"
-dependencies = [
- "async-trait",
- "attohttpc",
- "bytes",
- "futures",
- "http 1.4.0",
- "http-body-util",
- "hyper",
- "hyper-util",
- "log",
- "rand 0.9.4",
- "tokio",
- "url",
- "xmltree",
-]
-
-[[package]]
-name = "igd-next"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bac9a3c8278f43b4cd8463380f4a25653ac843e5b177e1d3eaf849cc9ba10d4d"
@@ -5987,7 +5955,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6473,108 +6441,65 @@ dependencies = [
 
 [[package]]
 name = "libp2p"
-version = "0.56.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=7e9532d65530ebd0cf92c53fc326948ee8467fea#7e9532d65530ebd0cf92c53fc326948ee8467fea"
-dependencies = [
- "bytes",
- "either",
- "futures",
- "futures-timer",
- "getrandom 0.2.17",
- "libp2p-allow-block-list 0.6.0",
- "libp2p-connection-limits 0.6.0",
- "libp2p-core 0.43.1",
- "libp2p-dns 0.44.0",
- "libp2p-identify 0.47.0",
- "libp2p-identity",
- "libp2p-kad 0.48.0",
- "libp2p-mdns 0.48.0",
- "libp2p-metrics 0.17.0",
- "libp2p-noise 0.46.1",
- "libp2p-ping 0.47.0",
- "libp2p-quic 0.13.0",
- "libp2p-request-response 0.29.0",
- "libp2p-swarm 0.47.0",
- "libp2p-tcp 0.44.0",
- "libp2p-upnp 0.5.0",
- "libp2p-websocket",
- "libp2p-yamux 0.47.0",
- "multiaddr 0.18.2",
- "pin-project",
- "rw-stream-sink 0.4.0",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "libp2p"
 version = "0.57.0"
-source = "git+https://github.com/subspace/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
+source = "git+https://github.com/autonomys/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
 dependencies = [
  "bytes",
  "either",
  "futures",
  "futures-timer",
  "getrandom 0.2.17",
- "libp2p-allow-block-list 0.7.0",
+ "libp2p-allow-block-list",
  "libp2p-autonat",
- "libp2p-connection-limits 0.7.0",
- "libp2p-core 0.44.0",
- "libp2p-dns 0.45.0",
+ "libp2p-connection-limits",
+ "libp2p-core",
+ "libp2p-dns",
  "libp2p-gossipsub",
- "libp2p-identify 0.48.0",
+ "libp2p-identify",
  "libp2p-identity",
- "libp2p-kad 0.49.0",
- "libp2p-mdns 0.49.0",
- "libp2p-metrics 0.18.0",
- "libp2p-noise 0.47.0",
- "libp2p-ping 0.48.0",
+ "libp2p-kad",
+ "libp2p-mdns",
+ "libp2p-metrics",
+ "libp2p-noise",
+ "libp2p-ping",
  "libp2p-plaintext",
- "libp2p-quic 0.14.0",
- "libp2p-request-response 0.30.0",
- "libp2p-swarm 0.48.0",
- "libp2p-tcp 0.45.0",
- "libp2p-upnp 0.7.0",
- "libp2p-yamux 0.48.0",
+ "libp2p-quic",
+ "libp2p-request-response",
+ "libp2p-swarm",
+ "libp2p-tcp",
+ "libp2p-upnp",
+ "libp2p-websocket",
+ "libp2p-yamux",
  "multiaddr 0.18.2",
  "pin-project",
- "rw-stream-sink 0.5.0",
+ "rw-stream-sink",
  "thiserror 2.0.18",
-]
-
-[[package]]
-name = "libp2p-allow-block-list"
-version = "0.6.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=7e9532d65530ebd0cf92c53fc326948ee8467fea#7e9532d65530ebd0cf92c53fc326948ee8467fea"
-dependencies = [
- "libp2p-core 0.43.1",
- "libp2p-identity",
- "libp2p-swarm 0.47.0",
 ]
 
 [[package]]
 name = "libp2p-allow-block-list"
 version = "0.7.0"
-source = "git+https://github.com/subspace/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
+source = "git+https://github.com/autonomys/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
 dependencies = [
- "libp2p-core 0.44.0",
+ "libp2p-core",
  "libp2p-identity",
- "libp2p-swarm 0.48.0",
+ "libp2p-swarm",
 ]
 
 [[package]]
 name = "libp2p-autonat"
 version = "0.16.0"
-source = "git+https://github.com/subspace/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
+source = "git+https://github.com/autonomys/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
 dependencies = [
  "asynchronous-codec 0.7.0",
  "either",
  "futures",
  "futures-bounded",
  "futures-timer",
- "libp2p-core 0.44.0",
+ "libp2p-core",
  "libp2p-identity",
- "libp2p-request-response 0.30.0",
- "libp2p-swarm 0.48.0",
+ "libp2p-request-response",
+ "libp2p-swarm",
  "prost 0.14.3",
  "prost-codec",
  "rand 0.8.5",
@@ -6586,52 +6511,18 @@ dependencies = [
 
 [[package]]
 name = "libp2p-connection-limits"
-version = "0.6.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=7e9532d65530ebd0cf92c53fc326948ee8467fea#7e9532d65530ebd0cf92c53fc326948ee8467fea"
-dependencies = [
- "libp2p-core 0.43.1",
- "libp2p-identity",
- "libp2p-swarm 0.47.0",
-]
-
-[[package]]
-name = "libp2p-connection-limits"
 version = "0.7.0"
-source = "git+https://github.com/subspace/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
+source = "git+https://github.com/autonomys/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
 dependencies = [
- "libp2p-core 0.44.0",
+ "libp2p-core",
  "libp2p-identity",
- "libp2p-swarm 0.48.0",
-]
-
-[[package]]
-name = "libp2p-core"
-version = "0.43.1"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=7e9532d65530ebd0cf92c53fc326948ee8467fea#7e9532d65530ebd0cf92c53fc326948ee8467fea"
-dependencies = [
- "either",
- "fnv",
- "futures",
- "futures-timer",
- "libp2p-identity",
- "multiaddr 0.18.2",
- "multihash 0.19.5",
- "multistream-select 0.13.0",
- "parking_lot 0.12.5",
- "pin-project",
- "quick-protobuf",
- "rand 0.8.5",
- "rw-stream-sink 0.4.0",
- "thiserror 2.0.18",
- "tracing",
- "unsigned-varint 0.8.0",
- "web-time",
+ "libp2p-swarm",
 ]
 
 [[package]]
 name = "libp2p-core"
 version = "0.44.0"
-source = "git+https://github.com/subspace/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
+source = "git+https://github.com/autonomys/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
 dependencies = [
  "either",
  "fnv",
@@ -6640,41 +6531,26 @@ dependencies = [
  "libp2p-identity",
  "multiaddr 0.18.2",
  "multihash 0.19.5",
- "multistream-select 0.14.0",
+ "multistream-select",
  "parking_lot 0.12.5",
  "pin-project",
  "prost 0.14.3",
  "rand 0.8.5",
- "rw-stream-sink 0.5.0",
+ "rw-stream-sink",
  "thiserror 2.0.18",
  "tracing",
  "unsigned-varint 0.8.0",
  "web-time",
-]
-
-[[package]]
-name = "libp2p-dns"
-version = "0.44.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=7e9532d65530ebd0cf92c53fc326948ee8467fea#7e9532d65530ebd0cf92c53fc326948ee8467fea"
-dependencies = [
- "async-trait",
- "futures",
- "hickory-resolver 0.25.2",
- "libp2p-core 0.43.1",
- "libp2p-identity",
- "parking_lot 0.12.5",
- "smallvec",
- "tracing",
 ]
 
 [[package]]
 name = "libp2p-dns"
 version = "0.45.0"
-source = "git+https://github.com/subspace/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
+source = "git+https://github.com/autonomys/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
 dependencies = [
  "futures",
  "hickory-resolver 0.26.1",
- "libp2p-core 0.44.0",
+ "libp2p-core",
  "libp2p-identity",
  "parking_lot 0.12.5",
  "smallvec",
@@ -6684,7 +6560,7 @@ dependencies = [
 [[package]]
 name = "libp2p-gossipsub"
 version = "0.50.0"
-source = "git+https://github.com/subspace/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
+source = "git+https://github.com/autonomys/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
 dependencies = [
  "async-channel 2.5.0",
  "asynchronous-codec 0.7.0",
@@ -6698,10 +6574,10 @@ dependencies = [
  "getrandom 0.2.17",
  "hashlink 0.11.0",
  "hex_fmt",
- "libp2p-core 0.44.0",
+ "libp2p-core",
  "libp2p-identity",
- "libp2p-swarm 0.48.0",
- "prometheus-client 0.24.1",
+ "libp2p-swarm",
+ "prometheus-client",
  "prost 0.14.3",
  "prost-codec",
  "rand 0.8.5",
@@ -6714,37 +6590,17 @@ dependencies = [
 
 [[package]]
 name = "libp2p-identify"
-version = "0.47.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=7e9532d65530ebd0cf92c53fc326948ee8467fea#7e9532d65530ebd0cf92c53fc326948ee8467fea"
-dependencies = [
- "asynchronous-codec 0.7.0",
- "either",
- "futures",
- "futures-bounded",
- "futures-timer",
- "libp2p-core 0.43.1",
- "libp2p-identity",
- "libp2p-swarm 0.47.0",
- "quick-protobuf",
- "quick-protobuf-codec",
- "smallvec",
- "thiserror 2.0.18",
- "tracing",
-]
-
-[[package]]
-name = "libp2p-identify"
 version = "0.48.0"
-source = "git+https://github.com/subspace/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
+source = "git+https://github.com/autonomys/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
 dependencies = [
  "asynchronous-codec 0.7.0",
  "either",
  "futures",
  "futures-bounded",
  "futures-timer",
- "libp2p-core 0.44.0",
+ "libp2p-core",
  "libp2p-identity",
- "libp2p-swarm 0.48.0",
+ "libp2p-swarm",
  "prost 0.14.3",
  "prost-codec",
  "smallvec",
@@ -6755,7 +6611,7 @@ dependencies = [
 [[package]]
 name = "libp2p-identity"
 version = "0.2.14"
-source = "git+https://github.com/subspace/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
+source = "git+https://github.com/autonomys/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
 dependencies = [
  "bs58",
  "ed25519-dalek",
@@ -6772,34 +6628,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-kad"
-version = "0.48.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=7e9532d65530ebd0cf92c53fc326948ee8467fea#7e9532d65530ebd0cf92c53fc326948ee8467fea"
-dependencies = [
- "asynchronous-codec 0.7.0",
- "bytes",
- "either",
- "fnv",
- "futures",
- "futures-bounded",
- "futures-timer",
- "libp2p-core 0.43.1",
- "libp2p-identity",
- "libp2p-swarm 0.47.0",
- "quick-protobuf",
- "quick-protobuf-codec",
- "rand 0.8.5",
- "sha2 0.10.9",
- "smallvec",
- "thiserror 2.0.18",
- "tracing",
- "uint",
- "web-time",
-]
-
-[[package]]
-name = "libp2p-kad"
 version = "0.49.0"
-source = "git+https://github.com/subspace/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
+source = "git+https://github.com/autonomys/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
 dependencies = [
  "asynchronous-codec 0.7.0",
  "bytes",
@@ -6808,9 +6638,9 @@ dependencies = [
  "futures",
  "futures-bounded",
  "futures-timer",
- "libp2p-core 0.44.0",
+ "libp2p-core",
  "libp2p-identity",
- "libp2p-swarm 0.48.0",
+ "libp2p-swarm",
  "prost 0.14.3",
  "prost-codec",
  "rand 0.8.5",
@@ -6825,33 +6655,15 @@ dependencies = [
 
 [[package]]
 name = "libp2p-mdns"
-version = "0.48.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=7e9532d65530ebd0cf92c53fc326948ee8467fea#7e9532d65530ebd0cf92c53fc326948ee8467fea"
-dependencies = [
- "futures",
- "hickory-proto 0.25.2",
- "if-watch",
- "libp2p-core 0.43.1",
- "libp2p-identity",
- "libp2p-swarm 0.47.0",
- "rand 0.8.5",
- "smallvec",
- "socket2 0.5.10",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "libp2p-mdns"
 version = "0.49.0"
-source = "git+https://github.com/subspace/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
+source = "git+https://github.com/autonomys/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
 dependencies = [
  "futures",
  "hickory-proto 0.26.1",
  "if-watch",
- "libp2p-core 0.44.0",
+ "libp2p-core",
  "libp2p-identity",
- "libp2p-swarm 0.48.0",
+ "libp2p-swarm",
  "rand 0.8.5",
  "smallvec",
  "socket2 0.6.3",
@@ -6861,70 +6673,31 @@ dependencies = [
 
 [[package]]
 name = "libp2p-metrics"
-version = "0.17.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=7e9532d65530ebd0cf92c53fc326948ee8467fea#7e9532d65530ebd0cf92c53fc326948ee8467fea"
-dependencies = [
- "futures",
- "libp2p-core 0.43.1",
- "libp2p-identify 0.47.0",
- "libp2p-identity",
- "libp2p-kad 0.48.0",
- "libp2p-ping 0.47.0",
- "libp2p-swarm 0.47.0",
- "pin-project",
- "prometheus-client 0.23.1",
- "web-time",
-]
-
-[[package]]
-name = "libp2p-metrics"
 version = "0.18.0"
-source = "git+https://github.com/subspace/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
+source = "git+https://github.com/autonomys/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
 dependencies = [
  "futures",
- "libp2p-core 0.44.0",
+ "libp2p-core",
  "libp2p-gossipsub",
- "libp2p-identify 0.48.0",
+ "libp2p-identify",
  "libp2p-identity",
- "libp2p-kad 0.49.0",
- "libp2p-ping 0.48.0",
- "libp2p-swarm 0.48.0",
+ "libp2p-kad",
+ "libp2p-ping",
+ "libp2p-swarm",
  "pin-project",
- "prometheus-client 0.24.1",
+ "prometheus-client",
  "web-time",
-]
-
-[[package]]
-name = "libp2p-noise"
-version = "0.46.1"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=7e9532d65530ebd0cf92c53fc326948ee8467fea#7e9532d65530ebd0cf92c53fc326948ee8467fea"
-dependencies = [
- "asynchronous-codec 0.7.0",
- "bytes",
- "futures",
- "libp2p-core 0.43.1",
- "libp2p-identity",
- "multiaddr 0.18.2",
- "multihash 0.19.5",
- "quick-protobuf",
- "rand 0.8.5",
- "snow",
- "static_assertions",
- "thiserror 2.0.18",
- "tracing",
- "x25519-dalek",
- "zeroize",
 ]
 
 [[package]]
 name = "libp2p-noise"
 version = "0.47.0"
-source = "git+https://github.com/subspace/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
+source = "git+https://github.com/autonomys/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
 dependencies = [
  "asynchronous-codec 0.7.0",
  "bytes",
  "futures",
- "libp2p-core 0.44.0",
+ "libp2p-core",
  "libp2p-identity",
  "multiaddr 0.18.2",
  "multihash 0.19.5",
@@ -6940,29 +6713,14 @@ dependencies = [
 
 [[package]]
 name = "libp2p-ping"
-version = "0.47.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=7e9532d65530ebd0cf92c53fc326948ee8467fea#7e9532d65530ebd0cf92c53fc326948ee8467fea"
-dependencies = [
- "futures",
- "futures-timer",
- "libp2p-core 0.43.1",
- "libp2p-identity",
- "libp2p-swarm 0.47.0",
- "rand 0.8.5",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "libp2p-ping"
 version = "0.48.0"
-source = "git+https://github.com/subspace/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
+source = "git+https://github.com/autonomys/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
 dependencies = [
  "futures",
  "futures-timer",
- "libp2p-core 0.44.0",
+ "libp2p-core",
  "libp2p-identity",
- "libp2p-swarm 0.48.0",
+ "libp2p-swarm",
  "rand 0.8.5",
  "tracing",
  "web-time",
@@ -6971,12 +6729,12 @@ dependencies = [
 [[package]]
 name = "libp2p-plaintext"
 version = "0.44.0"
-source = "git+https://github.com/subspace/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
+source = "git+https://github.com/autonomys/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
 dependencies = [
  "asynchronous-codec 0.7.0",
  "bytes",
  "futures",
- "libp2p-core 0.44.0",
+ "libp2p-core",
  "libp2p-identity",
  "prost 0.14.3",
  "prost-codec",
@@ -6985,36 +6743,15 @@ dependencies = [
 
 [[package]]
 name = "libp2p-quic"
-version = "0.13.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=7e9532d65530ebd0cf92c53fc326948ee8467fea#7e9532d65530ebd0cf92c53fc326948ee8467fea"
-dependencies = [
- "futures",
- "futures-timer",
- "if-watch",
- "libp2p-core 0.43.1",
- "libp2p-identity",
- "libp2p-tls 0.6.2",
- "quinn",
- "rand 0.8.5",
- "ring",
- "rustls",
- "socket2 0.5.10",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "libp2p-quic"
 version = "0.14.0"
-source = "git+https://github.com/subspace/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
+source = "git+https://github.com/autonomys/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
 dependencies = [
  "futures",
  "futures-timer",
  "if-watch",
- "libp2p-core 0.44.0",
+ "libp2p-core",
  "libp2p-identity",
- "libp2p-tls 0.7.0",
+ "libp2p-tls",
  "quinn",
  "rand 0.8.5",
  "ring",
@@ -7027,60 +6764,23 @@ dependencies = [
 
 [[package]]
 name = "libp2p-request-response"
-version = "0.29.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=7e9532d65530ebd0cf92c53fc326948ee8467fea#7e9532d65530ebd0cf92c53fc326948ee8467fea"
-dependencies = [
- "async-trait",
- "futures",
- "futures-bounded",
- "libp2p-core 0.43.1",
- "libp2p-identity",
- "libp2p-swarm 0.47.0",
- "rand 0.8.5",
- "smallvec",
- "tracing",
-]
-
-[[package]]
-name = "libp2p-request-response"
 version = "0.30.0"
-source = "git+https://github.com/subspace/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
+source = "git+https://github.com/autonomys/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
 dependencies = [
  "futures",
  "futures-bounded",
- "libp2p-core 0.44.0",
+ "libp2p-core",
  "libp2p-identity",
- "libp2p-swarm 0.48.0",
+ "libp2p-swarm",
  "rand 0.8.5",
  "smallvec",
  "tracing",
-]
-
-[[package]]
-name = "libp2p-swarm"
-version = "0.47.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=7e9532d65530ebd0cf92c53fc326948ee8467fea#7e9532d65530ebd0cf92c53fc326948ee8467fea"
-dependencies = [
- "either",
- "fnv",
- "futures",
- "futures-timer",
- "hashlink 0.9.1",
- "libp2p-core 0.43.1",
- "libp2p-identity",
- "libp2p-swarm-derive 0.35.1",
- "multistream-select 0.13.0",
- "rand 0.8.5",
- "smallvec",
- "tokio",
- "tracing",
- "web-time",
 ]
 
 [[package]]
 name = "libp2p-swarm"
 version = "0.48.0"
-source = "git+https://github.com/subspace/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
+source = "git+https://github.com/autonomys/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
 dependencies = [
  "either",
  "fnv",
@@ -7088,10 +6788,10 @@ dependencies = [
  "futures-timer",
  "getrandom 0.2.17",
  "hashlink 0.11.0",
- "libp2p-core 0.44.0",
+ "libp2p-core",
  "libp2p-identity",
- "libp2p-swarm-derive 0.36.0",
- "multistream-select 0.14.0",
+ "libp2p-swarm-derive",
+ "multistream-select",
  "rand 0.8.5",
  "smallvec",
  "tokio",
@@ -7102,18 +6802,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-swarm-derive"
-version = "0.35.1"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=7e9532d65530ebd0cf92c53fc326948ee8467fea#7e9532d65530ebd0cf92c53fc326948ee8467fea"
-dependencies = [
- "heck 0.5.0",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "libp2p-swarm-derive"
 version = "0.36.0"
-source = "git+https://github.com/subspace/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
+source = "git+https://github.com/autonomys/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
 dependencies = [
  "heck 0.5.0",
  "quote",
@@ -7123,45 +6813,30 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm-test"
 version = "0.7.0"
-source = "git+https://github.com/subspace/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
+source = "git+https://github.com/autonomys/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
 dependencies = [
  "async-trait",
  "futures",
  "futures-timer",
- "libp2p-core 0.44.0",
+ "libp2p-core",
  "libp2p-identity",
  "libp2p-plaintext",
- "libp2p-swarm 0.48.0",
- "libp2p-tcp 0.45.0",
- "libp2p-yamux 0.48.0",
- "tracing",
-]
-
-[[package]]
-name = "libp2p-tcp"
-version = "0.44.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=7e9532d65530ebd0cf92c53fc326948ee8467fea#7e9532d65530ebd0cf92c53fc326948ee8467fea"
-dependencies = [
- "futures",
- "futures-timer",
- "if-watch",
- "libc",
- "libp2p-core 0.43.1",
- "socket2 0.5.10",
- "tokio",
+ "libp2p-swarm",
+ "libp2p-tcp",
+ "libp2p-yamux",
  "tracing",
 ]
 
 [[package]]
 name = "libp2p-tcp"
 version = "0.45.0"
-source = "git+https://github.com/subspace/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
+source = "git+https://github.com/autonomys/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
 dependencies = [
  "futures",
  "futures-timer",
  "if-watch",
  "libc",
- "libp2p-core 0.44.0",
+ "libp2p-core",
  "socket2 0.6.3",
  "tokio",
  "tracing",
@@ -7169,30 +6844,12 @@ dependencies = [
 
 [[package]]
 name = "libp2p-tls"
-version = "0.6.2"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=7e9532d65530ebd0cf92c53fc326948ee8467fea#7e9532d65530ebd0cf92c53fc326948ee8467fea"
-dependencies = [
- "futures",
- "futures-rustls",
- "libp2p-core 0.43.1",
- "libp2p-identity",
- "rcgen",
- "ring",
- "rustls",
- "rustls-webpki",
- "thiserror 2.0.18",
- "x509-parser 0.17.0",
- "yasna 0.5.2",
-]
-
-[[package]]
-name = "libp2p-tls"
 version = "0.7.0"
-source = "git+https://github.com/subspace/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
+source = "git+https://github.com/autonomys/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
 dependencies = [
  "futures",
  "futures-rustls",
- "libp2p-core 0.44.0",
+ "libp2p-core",
  "libp2p-identity",
  "rcgen",
  "ring",
@@ -7205,45 +6862,31 @@ dependencies = [
 
 [[package]]
 name = "libp2p-upnp"
-version = "0.5.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=7e9532d65530ebd0cf92c53fc326948ee8467fea#7e9532d65530ebd0cf92c53fc326948ee8467fea"
-dependencies = [
- "futures",
- "futures-timer",
- "igd-next 0.16.2",
- "libp2p-core 0.43.1",
- "libp2p-swarm 0.47.0",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "libp2p-upnp"
 version = "0.7.0"
-source = "git+https://github.com/subspace/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
+source = "git+https://github.com/autonomys/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
 dependencies = [
  "futures",
  "futures-timer",
- "igd-next 0.17.0",
- "libp2p-core 0.44.0",
- "libp2p-swarm 0.48.0",
+ "igd-next",
+ "libp2p-core",
+ "libp2p-swarm",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "libp2p-websocket"
-version = "0.45.1"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=7e9532d65530ebd0cf92c53fc326948ee8467fea#7e9532d65530ebd0cf92c53fc326948ee8467fea"
+version = "0.46.0"
+source = "git+https://github.com/autonomys/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
 dependencies = [
  "either",
  "futures",
  "futures-rustls",
- "libp2p-core 0.43.1",
+ "libp2p-core",
  "libp2p-identity",
  "parking_lot 0.12.5",
  "pin-project-lite",
- "rw-stream-sink 0.4.0",
+ "rw-stream-sink",
  "soketto",
  "thiserror 2.0.18",
  "tracing",
@@ -7253,26 +6896,12 @@ dependencies = [
 
 [[package]]
 name = "libp2p-yamux"
-version = "0.47.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=7e9532d65530ebd0cf92c53fc326948ee8467fea#7e9532d65530ebd0cf92c53fc326948ee8467fea"
-dependencies = [
- "either",
- "futures",
- "libp2p-core 0.43.1",
- "thiserror 2.0.18",
- "tracing",
- "yamux 0.12.1",
- "yamux 0.13.10",
-]
-
-[[package]]
-name = "libp2p-yamux"
 version = "0.48.0"
-source = "git+https://github.com/subspace/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
+source = "git+https://github.com/autonomys/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
 dependencies = [
  "either",
  "futures",
- "libp2p-core 0.44.0",
+ "libp2p-core",
  "thiserror 2.0.18",
  "tracing",
  "yamux 0.12.1",
@@ -7730,7 +7359,7 @@ dependencies = [
 [[package]]
 name = "mmr-gadget"
 version = "50.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "futures",
  "log",
@@ -7749,7 +7378,7 @@ dependencies = [
 [[package]]
 name = "mmr-rpc"
 version = "44.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -7908,21 +7537,8 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "multistream-select"
-version = "0.13.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=7e9532d65530ebd0cf92c53fc326948ee8467fea#7e9532d65530ebd0cf92c53fc326948ee8467fea"
-dependencies = [
- "bytes",
- "futures",
- "pin-project",
- "smallvec",
- "tracing",
- "unsigned-varint 0.8.0",
-]
-
-[[package]]
-name = "multistream-select"
 version = "0.14.0"
-source = "git+https://github.com/subspace/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
+source = "git+https://github.com/autonomys/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
 dependencies = [
  "bytes",
  "futures",
@@ -8119,7 +7735,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8247,7 +7863,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 1.1.3",
+ "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -8399,7 +8015,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-conversion"
 version = "27.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8417,7 +8033,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "45.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8432,7 +8048,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "45.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8465,7 +8081,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "45.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8488,7 +8104,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "46.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8520,7 +8136,7 @@ dependencies = [
 [[package]]
 name = "pallet-broker"
 version = "0.24.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -8538,7 +8154,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "45.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8555,7 +8171,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "45.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8752,7 +8368,7 @@ dependencies = [
 [[package]]
 name = "pallet-message-queue"
 version = "48.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -8795,7 +8411,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr"
 version = "45.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -8807,7 +8423,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "45.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -8818,7 +8434,7 @@ dependencies = [
 [[package]]
 name = "pallet-preimage"
 version = "45.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8867,7 +8483,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "46.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8884,7 +8500,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "45.2.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8906,7 +8522,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "45.1.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -8987,7 +8603,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "45.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9002,7 +8618,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "44.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9031,7 +8647,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "45.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9047,7 +8663,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "48.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -9063,7 +8679,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "45.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -9096,7 +8712,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "45.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9456,7 +9072,7 @@ dependencies = [
 [[package]]
 name = "polkadot-core-primitives"
 version = "21.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9467,7 +9083,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-metrics"
 version = "28.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "bs58",
  "futures",
@@ -9484,7 +9100,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-network-protocol"
 version = "28.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -9509,7 +9125,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-primitives"
 version = "23.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "bitvec",
  "bounded-vec",
@@ -9533,7 +9149,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-types"
 version = "28.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "async-trait",
  "derive_more 0.99.20",
@@ -9561,7 +9177,7 @@ dependencies = [
 [[package]]
 name = "polkadot-overseer"
 version = "28.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "async-trait",
  "futures",
@@ -9581,7 +9197,7 @@ dependencies = [
 [[package]]
 name = "polkadot-parachain-primitives"
 version = "20.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "array-bytes",
  "bounded-collections",
@@ -9598,7 +9214,7 @@ dependencies = [
 [[package]]
 name = "polkadot-primitives"
 version = "22.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "bitvec",
  "bounded-collections",
@@ -9627,7 +9243,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-metrics"
 version = "25.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "bs58",
  "frame-benchmarking",
@@ -9639,7 +9255,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-parachains"
 version = "24.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "bitflags 1.3.2",
  "bitvec",
@@ -9687,7 +9303,7 @@ dependencies = [
 [[package]]
 name = "polkadot-sdk-frame"
 version = "0.14.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9722,7 +9338,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-table"
 version = "23.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
@@ -9938,7 +9554,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c)",
  "syn 2.0.117",
 ]
 
@@ -10134,18 +9750,6 @@ dependencies = [
 
 [[package]]
 name = "prometheus-client"
-version = "0.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf41c1a7c32ed72abe5082fb19505b969095c12da9f5732a4bc9878757fd087c"
-dependencies = [
- "dtoa",
- "itoa",
- "parking_lot 0.12.5",
- "prometheus-client-derive-encode 0.4.2",
-]
-
-[[package]]
-name = "prometheus-client"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cca3d75b4566b9a29fe1ed623587fb058e826eb329a0be4b7c4da1ebb2d7a6ca"
@@ -10153,18 +9757,7 @@ dependencies = [
  "dtoa",
  "itoa",
  "parking_lot 0.12.5",
- "prometheus-client-derive-encode 0.5.0",
-]
-
-[[package]]
-name = "prometheus-client-derive-encode"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
+ "prometheus-client-derive-encode",
 ]
 
 [[package]]
@@ -10242,8 +9835,8 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.4.1",
- "itertools 0.11.0",
+ "heck 0.5.0",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
@@ -10262,8 +9855,8 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.4.1",
- "itertools 0.11.0",
+ "heck 0.5.0",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph 0.8.3",
@@ -10278,7 +9871,7 @@ dependencies = [
 [[package]]
 name = "prost-codec"
 version = "0.4.0"
-source = "git+https://github.com/subspace/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
+source = "git+https://github.com/autonomys/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
 dependencies = [
  "asynchronous-codec 0.7.0",
  "bytes",
@@ -10307,7 +9900,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -10320,7 +9913,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -10387,27 +9980,6 @@ name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
-
-[[package]]
-name = "quick-protobuf"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d6da84cc204722a989e01ba2f6e1e276e190f22263d0cb6ce8526fcdb0d2e1f"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
-name = "quick-protobuf-codec"
-version = "0.3.1"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=7e9532d65530ebd0cf92c53fc326948ee8467fea#7e9532d65530ebd0cf92c53fc326948ee8467fea"
-dependencies = [
- "asynchronous-codec 0.7.0",
- "bytes",
- "quick-protobuf",
- "thiserror 2.0.18",
- "unsigned-varint 0.8.0",
-]
 
 [[package]]
 name = "quinn"
@@ -10997,7 +10569,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11101,18 +10673,8 @@ checksum = "e5ff0cc5e135c8870a775d3320910cd9b564ec036b4dc0b8741629020be63f01"
 
 [[package]]
 name = "rw-stream-sink"
-version = "0.4.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=7e9532d65530ebd0cf92c53fc326948ee8467fea#7e9532d65530ebd0cf92c53fc326948ee8467fea"
-dependencies = [
- "futures",
- "pin-project",
- "static_assertions",
-]
-
-[[package]]
-name = "rw-stream-sink"
 version = "0.5.0"
-source = "git+https://github.com/subspace/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
+source = "git+https://github.com/autonomys/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
 dependencies = [
  "futures",
  "pin-project",
@@ -11155,7 +10717,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "35.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "log",
  "sp-core",
@@ -11166,7 +10728,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.55.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "async-trait",
  "futures",
@@ -11198,7 +10760,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.53.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "futures",
  "log",
@@ -11220,7 +10782,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.48.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -11235,7 +10797,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "48.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "array-bytes",
  "docify",
@@ -11250,7 +10812,7 @@ dependencies = [
  "serde_json",
  "sp-blockchain",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c)",
  "sp-genesis-builder",
  "sp-io",
  "sp-runtime",
@@ -11261,7 +10823,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "12.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
@@ -11272,7 +10834,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.57.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "array-bytes",
  "bip39",
@@ -11314,7 +10876,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "44.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "fnv",
  "futures",
@@ -11340,7 +10902,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.51.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -11367,7 +10929,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.54.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "async-trait",
  "futures",
@@ -11390,7 +10952,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.55.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -11415,7 +10977,7 @@ dependencies = [
  "sp-consensus-babe",
  "sp-consensus-slots",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c)",
  "sp-inherents",
  "sp-keystore",
  "sp-runtime",
@@ -11427,7 +10989,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.54.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -11440,7 +11002,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.54.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "async-trait",
  "futures",
@@ -11570,7 +11132,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.47.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.5",
@@ -11593,7 +11155,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.43.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "polkavm",
  "sc-allocator",
@@ -11606,7 +11168,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-polkavm"
 version = "0.40.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "log",
  "polkavm",
@@ -11617,7 +11179,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.43.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "anyhow",
  "log",
@@ -11633,7 +11195,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.54.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "console",
  "futures",
@@ -11649,7 +11211,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "39.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "array-bytes",
  "parking_lot 0.12.5",
@@ -11663,7 +11225,7 @@ dependencies = [
 [[package]]
 name = "sc-mixnet"
 version = "0.25.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "array-bytes",
  "arrayvec 0.7.6",
@@ -11691,7 +11253,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.55.2"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -11703,7 +11265,7 @@ dependencies = [
  "futures",
  "futures-timer",
  "ip_network",
- "libp2p 0.56.0",
+ "libp2p",
  "linked_hash_set",
  "litep2p",
  "log",
@@ -11740,7 +11302,7 @@ dependencies = [
 [[package]]
 name = "sc-network-common"
 version = "0.52.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "bitflags 1.3.2",
  "parity-scale-codec",
@@ -11750,7 +11312,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.55.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "ahash 0.8.12",
  "futures",
@@ -11769,7 +11331,7 @@ dependencies = [
 [[package]]
 name = "sc-network-light"
 version = "0.54.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -11790,7 +11352,7 @@ dependencies = [
 [[package]]
 name = "sc-network-sync"
 version = "0.54.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -11825,7 +11387,7 @@ dependencies = [
 [[package]]
 name = "sc-network-transactions"
 version = "0.54.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "array-bytes",
  "futures",
@@ -11844,13 +11406,13 @@ dependencies = [
 [[package]]
 name = "sc-network-types"
 version = "0.20.2"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "bs58",
  "bytes",
  "ed25519-dalek",
  "libp2p-identity",
- "libp2p-kad 0.48.0",
+ "libp2p-kad",
  "litep2p",
  "log",
  "multiaddr 0.18.2",
@@ -11865,7 +11427,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "50.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "bytes",
  "fnv",
@@ -11928,7 +11490,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.20.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -11937,7 +11499,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "50.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -11969,7 +11531,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.54.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -11989,7 +11551,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "27.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "dyn-clone",
  "forwarded-header-value",
@@ -12013,7 +11575,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-spec-v2"
 version = "0.55.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "array-bytes",
  "futures",
@@ -12046,13 +11608,13 @@ dependencies = [
 [[package]]
 name = "sc-runtime-utilities"
 version = "0.7.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "parity-scale-codec",
  "sc-executor",
  "sc-executor-common",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c)",
  "sp-state-machine",
  "sp-wasm-interface",
  "thiserror 1.0.69",
@@ -12061,7 +11623,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.56.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "async-trait",
  "directories",
@@ -12125,7 +11687,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.41.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -12136,7 +11698,7 @@ dependencies = [
 [[package]]
 name = "sc-storage-monitor"
 version = "0.27.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "clap",
  "fs4 0.7.0",
@@ -12194,7 +11756,7 @@ dependencies = [
 [[package]]
 name = "sc-sysinfo"
 version = "46.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "derive_more 0.99.20",
  "futures",
@@ -12207,18 +11769,18 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c)",
  "sp-io",
 ]
 
 [[package]]
 name = "sc-telemetry"
 version = "30.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "chrono",
  "futures",
- "libp2p 0.56.0",
+ "libp2p",
  "log",
  "parking_lot 0.12.5",
  "pin-project",
@@ -12233,7 +11795,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "44.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "chrono",
  "console",
@@ -12261,7 +11823,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "11.1.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
@@ -12272,7 +11834,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "44.1.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "async-trait",
  "futures",
@@ -12289,7 +11851,7 @@ dependencies = [
  "sp-api",
  "sp-blockchain",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c)",
  "sp-runtime",
  "sp-tracing",
  "sp-transaction-pool",
@@ -12304,7 +11866,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "43.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "async-trait",
  "futures",
@@ -12322,7 +11884,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "20.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "async-channel 1.9.0",
  "futures",
@@ -13163,7 +12725,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -13185,7 +12747,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "40.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "docify",
  "hash-db",
@@ -13207,7 +12769,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "26.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "Inflector",
  "blake2 0.10.6",
@@ -13221,7 +12783,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "44.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -13233,7 +12795,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "28.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "docify",
  "integer-sqrt",
@@ -13247,7 +12809,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "40.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -13272,7 +12834,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "40.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "sp-api",
  "sp-inherents",
@@ -13293,7 +12855,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "43.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -13312,7 +12874,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.46.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "async-trait",
  "futures",
@@ -13326,7 +12888,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.46.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -13342,7 +12904,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.46.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -13360,7 +12922,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-beefy"
 version = "28.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -13368,7 +12930,7 @@ dependencies = [
  "sp-api",
  "sp-application-crypto",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c)",
  "sp-io",
  "sp-keystore",
  "sp-mmr-primitives",
@@ -13380,7 +12942,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-grandpa"
 version = "27.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -13397,7 +12959,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.46.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -13436,7 +12998,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "39.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "ark-vrf",
  "array-bytes",
@@ -13467,7 +13029,7 @@ dependencies = [
  "secrecy 0.8.0",
  "serde",
  "sha2 0.10.9",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c)",
  "sp-debug-derive",
  "sp-externalities",
  "sp-std",
@@ -13497,7 +13059,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing"
 version = "0.1.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -13510,17 +13072,17 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "quote",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c)",
  "syn 2.0.117",
 ]
 
 [[package]]
 name = "sp-database"
 version = "10.0.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.5",
@@ -13529,7 +13091,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "14.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -13682,7 +13244,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.31.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -13692,7 +13254,7 @@ dependencies = [
 [[package]]
 name = "sp-genesis-builder"
 version = "0.21.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -13704,7 +13266,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "40.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -13717,7 +13279,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "44.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "bytes",
  "docify",
@@ -13729,7 +13291,7 @@ dependencies = [
  "rustversion",
  "secp256k1 0.28.2",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c)",
  "sp-externalities",
  "sp-keystore",
  "sp-runtime-interface",
@@ -13743,7 +13305,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "45.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "sp-core",
  "sp-runtime",
@@ -13753,7 +13315,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.45.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.5",
@@ -13764,7 +13326,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "11.1.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "thiserror 1.0.69",
  "zstd 0.12.4",
@@ -13812,7 +13374,7 @@ dependencies = [
 [[package]]
 name = "sp-metadata-ir"
 version = "0.12.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "frame-metadata",
  "parity-scale-codec",
@@ -13822,7 +13384,7 @@ dependencies = [
 [[package]]
 name = "sp-mixnet"
 version = "0.18.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -13833,7 +13395,7 @@ dependencies = [
 [[package]]
 name = "sp-mmr-primitives"
 version = "40.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -13850,7 +13412,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "40.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -13871,7 +13433,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "40.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -13881,7 +13443,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "13.0.2"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "backtrace",
  "regex",
@@ -13890,7 +13452,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "37.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "rustc-hash 1.1.0",
  "serde",
@@ -13900,7 +13462,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "45.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "binary-merkle-tree",
  "bytes",
@@ -13931,7 +13493,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "33.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -13949,7 +13511,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "20.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "Inflector",
  "expander",
@@ -13962,7 +13524,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "42.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -13976,7 +13538,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "42.2.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -13989,7 +13551,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.49.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "hash-db",
  "log",
@@ -14009,7 +13571,7 @@ dependencies = [
 [[package]]
 name = "sp-statement-store"
 version = "24.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "aes-gcm",
  "curve25519-dalek",
@@ -14022,7 +13584,7 @@ dependencies = [
  "sp-api",
  "sp-application-crypto",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c)",
  "sp-externalities",
  "sp-runtime",
  "sp-runtime-interface",
@@ -14033,12 +13595,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "14.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 
 [[package]]
 name = "sp-storage"
 version = "22.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -14068,7 +13630,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "40.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -14080,7 +13642,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "19.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "parity-scale-codec",
  "regex",
@@ -14092,7 +13654,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "40.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -14101,7 +13663,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "40.1.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -14116,7 +13678,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "42.0.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "ahash 0.8.12",
  "foldhash 0.1.5",
@@ -14141,7 +13703,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "43.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -14158,7 +13720,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "15.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "parity-scale-codec",
  "proc-macro-warning",
@@ -14170,7 +13732,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "24.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -14182,7 +13744,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "33.2.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "bounded-collections",
  "parity-scale-codec",
@@ -14260,7 +13822,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 [[package]]
 name = "staging-xcm"
 version = "21.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "array-bytes",
  "bounded-collections",
@@ -14281,7 +13843,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-builder"
 version = "25.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "environmental",
  "frame-support",
@@ -14305,7 +13867,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-executor"
 version = "24.0.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -14447,8 +14009,8 @@ dependencies = [
  "clap",
  "futures",
  "hex",
- "libp2p 0.57.0",
- "prometheus-client 0.24.1",
+ "libp2p",
+ "prometheus-client",
  "serde",
  "serde_json",
  "subspace-metrics",
@@ -14568,7 +14130,7 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.5",
  "pin-project",
- "prometheus-client 0.24.1",
+ "prometheus-client",
  "rand 0.8.5",
  "rayon",
  "schnorrkel",
@@ -14778,7 +14340,7 @@ version = "0.1.0"
 dependencies = [
  "actix-web",
  "prometheus",
- "prometheus-client 0.24.1",
+ "prometheus-client",
  "tracing",
 ]
 
@@ -14797,7 +14359,7 @@ dependencies = [
  "futures",
  "futures-timer",
  "hex",
- "libp2p 0.57.0",
+ "libp2p",
  "libp2p-swarm-test",
  "memmap2 0.9.10",
  "multihash 0.19.5",
@@ -14805,7 +14367,7 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.5",
  "pin-project",
- "prometheus-client 0.24.1",
+ "prometheus-client",
  "rand 0.8.5",
  "schnellru",
  "subspace-core-primitives",
@@ -14842,7 +14404,7 @@ dependencies = [
  "hex-literal 1.1.0",
  "mimalloc",
  "parity-scale-codec",
- "prometheus-client 0.24.1",
+ "prometheus-client",
  "sc-chain-spec",
  "sc-cli",
  "sc-client-api",
@@ -15060,7 +14622,7 @@ dependencies = [
  "pallet-transaction-payment-rpc-runtime-api",
  "parity-scale-codec",
  "parking_lot 0.12.5",
- "prometheus-client 0.24.1",
+ "prometheus-client",
  "rayon",
  "sc-basic-authorship",
  "sc-chain-spec",
@@ -15327,12 +14889,12 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "11.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "49.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "docify",
  "frame-system-rpc-runtime-api",
@@ -15352,7 +14914,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.17.7"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "http-body-util",
  "hyper",
@@ -15366,7 +14928,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-client"
 version = "2.0.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "array-bytes",
  "async-trait",
@@ -15391,7 +14953,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "31.1.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "build-helper",
  "cargo_metadata",
@@ -15754,7 +15316,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -15773,7 +15335,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -16259,7 +15821,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum"
 version = "23.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "coarsetime",
  "polkadot-primitives",
@@ -16270,7 +15832,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "expander",
  "proc-macro-crate 3.5.0",
@@ -17335,7 +16897,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -18071,7 +17633,7 @@ dependencies = [
 [[package]]
 name = "xcm-procedural"
 version = "11.0.2"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d008c68f08ea8c76040c2be6ff1a593f52f88342#d008c68f08ea8c76040c2be6ff1a593f52f88342"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "Inflector",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ core_affinity = "0.8.1"
 cpufeatures = "0.3.0"
 criterion = { version = "0.8.2", default-features = false }
 cross-domain-message-gossip = { version = "0.1.0", path = "domains/client/cross-domain-message-gossip" }
-cumulus-primitives-proof-size-hostfunction = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
+cumulus-primitives-proof-size-hostfunction = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
 derive_more = { version = "2.1.1", default-features = false }
 domain-block-builder = { version = "0.1.0", path = "domains/client/block-builder", default-features = false }
 domain-block-preprocessor = { version = "0.1.0", path = "domains/client/block-preprocessor", default-features = false }
@@ -89,13 +89,13 @@ fp-account = { version = "1.0.0-dev", git = "https://github.com/polkadot-evm/fro
 fp-evm = { version = "3.0.0-dev", git = "https://github.com/polkadot-evm/frontier", rev = "9d49e36ed5bac38241594f8ba055fdb94991483a", default-features = false }
 fp-rpc = { version = "3.0.0-dev", git = "https://github.com/polkadot-evm/frontier", rev = "9d49e36ed5bac38241594f8ba055fdb94991483a", default-features = false }
 fp-self-contained = { version = "1.0.0-dev", git = "https://github.com/polkadot-evm/frontier", rev = "9d49e36ed5bac38241594f8ba055fdb94991483a", default-features = false }
-frame-benchmarking = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
-frame-benchmarking-cli = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
-frame-executive = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
-frame-support = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
-frame-system = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
-frame-system-benchmarking = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
-frame-system-rpc-runtime-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
+frame-benchmarking = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
+frame-benchmarking-cli = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
+frame-executive = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
+frame-support = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
+frame-system = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
+frame-system-benchmarking = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
+frame-system-rpc-runtime-api = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
 fs2 = "0.4.3"
 fs4 = "1.1.0"
 futures = "0.3.31"
@@ -107,15 +107,15 @@ hwlocality = "1.0.0-alpha.12"
 jsonrpsee = "0.24.10"
 kzg = { git = "https://github.com/grandinetech/rust-kzg", rev = "8f5f1a0f73b3c529c77cb880ff8d265830c7d7ac", default-features = false }
 libc = "0.2.186"
-libp2p = { version = "0.57.0", git = "https://github.com/subspace/rust-libp2p", rev = "676c687c2f7a6e92f8f4f77a6934022aec3ba16c", default-features = false }
-libp2p-swarm-test = { version = "0.7.0", git = "https://github.com/subspace/rust-libp2p", rev = "676c687c2f7a6e92f8f4f77a6934022aec3ba16c" }
+libp2p = { version = "0.57.0", git = "https://github.com/autonomys/rust-libp2p", rev = "676c687c2f7a6e92f8f4f77a6934022aec3ba16c", default-features = false }
+libp2p-swarm-test = { version = "0.7.0", git = "https://github.com/autonomys/rust-libp2p", rev = "676c687c2f7a6e92f8f4f77a6934022aec3ba16c" }
 libsecp256k1 = "0.7.1"
 log = { version = "0.4.22", default-features = false }
 memmap2 = "0.9.5"
 memory-db = { version = "0.34.0", default-features = false }
 mimalloc = "0.1.50"
-mmr-gadget = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
-mmr-rpc = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
+mmr-gadget = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
+mmr-rpc = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
 multihash = "0.19.5"
 nohash-hasher = "0.2.0"
 num-traits = { version = "0.2.18", default-features = false }
@@ -123,10 +123,10 @@ num_cpus = "1.16.0"
 num_enum = { version = "0.7.6", default-features = false }
 ouroboros = "0.18.4"
 pallet-auto-id = { version = "0.1.0", path = "domains/pallets/auto-id", default-features = false }
-pallet-balances = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
+pallet-balances = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
 pallet-block-fees = { version = "0.1.0", path = "domains/pallets/block-fees", default-features = false }
-pallet-collective = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
-pallet-democracy = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
+pallet-collective = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
+pallet-democracy = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
 pallet-domain-id = { version = "0.1.0", path = "domains/pallets/domain-id", default-features = false }
 pallet-domain-sudo = { version = "0.1.0", path = "domains/pallets/domain-sudo", default-features = false }
 pallet-domains = { version = "0.1.0", path = "crates/pallet-domains", default-features = false }
@@ -138,23 +138,23 @@ pallet-evm-precompile-sha3fips = { version = "2.0.0-dev", git = "https://github.
 pallet-evm-precompile-simple = { version = "2.0.0-dev", git = "https://github.com/polkadot-evm/frontier", rev = "9d49e36ed5bac38241594f8ba055fdb94991483a", default-features = false }
 pallet-evm-tracker = { version = "0.1.0", path = "domains/pallets/evm-tracker", default-features = false }
 pallet-messenger = { version = "0.1.0", path = "domains/pallets/messenger", default-features = false }
-pallet-mmr = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
-pallet-multisig = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
-pallet-preimage = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
+pallet-mmr = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
+pallet-multisig = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
+pallet-preimage = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
 pallet-rewards = { version = "0.1.0", path = "crates/pallet-rewards", default-features = false }
 pallet-runtime-configs = { version = "0.1.0", path = "crates/pallet-runtime-configs", default-features = false }
-pallet-scheduler = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
+pallet-scheduler = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
 pallet-storage-overlay-checks = { version = "0.1.0", path = "domains/test/pallets/storage_overlay_checks", default-features = false }
 pallet-subspace = { version = "0.1.0", path = "crates/pallet-subspace", default-features = false }
 pallet-subspace-mmr = { version = "0.1.0", path = "crates/pallet-subspace-mmr", default-features = false }
-pallet-sudo = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
-pallet-timestamp = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
+pallet-sudo = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
+pallet-timestamp = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
 pallet-transaction-fees = { version = "0.1.0", path = "crates/pallet-transaction-fees", default-features = false }
-pallet-transaction-payment = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
-pallet-transaction-payment-rpc = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
-pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
+pallet-transaction-payment = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
+pallet-transaction-payment-rpc = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
+pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
 pallet-transporter = { version = "0.1.0", path = "domains/pallets/transporter", default-features = false }
-pallet-utility = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
+pallet-utility = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
 parity-scale-codec = { version = "3.7.5", default-features = false }
 parking_lot = "0.12.2"
 pem = "3.0.4"
@@ -172,42 +172,42 @@ ring = "0.17.8"
 rlp = "0.6"
 rs_merkle = { version = "1.4.2", default-features = false }
 rust-kzg-blst = { git = "https://github.com/grandinetech/rust-kzg", rev = "8f5f1a0f73b3c529c77cb880ff8d265830c7d7ac", default-features = false }
-sc-basic-authorship = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
-sc-block-builder = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
-sc-chain-spec = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
-sc-cli = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
-sc-client-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
-sc-client-db = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
-sc-consensus = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
-sc-consensus-slots = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
+sc-basic-authorship = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
+sc-block-builder = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
+sc-chain-spec = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
+sc-cli = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
+sc-client-api = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
+sc-client-db = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
+sc-consensus = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
+sc-consensus-slots = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
 sc-consensus-subspace = { version = "0.1.0", path = "crates/sc-consensus-subspace" }
 sc-consensus-subspace-rpc = { version = "0.1.0", path = "crates/sc-consensus-subspace-rpc" }
 sc-domains = { version = "0.1.0", path = "crates/sc-domains" }
-sc-executor = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
-sc-informant = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
-sc-keystore = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
-sc-network = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
-sc-network-common = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
-sc-network-gossip = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
-sc-network-sync = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
-sc-network-transactions = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
-sc-offchain = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
+sc-executor = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
+sc-informant = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
+sc-keystore = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
+sc-network = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
+sc-network-common = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
+sc-network-gossip = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
+sc-network-sync = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
+sc-network-transactions = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
+sc-offchain = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
 sc-proof-of-time = { version = "0.1.0", path = "crates/sc-proof-of-time" }
-sc-rpc = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
-sc-rpc-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
-sc-rpc-server = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
-sc-service = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
-sc-state-db = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
-sc-storage-monitor = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
+sc-rpc = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
+sc-rpc-api = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
+sc-rpc-server = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
+sc-service = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
+sc-state-db = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
+sc-storage-monitor = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
 sc-subspace-block-relay = { version = "0.1.0", path = "crates/sc-subspace-block-relay" }
 sc-subspace-chain-specs = { version = "0.1.0", path = "crates/sc-subspace-chain-specs" }
 sc-subspace-sync-common = { version = "0.1.0", path = "shared/sc-subspace-sync-common", default-features = false }
-sc-sysinfo = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
-sc-telemetry = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
-sc-tracing = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
-sc-transaction-pool = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
-sc-transaction-pool-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
-sc-utils = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
+sc-sysinfo = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
+sc-telemetry = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
+sc-tracing = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
+sc-transaction-pool = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
+sc-transaction-pool-api = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
+sc-utils = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
 scale-info = { version = "2.11.6", default-features = false }
 schnellru = "0.2.4"
 schnorrkel = { version = "0.11.4", default-features = false }
@@ -216,48 +216,48 @@ serde = { version = "1.0.216", default-features = false }
 serde-big-array = "0.5.1"
 serde_json = "1.0.133"
 sha2 = { version = "0.11.0", default-features = false }
-sp-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
-sp-application-crypto = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
-sp-arithmetic = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
+sp-api = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
+sp-application-crypto = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
+sp-arithmetic = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
 sp-auto-id = { version = "0.1.0", path = "domains/primitives/auto-id", default-features = false }
-sp-block-builder = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
+sp-block-builder = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
 sp-block-fees = { version = "0.1.0", path = "domains/primitives/block-fees", default-features = false }
-sp-blockchain = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
-sp-consensus = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
-sp-consensus-slots = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
+sp-blockchain = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
+sp-consensus = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
+sp-consensus-slots = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
 sp-consensus-subspace = { version = "0.1.0", path = "crates/sp-consensus-subspace", default-features = false }
-sp-core = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
+sp-core = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
 sp-domain-digests = { version = "0.1.0", path = "domains/primitives/digests", default-features = false }
 sp-domain-sudo = { version = "0.1.0", path = "domains/primitives/domain-sudo", default-features = false }
 sp-domains = { version = "0.1.0", path = "crates/sp-domains", default-features = false }
 sp-domains-fraud-proof = { version = "0.1.0", path = "crates/sp-domains-fraud-proof", default-features = false }
 sp-evm-tracker = { version = "0.1.0", path = "domains/primitives/evm-tracker", default-features = false }
 sp-executive = { version = "0.1.0", path = "domains/primitives/executive", default-features = false }
-sp-externalities = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
+sp-externalities = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
 sp-evm-precompiles = { version = "0.1.0", path = "domains/primitives/evm-precompiles", default-features = false }
-sp-genesis-builder = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
-sp-inherents = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
-sp-io = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
-sp-keyring = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
-sp-keystore = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
+sp-genesis-builder = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
+sp-inherents = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
+sp-io = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
+sp-keyring = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
+sp-keystore = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
 sp-messenger = { version = "0.1.0", path = "domains/primitives/messenger", default-features = false }
 sp-messenger-host-functions = { version = "0.1.0", path = "domains/primitives/messenger-host-functions", default-features = false }
-sp-mmr-primitives = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
+sp-mmr-primitives = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
 sp-objects = { version = "0.1.0", path = "crates/sp-objects", default-features = false }
-sp-offchain = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
-sp-runtime = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
-sp-runtime-interface = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
-sp-session = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
-sp-state-machine = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
-sp-std = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
-sp-storage = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
+sp-offchain = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
+sp-runtime = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
+sp-runtime-interface = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
+sp-session = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
+sp-state-machine = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
+sp-std = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
+sp-storage = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
 sp-subspace-mmr = { version = "0.1.0", path = "crates/sp-subspace-mmr", default-features = false }
-sp-timestamp = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
-sp-tracing = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
-sp-transaction-pool = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
-sp-trie = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
-sp-version = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
-sp-weights = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342", default-features = false }
+sp-timestamp = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
+sp-tracing = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
+sp-transaction-pool = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
+sp-trie = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
+sp-version = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
+sp-weights = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
 spin = "0.10.0"
 sppark = { version = "0.1.8", git = "https://github.com/autonomys/sppark", rev = "b2a181eb99c8200f1a604f04122551ea39fbf63f" }
 ss58-registry = "1.51.0"
@@ -286,11 +286,11 @@ subspace-test-runtime = { version = "0.1.0", path = "test/subspace-test-runtime"
 subspace-test-service = { version = "0.1.0", path = "test/subspace-test-service" }
 subspace-verification = { version = "0.1.0", path = "crates/subspace-verification", default-features = false }
 substrate-bip39 = "=0.6.0"
-substrate-build-script-utils = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
-substrate-frame-rpc-system = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
-substrate-prometheus-endpoint = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
-substrate-test-client = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
-substrate-wasm-builder = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
+substrate-build-script-utils = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
+substrate-frame-rpc-system = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
+substrate-prometheus-endpoint = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
+substrate-test-client = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
+substrate-wasm-builder = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
 supports-color = "3.0.1"
 tempfile = "3.13.0"
 thiserror = { version = "2.0.0", default-features = false }
@@ -389,69 +389,57 @@ lto = "fat"
 # Reason: We need to patch substrate dependency of frontier to our fork
 # TODO: Remove if/when we are using upstream substrate instead of fork
 [patch."https://github.com/paritytech/polkadot-sdk.git"]
-cumulus-primitives-storage-weight-reclaim = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
-frame-benchmarking = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
-frame-support = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
-frame-system = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
-sc-block-builder = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
-sc-client-db = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
-sc-consensus = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
-sc-consensus-slots = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
-sc-client-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
-sc-network = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
-sc-network-common = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
-sc-network-sync = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
-sc-rpc = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
-sc-service = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
-sc-telemetry = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
-sc-transaction-pool = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
-sc-transaction-pool-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
-sc-utils = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
-sp-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
-sp-application-crypto = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
-sp-arithmetic = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
-sp-block-builder = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
-sp-blockchain = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
-sp-consensus = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
-sp-consensus-slots = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
-sp-core = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
-sp-crypto-hashing = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
-sp-database = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
-sp-debug-derive = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
-sp-externalities = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
-sp-inherents = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
-sp-io = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
-sp-keystore = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
-sp-runtime = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
-sp-runtime-interface = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
-sp-state-machine = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
-sp-std = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
-sp-storage = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
-sp-timestamp = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
-sp-trie = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
-sp-version = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
-sp-weights = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
-staging-xcm = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
-substrate-prometheus-endpoint = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
-xcm-procedural = { git = "https://github.com/subspace/polkadot-sdk", rev = "d008c68f08ea8c76040c2be6ff1a593f52f88342" }
+cumulus-primitives-storage-weight-reclaim = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
+frame-benchmarking = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
+frame-support = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
+frame-system = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
+sc-block-builder = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
+sc-client-db = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
+sc-consensus = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
+sc-consensus-slots = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
+sc-client-api = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
+sc-network = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
+sc-network-common = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
+sc-network-sync = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
+sc-rpc = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
+sc-service = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
+sc-telemetry = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
+sc-transaction-pool = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
+sc-transaction-pool-api = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
+sc-utils = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
+sp-api = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
+sp-application-crypto = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
+sp-arithmetic = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
+sp-block-builder = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
+sp-blockchain = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
+sp-consensus = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
+sp-consensus-slots = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
+sp-core = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
+sp-crypto-hashing = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
+sp-database = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
+sp-debug-derive = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
+sp-externalities = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
+sp-inherents = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
+sp-io = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
+sp-keystore = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
+sp-runtime = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
+sp-runtime-interface = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
+sp-state-machine = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
+sp-std = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
+sp-storage = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
+sp-timestamp = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
+sp-trie = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
+sp-version = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
+sp-weights = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
+staging-xcm = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
+substrate-prometheus-endpoint = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
+xcm-procedural = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
 
-[patch."https://github.com/subspace/polkadot-sdk.git"]
+[patch."https://github.com/autonomys/polkadot-sdk.git"]
 # De-duplicate extra copy that comes from Substrate repo
 substrate-bip39 = "=0.6.0"
 
-[patch."https://github.com/autonomys/rust-libp2p.git"]
-# Patch away `libp2p` in our dependency tree with the git version.
-# This brings the fixes in our `libp2p` fork into substrate's dependencies.
-#
-# This is a hack: patches to the same repository are rejected by `cargo`. But it considers
-# "subspace/rust-libp2p" and "autonomys/rust-libp2p" to be different repositories, even though
-# they're redirected to the same place by GitHub, so it allows this patch.
-libp2p = { git = "https://github.com/subspace/rust-libp2p", rev = "676c687c2f7a6e92f8f4f77a6934022aec3ba16c" }
-libp2p-identity = { git = "https://github.com/subspace/rust-libp2p", rev = "676c687c2f7a6e92f8f4f77a6934022aec3ba16c" }
-libp2p-kad = { git = "https://github.com/subspace/rust-libp2p", rev = "676c687c2f7a6e92f8f4f77a6934022aec3ba16c" }
-multistream-select = { git = "https://github.com/subspace/rust-libp2p", rev = "676c687c2f7a6e92f8f4f77a6934022aec3ba16c" }
-
 [patch.crates-io]
 # Patch away `libp2p-identity` in our dependency tree with the git version.
-# For details see: https://github.com/subspace/rust-libp2p/blob/676c687c2f7a6e92f8f4f77a6934022aec3ba16c/Cargo.toml#L140-L145
-libp2p-identity = { git = "https://github.com/subspace/rust-libp2p", rev = "676c687c2f7a6e92f8f4f77a6934022aec3ba16c" }
+# For details see: https://github.com/autonomys/rust-libp2p/blob/676c687c2f7a6e92f8f4f77a6934022aec3ba16c/Cargo.toml#L140-L145
+libp2p-identity = { git = "https://github.com/autonomys/rust-libp2p", rev = "676c687c2f7a6e92f8f4f77a6934022aec3ba16c" }


### PR DESCRIPTION
The dependency tree carried two full libp2p stacks: one from `subspace/rust-libp2p` (libp2p 0.57) for our own networking, and one from `autonomys/rust-libp2p` (libp2p 0.56) that only `sc-network` pulled, because cargo treats the two fork URLs as separate sources during the last upgrade. This re-pins the polkadot-sdk fork to `autonomys/polkadot-sdk@8304f885` (subspace-v16), pointing `sc-network` at the same `autonomys/rust-libp2p@676c687c` (0.57) commit our crates already use, collapsing everything to one stack. It also moves our remaining `subspace/` git refs to the canonical `autonomys/` org and drops the now-dead `autonomys/rust-libp2p` patch block - the `.git`-suffixed key never matched `sc-network`'s reference, which is exactly why the second stack existed.

The fork side (`subspace-v16`, on top of `subspace-v15`) is two commits worth reviewing separately: the libp2p reference bump, and a small `sc-network` change porting the request-response `Codec` impl to libp2p 0.57's trait (0.57 made those methods return `impl Future + Send`, which an `async fn` impl doesn't satisfy under edition 2021).

On the hickory-proto advisory (#31): this clears the libp2p-sourced copy of the vulnerable hickory 0.25.2, but litep2p still pulls it (even the latest litep2p 0.14.0 needs hickory-resolver 0.25.x and there is no patched 0.25.x), so the alert stays open until litep2p moves to hickory 0.26.

### Code contributor checklist:
* [x] I have read, understood and followed the [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
