### PR TITLE
Farmer hardening: ban disconnect, sector download timeout, log colors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14455,6 +14455,7 @@ dependencies = [
 name = "subspace-process"
 version = "0.0.1"
 dependencies = [
+ "console",
  "fdlimit",
  "futures",
  "supports-color",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ bytesize = "2.3.1"
 cc = "1.2.62"
 chacha20 = { version = "0.10.0", default-features = false }
 clap = "4.6.1"
+console = "0.15.11"
 core_affinity = "0.8.1"
 cpufeatures = "0.3.0"
 criterion = { version = "0.8.2", default-features = false }

--- a/crates/subspace-farmer-components/src/plotting.rs
+++ b/crates/subspace-farmer-components/src/plotting.rs
@@ -40,12 +40,14 @@ use tracing::{debug, trace, warn};
 
 const RECONSTRUCTION_CONCURRENCY_LIMIT: usize = 1;
 
+/// Maximum time allowed for a sector download before giving up (retry will continue at the farm level).
+const SECTOR_DOWNLOAD_MAX_ELAPSED_TIME: Duration = Duration::from_secs(30 * 60); // 30 minutes
+
 fn default_backoff() -> ExponentialBackoff {
     ExponentialBackoff {
         initial_interval: Duration::from_secs(15),
         max_interval: Duration::from_secs(10 * 60),
-        // Try until we get a valid piece
-        max_elapsed_time: None,
+        max_elapsed_time: Some(SECTOR_DOWNLOAD_MAX_ELAPSED_TIME),
         ..ExponentialBackoff::default()
     }
 }

--- a/crates/subspace-networking/src/node_runner.rs
+++ b/crates/subspace-networking/src/node_runner.rs
@@ -1542,6 +1542,9 @@ impl NodeRunner {
         self.swarm.behaviour_mut().kademlia.remove_peer(&peer_id);
         self.known_peers_registry
             .remove_all_known_peer_addresses(peer_id);
+
+        // Immediately disconnect the peer to cancel any in-flight requests.
+        let _ = self.swarm.disconnect_peer_id(peer_id);
     }
 
     fn register_event_metrics(&mut self, swarm_event: &SwarmEvent<Event>) {

--- a/shared/subspace-process/Cargo.toml
+++ b/shared/subspace-process/Cargo.toml
@@ -11,6 +11,7 @@ include = [
 ]
 
 [dependencies]
+console.workspace = true
 fdlimit.workspace = true
 futures.workspace = true
 supports-color.workspace = true

--- a/shared/subspace-process/src/lib.rs
+++ b/shared/subspace-process/src/lib.rs
@@ -20,6 +20,12 @@ use tracing_subscriber::{EnvFilter, Layer, fmt};
 mod tests;
 
 pub fn init_logger() {
+    // sc_informant and other substrate crates colorize log content via `console`;
+    // tracing-subscriber 0.3.20+ escapes those embedded ANSI codes into literal `\x1b[`
+    // text in the message. Turn console color off at the source so nothing is emitted.
+    console::set_colors_enabled(false);
+    console::set_colors_enabled_stderr(false);
+
     // TODO: Workaround for https://github.com/tokio-rs/tracing/issues/2214, also on
     //  Windows terminal doesn't support the same colors as bash does
     let enable_color = if cfg!(windows) {

--- a/shared/subspace-process/src/tests.rs
+++ b/shared/subspace-process/src/tests.rs
@@ -4,6 +4,19 @@ use crate::run_future_in_dedicated_thread;
 use std::future;
 use tokio::sync::oneshot;
 
+// Runs on every CI platform (Linux/macOS/Windows). `init_logger` disables console colors so
+// substrate's `console`-styled log content is not escaped into literal `\x1b[` text in messages.
+#[test]
+fn init_logger_disables_console_ansi() {
+    crate::init_logger();
+
+    let styled = format!("{}", console::style("x").white().bold());
+    assert_eq!(
+        styled, "x",
+        "console emitted ANSI after init_logger: {styled:?}"
+    );
+}
+
 #[tokio::test]
 async fn run_future_in_dedicated_thread_ready() {
     let value = run_future_in_dedicated_thread(|| future::ready(1), "ready".to_string())


### PR DESCRIPTION
A couple of @ageorge95's farmer hardening tweaks that Jim flagged. We now disconnect a peer immediately on permanent ban so in-flight requests get cancelled, and sector downloads get a 30 minute cap on their retry backoff instead of retrying forever (the plotting loop already retries the whole sector).

I also reworked the Windows logging fix - the escaped `\x1b[` litter isn't really Windows-specific, so I turn console's colors off at the source rather than stripping it after the fact.

Worth a commit-by-commit read.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
