### PR TITLE
Bump runtime spec_version: consensus 10, EVM domain 4

### DIFF
--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -131,7 +131,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: Cow::Borrowed("subspace"),
     impl_name: Cow::Borrowed("subspace"),
     authoring_version: 0,
-    spec_version: 9,
+    spec_version: 10,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/domains/runtime/evm/src/lib.rs
+++ b/domains/runtime/evm/src/lib.rs
@@ -317,7 +317,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: Cow::Borrowed("subspace-evm-domain"),
     impl_name: Cow::Borrowed("subspace-evm-domain"),
     authoring_version: 0,
-    spec_version: 3,
+    spec_version: 4,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
Bumps the consensus runtime `spec_version` to 10 and the EVM domain runtime to 4 for the stable2512 runtime upgrade. `transaction_version` stays at 1 since the signed-extension set is unchanged.

I validated the upgrade path on a local dev network: both the consensus `set_code` (9→10) and the domain runtime upgrade (3→4) enact cleanly, the deployed contract's storage and EVM + XDM keep working afterwards, and all of it holds across the current and previous client releases, including the pre-2512 (0.1.7) client. So the upgrade is backwards-compatible and doesn't force a client upgrade.

This is the dedicated spec bump ahead of cutting the `runtime-*` and `domain-genesis-storage-*` releases.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
