### PR TITLE
Fix out-of-bounds write in non-parallel chiapos table creation

### DIFF
--- a/crates/subspace-farmer/src/single_disk_farm/piece_reader.rs
+++ b/crates/subspace-farmer/src/single_disk_farm/piece_reader.rs
@@ -246,9 +246,13 @@ where
     {
         Ok(piece) => piece,
         Err(error) => {
+            // The evaluation seed regenerates the exact proof-of-space table for this read, making
+            // a failure locally reproducible.
+            let evaluation_seed = sector_id.derive_evaluation_seed(piece_offset);
             error!(
                 %sector_index,
                 %piece_offset,
+                evaluation_seed = %hex::encode(*evaluation_seed),
                 %error,
                 "Failed to read piece from sector"
             );

--- a/crates/subspace-proof-of-space/src/chiapos/table.rs
+++ b/crates/subspace-proof-of-space/src/chiapos/table.rs
@@ -105,6 +105,13 @@ pub const fn num_buckets(k: u8) -> usize {
         .div_ceil(PARAM_BC as usize)
 }
 
+/// Upper bound on entries in a non-first table: `num_buckets(K) - 1` bucket pairs, each yielding at
+/// most `REDUCED_MATCHES_COUNT` matches. The actual count is data-dependent and can exceed `2^K`.
+#[cfg(feature = "alloc")]
+const fn max_table_entries(k: u8) -> usize {
+    (num_buckets(k) - 1) * REDUCED_MATCHES_COUNT
+}
+
 #[cfg(feature = "parallel")]
 #[inline(always)]
 fn strip_sync_unsafe_cell<const N: usize, T>(value: Box<[SyncUnsafeCell<T>; N]>) -> Box<[T; N]> {
@@ -901,7 +908,7 @@ where
     /// Other tables
     Other {
         /// Left and right entry positions in a previous table encoded into bits
-        positions: Box<[MaybeUninit<[Position; 2]>; 1 << K]>,
+        positions: Box<[MaybeUninit<[Position; 2]>]>,
     },
     /// Other tables
     #[cfg(feature = "parallel")]
@@ -968,9 +975,9 @@ where
     /// Other tables
     Other {
         /// Left and right entry positions in a previous table encoded into bits
-        positions: Box<[MaybeUninit<[Position; 2]>; 1 << K]>,
+        positions: Box<[MaybeUninit<[Position; 2]>]>,
         /// Metadata corresponding to each entry
-        metadatas: Box<[MaybeUninit<Metadata<K, TABLE_NUMBER>>; 1 << K]>,
+        metadatas: Box<[MaybeUninit<Metadata<K, TABLE_NUMBER>>]>,
         /// Each bucket contains positions of `Y` values that belong to it and corresponding `y`.
         ///
         /// Buckets are padded with sentinel values to `REDUCED_BUCKETS_SIZE`.
@@ -1245,16 +1252,12 @@ where
     {
         let left_targets = &*cache.left_targets;
         let mut initialized_elements = 0_usize;
-        // SAFETY: Contents is `MaybeUninit`
-        let mut ys = unsafe { Box::<[MaybeUninit<Y>; 1 << K]>::new_uninit().assume_init() };
-        // SAFETY: Contents is `MaybeUninit`
-        let mut positions =
-            unsafe { Box::<[MaybeUninit<[Position; 2]>; 1 << K]>::new_uninit().assume_init() };
+        let mut ys: Box<[MaybeUninit<Y>]> = Box::new_uninit_slice(max_table_entries(K));
+        let mut positions: Box<[MaybeUninit<[Position; 2]>]> =
+            Box::new_uninit_slice(max_table_entries(K));
         // The last table doesn't have metadata
-        // SAFETY: Contents is `MaybeUninit`
-        let mut metadatas = unsafe {
-            Box::<[MaybeUninit<Metadata<K, TABLE_NUMBER>>; 1 << K]>::new_uninit().assume_init()
-        };
+        let mut metadatas: Box<[MaybeUninit<Metadata<K, TABLE_NUMBER>>]> =
+            Box::new_uninit_slice(max_table_entries(K));
 
         for ([left_bucket, right_bucket], left_bucket_index) in
             parent_table.buckets().array_windows().zip(0..)
@@ -1282,7 +1285,8 @@ where
                 )
             };
 
-            // SAFETY: Preallocated length is an upper bound and is always sufficient
+            // SAFETY: arrays are sized to `max_table_entries(K)`, the exact upper bound on the total
+            // number of matches, so `initialized_elements + matches.len()` never exceeds the length
             let (ys, positions, metadatas) = unsafe {
                 (
                     ys.split_at_mut_unchecked(matches.len()).0,

--- a/crates/subspace-proof-of-space/src/chiapos/tables/tests.rs
+++ b/crates/subspace-proof-of-space/src/chiapos/tables/tests.rs
@@ -399,3 +399,48 @@ fn bucketed_proofs_match_sorted_reference() {
         "Expected at least some challenges to have proofs"
     );
 }
+
+/// Regression test for the out-of-bounds write in the non-parallel `Table::create`.
+///
+/// A non-first table's entry count fluctuates around `2^K` and exceeds it for a large fraction of
+/// K=20 seeds. The flat output arrays were sized `1 << K`, so those seeds wrote past the end (a
+/// segfault, or silent corruption that yields invalid proofs on read). Building tables across a
+/// spread of seeds must not corrupt memory, and every proof found must verify.
+#[test]
+fn table_create_does_not_overflow_at_k20() {
+    const PRODUCTION_K: u8 = 20;
+
+    let cache = TablesCache::default();
+    let mut total_proofs = 0_u32;
+    for i in 0..16_u32 {
+        // ~44% of seeds overflow a non-first table at K=20, so a derived spread reliably hits it.
+        let seed = *blake3::hash(&i.to_le_bytes()).as_bytes();
+        // Building the tables is what triggers the overflow.
+        let tables = TablesGeneric::<PRODUCTION_K>::create(seed, &cache);
+
+        for challenge_index in 0..256_u32 {
+            let mut challenge = [0u8; 32];
+            challenge[..4].copy_from_slice(&challenge_index.to_le_bytes());
+            let first_challenge_bytes: [u8; 4] = challenge[..4].try_into().unwrap();
+
+            for proof in tables.find_proof(first_challenge_bytes) {
+                assert!(
+                    TablesGeneric::<PRODUCTION_K>::verify(
+                        &seed,
+                        &challenge,
+                        proof.as_slice().try_into().unwrap(),
+                    )
+                    .is_some(),
+                    "proof failed to verify (table memory corruption): seed {i}, challenge \
+                     {challenge_index}"
+                );
+                total_proofs += 1;
+            }
+        }
+    }
+
+    assert!(
+        total_proofs > 0,
+        "expected to find proofs across the derived seeds"
+    );
+}


### PR DESCRIPTION
The non-parallel chiapos table builder, used only by the piece-read path (`reading::read_piece` → `generate`), sizes its per-table `ys`/`positions`/`metadatas` arrays at `1 << K`, assuming a non-first table never holds more than `2^K` entries. That count is data-dependent and can exceed `2^K`, so for a fraction of seeds the builder writes past the end of those arrays - a heap buffer overflow in `Table::create`. Depending on heap layout it either crashes or overwrites adjacent memory.

The fix sizes those arrays to their actual upper bound, `(num_buckets(K) - 1) * REDUCED_MATCHES_COUNT`, as boxed slices - the same capacity the parallel (bucketed) builder already uses. Table 1 keeps `1 << K`, since it does hold exactly that many entries. Only the read path is affected: plotting and proving go through `generate_parallel`, the bucketed builder, which was never affected, so existing plots stay valid and nothing needs replotting.

Reviewable commit by commit:

- `79a7e1a6` - the fix.
- `7438e088` - a K=20 regression test that overflows the old arrays; it aborts on the pre-fix code (the unchecked slice split trips its bounds precondition) and passes with the fix.
- `d90906a7` - log the evaluation seed on a piece-read failure, so a read error is reproducible from the log line.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
