### PR TITLE
Bump client versions to 0.1.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14004,7 +14004,7 @@ dependencies = [
 
 [[package]]
 name = "subspace-bootstrap-node"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "clap",
  "futures",
@@ -14102,7 +14102,7 @@ dependencies = [
 
 [[package]]
 name = "subspace-farmer"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "anyhow",
  "async-lock",
@@ -14213,7 +14213,7 @@ dependencies = [
 
 [[package]]
 name = "subspace-gateway"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -14383,7 +14383,7 @@ dependencies = [
 
 [[package]]
 name = "subspace-node"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "auto-id-domain-runtime",
  "bip39",

--- a/crates/subspace-bootstrap-node/Cargo.toml
+++ b/crates/subspace-bootstrap-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subspace-bootstrap-node"
-version = "0.1.10"
+version = "0.1.11"
 authors = [
     "Nazar Mokrynskyi <nazar@mokrynskyi.com>",
     "Shamil Gadelshin <shamilgadelshin@gmail.com>"

--- a/crates/subspace-farmer/Cargo.toml
+++ b/crates/subspace-farmer/Cargo.toml
@@ -2,7 +2,7 @@
 name = "subspace-farmer"
 description = "Farmer for the Subspace Network Blockchain"
 license = "0BSD"
-version = "0.1.10"
+version = "0.1.11"
 authors = ["Nazar Mokrynskyi <nazar@mokrynskyi.com>"]
 edition.workspace = true
 include = [

--- a/crates/subspace-gateway/Cargo.toml
+++ b/crates/subspace-gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subspace-gateway"
-version = "0.1.10"
+version = "0.1.11"
 authors = [
     "Teor <teor@riseup.net>",
     "Shamil Gadelshin <shamilgadelshin@gmail.com>"

--- a/crates/subspace-node/Cargo.toml
+++ b/crates/subspace-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subspace-node"
-version = "0.1.10"
+version = "0.1.11"
 authors = ["Subspace Labs <https://subspace.network>"]
 description = "A Subspace Network Blockchain node."
 edition.workspace = true


### PR DESCRIPTION
Bumping the client version ahead of the next mainnet release.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
