### PR TITLE
Abundance-backed proof of space (CPU)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,10 +13,85 @@ dependencies = [
 ]
 
 [[package]]
+name = "ab-blake3"
+version = "0.1.0"
+source = "git+https://github.com/nazar-pc/abundance?rev=fc8da9992575a3b33ea9c5c764ea71f926f4592e#fc8da9992575a3b33ea9c5c764ea71f926f4592e"
+dependencies = [
+ "blake3",
+]
+
+[[package]]
 name = "ab-chacha8"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78928d0e8969c1b539a98de5cf3a678d136f160415c765f3f4c464b5eee39976"
+
+[[package]]
+name = "ab-chacha8"
+version = "0.1.0"
+source = "git+https://github.com/nazar-pc/abundance?rev=fc8da9992575a3b33ea9c5c764ea71f926f4592e#fc8da9992575a3b33ea9c5c764ea71f926f4592e"
+
+[[package]]
+name = "ab-core-primitives"
+version = "0.1.0"
+source = "git+https://github.com/nazar-pc/abundance?rev=fc8da9992575a3b33ea9c5c764ea71f926f4592e#fc8da9992575a3b33ea9c5c764ea71f926f4592e"
+dependencies = [
+ "ab-blake3",
+ "ab-io-type",
+ "ab-merkle-tree",
+ "bech32",
+ "blake3",
+ "derive_more 2.1.1",
+ "ed25519-dalek 3.0.0-rc.1",
+ "hex",
+ "rclite",
+ "replace_with",
+ "serde-big-array",
+ "thiserror 2.0.18",
+ "yoke",
+]
+
+[[package]]
+name = "ab-io-type"
+version = "0.1.0"
+source = "git+https://github.com/nazar-pc/abundance?rev=fc8da9992575a3b33ea9c5c764ea71f926f4592e#fc8da9992575a3b33ea9c5c764ea71f926f4592e"
+dependencies = [
+ "ab-io-type-derive",
+]
+
+[[package]]
+name = "ab-io-type-derive"
+version = "0.1.0"
+source = "git+https://github.com/nazar-pc/abundance?rev=fc8da9992575a3b33ea9c5c764ea71f926f4592e#fc8da9992575a3b33ea9c5c764ea71f926f4592e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "ab-merkle-tree"
+version = "0.1.0"
+source = "git+https://github.com/nazar-pc/abundance?rev=fc8da9992575a3b33ea9c5c764ea71f926f4592e#fc8da9992575a3b33ea9c5c764ea71f926f4592e"
+dependencies = [
+ "ab-blake3",
+]
+
+[[package]]
+name = "ab-proof-of-space"
+version = "0.1.0"
+source = "git+https://github.com/nazar-pc/abundance?rev=fc8da9992575a3b33ea9c5c764ea71f926f4592e#fc8da9992575a3b33ea9c5c764ea71f926f4592e"
+dependencies = [
+ "ab-blake3",
+ "ab-chacha8 0.1.0 (git+https://github.com/nazar-pc/abundance?rev=fc8da9992575a3b33ea9c5c764ea71f926f4592e)",
+ "ab-core-primitives",
+ "chacha20 0.10.1",
+ "derive_more 2.1.1",
+ "rayon",
+ "rclite",
+ "seq-macro",
+ "sha2 0.11.0",
+]
 
 [[package]]
 name = "actix-codec"
@@ -73,7 +148,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e01ed3140b2f8d422c68afa1ed2e85d996ea619c988ac834d255db32138655cb"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -187,7 +262,7 @@ dependencies = [
  "actix-router",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -356,7 +431,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -367,7 +442,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -396,7 +471,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -547,7 +622,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -573,7 +648,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -648,7 +723,7 @@ checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -755,7 +830,7 @@ checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "synstructure 0.13.2",
 ]
 
@@ -767,7 +842,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -953,7 +1028,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1114,7 +1189,7 @@ checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1200,6 +1275,12 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bech32"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efbd3e1070bbdf4cd88a75264e18e8a26f7cb5c6949eadf0ceb85fb159cf08f8"
 
 [[package]]
 name = "binary-merkle-tree"
@@ -1449,6 +1530,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "branches"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e426eb5cc1900033930ec955317b302e68f19f326cc7bb0c8a86865a826cdf0c"
+dependencies = [
+ "rustc_version",
+]
+
+[[package]]
 name = "bs58"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1646,9 +1736,9 @@ dependencies = [
 
 [[package]]
 name = "chacha20"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
  "cipher 0.5.1",
@@ -1785,7 +1875,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2468,7 +2558,7 @@ dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2574,10 +2664,25 @@ dependencies = [
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest 0.10.7",
- "fiat-crypto",
+ "fiat-crypto 0.2.9",
  "rustc_version",
  "subtle 2.6.1",
  "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "5.0.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c906a87e53a36ff795d72e06e8162a83c5436e3ea89e942a9cb9fc083f0a384f"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "curve25519-dalek-derive",
+ "digest 0.11.3",
+ "fiat-crypto 0.3.0",
+ "rustc_version",
+ "subtle 2.6.1",
 ]
 
 [[package]]
@@ -2588,7 +2693,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2618,7 +2723,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2632,7 +2737,7 @@ dependencies = [
  "indexmap",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2650,7 +2755,7 @@ dependencies = [
  "indexmap",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2684,7 +2789,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2697,7 +2802,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2708,7 +2813,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2719,7 +2824,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core 0.23.0",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2824,7 +2929,7 @@ checksum = "d65d7ce8132b7c0e54497a4d9a55a1c2a0912a0d786cf894472ba818fba45762"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2835,7 +2940,7 @@ checksum = "d08b3a0bcc0d079199cd476b2cae8435016ec11d1c0986c6901c5ac223041534"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2848,7 +2953,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2877,7 +2982,7 @@ checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2890,7 +2995,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.117",
+ "syn 2.0.118",
  "unicode-xid",
 ]
 
@@ -2994,7 +3099,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3018,7 +3123,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.117",
+ "syn 2.0.118",
  "termcolor",
  "toml 0.8.23",
  "walkdir",
@@ -3447,7 +3552,7 @@ checksum = "7e8671d54058979a37a26f3511fbf8d198ba1aa35ffb202c42587d918d77213a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3467,7 +3572,7 @@ dependencies = [
  "elliptic-curve",
  "rfc6979",
  "serdect",
- "signature",
+ "signature 2.2.0",
  "spki",
 ]
 
@@ -3478,7 +3583,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
  "pkcs8",
- "signature",
+ "signature 2.2.0",
+]
+
+[[package]]
+name = "ed25519"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29fcf32e6c73d1079f83ab4d782de2d81620346a5f38c6237a86a22f8368980a"
+dependencies = [
+ "signature 3.0.0",
 ]
 
 [[package]]
@@ -3487,14 +3601,26 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
- "curve25519-dalek",
- "ed25519",
+ "curve25519-dalek 4.1.3",
+ "ed25519 2.2.3",
  "rand_core 0.6.4",
  "serde",
  "sha2 0.10.9",
- "signature",
+ "signature 2.2.0",
  "subtle 2.6.1",
  "zeroize",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "3.0.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1685663e23882cd8517dcbcb1c23a6ebff4433c22dfb681d760219b62cd1b849"
+dependencies = [
+ "curve25519-dalek 5.0.0-rc.1",
+ "ed25519 3.0.0",
+ "sha2 0.11.0",
+ "subtle 2.6.1",
 ]
 
 [[package]]
@@ -3503,8 +3629,8 @@ version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "775765289f7c6336c18d3d66127527820dd45ffd9eb3b6b8ee4708590e6c20f5"
 dependencies = [
- "curve25519-dalek",
- "ed25519",
+ "curve25519-dalek 4.1.3",
+ "ed25519 2.2.3",
  "hashbrown 0.16.1",
  "pkcs8",
  "rand_core 0.6.4",
@@ -3522,7 +3648,7 @@ dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3587,7 +3713,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3627,7 +3753,7 @@ checksum = "8ca9601fb2d62598ee17836250842873a413586e5d7ed88b356e38ddbb0ec631"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3682,7 +3808,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3968,7 +4094,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4004,7 +4130,7 @@ dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4183,6 +4309,12 @@ name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
+name = "fiat-crypto"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
 name = "file-guard"
@@ -4517,7 +4649,7 @@ dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4639,7 +4771,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sp-crypto-hashing 0.1.0 (git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c)",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4651,7 +4783,7 @@ dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4661,7 +4793,7 @@ source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d690
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4841,7 +4973,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5839,7 +5971,7 @@ checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5955,7 +6087,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6066,7 +6198,7 @@ dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6090,7 +6222,7 @@ checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6136,7 +6268,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6164,7 +6296,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6264,7 +6396,7 @@ dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6614,7 +6746,7 @@ version = "0.2.14"
 source = "git+https://github.com/autonomys/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
 dependencies = [
  "bs58",
- "ed25519-dalek",
+ "ed25519-dalek 2.2.0",
  "hkdf",
  "multihash 0.19.5",
  "prost 0.14.3",
@@ -6807,7 +6939,7 @@ source = "git+https://github.com/autonomys/rust-libp2p?rev=676c687c2f7a6e92f8f4f
 dependencies = [
  "heck 0.5.0",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7041,7 +7173,7 @@ dependencies = [
  "bs58",
  "bytes",
  "cid",
- "ed25519-dalek",
+ "ed25519-dalek 2.2.0",
  "enum-display",
  "futures",
  "futures-timer",
@@ -7163,7 +7295,7 @@ dependencies = [
  "macro_magic_core",
  "macro_magic_macros",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7177,7 +7309,7 @@ dependencies = [
  "macro_magic_core_macros",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7188,7 +7320,7 @@ checksum = "b02abfe41815b5bd98dbd4260173db2c116dda171dc0fe7838cb206333b83308"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7199,7 +7331,7 @@ checksum = "73ea28ee64b88876bf45277ed9a5817c1817df061a74f2b988971a12570e5869"
 dependencies = [
  "macro_magic_core",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7210,7 +7342,7 @@ checksum = "757aee279b8bdbb9f9e676796fd459e4207a1f986e87886700abf589f5abf771"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7342,7 +7474,7 @@ dependencies = [
  "bitflags 1.3.2",
  "blake2 0.10.6",
  "c2-chacha",
- "curve25519-dalek",
+ "curve25519-dalek 4.1.3",
  "either",
  "hashlink 0.8.4",
  "lioness",
@@ -7413,7 +7545,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7663,8 +7795,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879011babc47a1c7fdf5a935ae3cfe94f34645ca0cac1c7f6424b36fc743d1bf"
 dependencies = [
  "data-encoding",
- "ed25519",
- "ed25519-dalek",
+ "ed25519 2.2.3",
+ "ed25519-dalek 2.2.0",
  "getrandom 0.2.17",
  "log",
  "rand 0.8.6",
@@ -7735,7 +7867,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7866,7 +7998,7 @@ dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7999,7 +8131,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -8792,7 +8924,7 @@ dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -8944,7 +9076,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -9011,7 +9143,7 @@ checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -9397,7 +9529,7 @@ dependencies = [
  "polkavm-common",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -9407,7 +9539,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a4f5352e13c1ca5f0e4d7b4a804fbb85b0e02c45cae435d101fe71081bc8ed8"
 dependencies = [
  "polkavm-derive-impl",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -9555,7 +9687,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sp-crypto-hashing 0.1.0 (git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c)",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -9602,7 +9734,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -9698,7 +9830,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -9709,7 +9841,7 @@ checksum = "75eea531cfcd120e0851a3f8aed42c4841f78c889eefafd96339c72677ae42c3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -9729,7 +9861,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "version_check",
  "yansi",
 ]
@@ -9768,7 +9900,7 @@ checksum = "9adf1691c04c0a5ff46ff8f262b58beb07b0dbb61f96f9f54f6cbd82106ed87f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -9835,7 +9967,7 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -9845,7 +9977,7 @@ dependencies = [
  "prost 0.13.5",
  "prost-types 0.13.5",
  "regex",
- "syn 2.0.117",
+ "syn 2.0.118",
  "tempfile",
 ]
 
@@ -9855,7 +9987,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -9864,7 +9996,7 @@ dependencies = [
  "prost 0.14.3",
  "prost-types 0.14.3",
  "regex",
- "syn 2.0.117",
+ "syn 2.0.118",
  "tempfile",
 ]
 
@@ -9890,7 +10022,7 @@ dependencies = [
  "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -9903,7 +10035,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -9916,7 +10048,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -9957,7 +10089,7 @@ checksum = "8bccae89ed67a40989e780105fab43e6c71a077b9fc8ae4c805ff5f73d2a79c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -10039,9 +10171,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -10091,7 +10223,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
- "chacha20 0.10.0",
+ "chacha20 0.10.1",
  "getrandom 0.4.2",
  "rand_core 0.10.1",
 ]
@@ -10217,6 +10349,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rclite"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6716a637a8a17bce72da6b6ddab8548619cc748658c41ab6ee5c4a3c1001385"
+dependencies = [
+ "branches",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10271,7 +10412,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -10335,6 +10476,12 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "replace_with"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51743d3e274e2b18df81c4dc6caf8a5b8e15dbe799e0dca05c7617380094e884"
 
 [[package]]
 name = "reqwest"
@@ -10432,7 +10579,7 @@ checksum = "652db34deaaa57929e10ca18e5454a32cb0efc351ae80d320334bbf907b908b3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -10569,7 +10716,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10828,7 +10975,7 @@ dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -11410,7 +11557,7 @@ source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d690
 dependencies = [
  "bs58",
  "bytes",
- "ed25519-dalek",
+ "ed25519-dalek 2.2.0",
  "libp2p-identity",
  "libp2p-kad",
  "litep2p",
@@ -11828,7 +11975,7 @@ dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -11931,7 +12078,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -11959,7 +12106,7 @@ dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -11985,7 +12132,7 @@ dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -12007,7 +12154,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scale-info",
- "syn 2.0.117",
+ "syn 2.0.118",
  "thiserror 2.0.18",
 ]
 
@@ -12059,7 +12206,7 @@ dependencies = [
  "aead",
  "arrayref",
  "arrayvec 0.7.6",
- "curve25519-dalek",
+ "curve25519-dalek 4.1.3",
  "getrandom_or_panic",
  "merlin",
  "rand_core 0.6.4",
@@ -12288,7 +12435,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -12321,7 +12468,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -12369,7 +12516,7 @@ dependencies = [
  "darling 0.23.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -12487,7 +12634,7 @@ checksum = "c1e303f8205714074f6068773f0e29527e0453937fe837c9717d066635b65f31"
 dependencies = [
  "pkcs8",
  "rand_core 0.6.4",
- "signature",
+ "signature 2.2.0",
  "zeroize",
 ]
 
@@ -12500,6 +12647,12 @@ dependencies = [
  "digest 0.10.7",
  "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "signature"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
 
 [[package]]
 name = "simba"
@@ -12706,7 +12859,7 @@ dependencies = [
  "aes-gcm",
  "blake2 0.10.6",
  "chacha20poly1305",
- "curve25519-dalek",
+ "curve25519-dalek 4.1.3",
  "rand_core 0.6.4",
  "ring",
  "rustc_version",
@@ -12731,7 +12884,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12783,7 +12936,7 @@ dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -13082,7 +13235,7 @@ source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d690
 dependencies = [
  "quote",
  "sp-crypto-hashing 0.1.0 (git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c)",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -13101,7 +13254,7 @@ source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d690
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -13289,7 +13442,7 @@ source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d690
 dependencies = [
  "bytes",
  "docify",
- "ed25519-dalek",
+ "ed25519-dalek 2.2.0",
  "libsecp256k1",
  "log",
  "parity-scale-codec",
@@ -13524,7 +13677,7 @@ dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -13580,8 +13733,8 @@ version = "24.0.0"
 source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
 dependencies = [
  "aes-gcm",
- "curve25519-dalek",
- "ed25519-dalek",
+ "curve25519-dalek 4.1.3",
+ "ed25519-dalek 2.2.0",
  "hkdf",
  "parity-scale-codec",
  "rand 0.8.6",
@@ -13732,7 +13885,7 @@ dependencies = [
  "proc-macro-warning",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -13977,7 +14130,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -13989,7 +14142,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -14474,9 +14627,10 @@ dependencies = [
 name = "subspace-proof-of-space"
 version = "0.1.0"
 dependencies = [
- "ab-chacha8",
+ "ab-chacha8 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ab-proof-of-space",
  "blake3",
- "chacha20 0.10.0",
+ "chacha20 0.10.1",
  "criterion",
  "derive_more 2.1.1",
  "hex",
@@ -15038,7 +15192,7 @@ dependencies = [
  "scale-info",
  "scale-typegen",
  "subxt-metadata",
- "syn 2.0.117",
+ "syn 2.0.118",
  "thiserror 2.0.18",
 ]
 
@@ -15103,7 +15257,7 @@ dependencies = [
  "subxt-codegen",
  "subxt-metadata",
  "subxt-utils-fetchmetadata",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -15207,9 +15361,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -15245,7 +15399,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -15323,7 +15477,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -15342,7 +15496,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -15377,7 +15531,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -15388,7 +15542,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -15550,7 +15704,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -15802,7 +15956,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -15845,7 +15999,7 @@ dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -16378,7 +16532,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "wasm-bindgen-shared",
 ]
 
@@ -16778,7 +16932,7 @@ checksum = "a9cdb9c2e3965ee15629d067203cb800e9822664d04335dadc6fe1788d4fc335"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -16904,7 +17058,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -17005,7 +17159,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -17016,7 +17170,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -17418,7 +17572,7 @@ dependencies = [
  "heck 0.5.0",
  "indexmap",
  "prettyplease",
- "syn 2.0.117",
+ "syn 2.0.118",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -17434,7 +17588,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -17497,7 +17651,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
 dependencies = [
- "curve25519-dalek",
+ "curve25519-dalek 4.1.3",
  "rand_core 0.6.4",
  "serde",
  "zeroize",
@@ -17556,7 +17710,7 @@ dependencies = [
  "Inflector",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -17634,9 +17788,9 @@ checksum = "b5f6765e852b9b4dc8e2a76843e4d64d1cea8e79bcde0b6901aea8e7c7f08282"
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -17645,13 +17799,13 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "synstructure 0.13.2",
 ]
 
@@ -17672,7 +17826,7 @@ checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -17692,7 +17846,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "synstructure 0.13.2",
 ]
 
@@ -17713,7 +17867,7 @@ checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -17746,7 +17900,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ members = [
 
 [workspace.dependencies]
 ab-chacha8 = "0.1.0"
+ab-proof-of-space = { git = "https://github.com/nazar-pc/abundance", rev = "fc8da9992575a3b33ea9c5c764ea71f926f4592e", default-features = false }
 actix-web = { version = "4.9.0", default-features = false }
 aes = "0.9.0"
 anyhow = "1.0.89"
@@ -51,7 +52,7 @@ blst = "0.3.13"
 bytes = { version = "1.11.1", default-features = false }
 bytesize = "2.3.1"
 cc = "1.2.62"
-chacha20 = { version = "0.10.0", default-features = false }
+chacha20 = { version = "0.10.1", default-features = false }
 clap = "4.6.1"
 console = "0.15.11"
 core_affinity = "0.8.1"
@@ -318,6 +319,7 @@ ziggy = { version = "1.7.0", default-features = false }
 #
 # This list is ordered alphabetically.
 [profile.dev.package]
+ab-proof-of-space = { opt-level = 3 }
 bitvec = { opt-level = 3 }
 blake2 = { opt-level = 3 }
 blake3 = { opt-level = 3 }

--- a/crates/subspace-farmer-components/benches/auditing.rs
+++ b/crates/subspace-farmer-components/benches/auditing.rs
@@ -26,9 +26,9 @@ use subspace_farmer_components::sector::{
 };
 use subspace_kzg::Kzg;
 use subspace_proof_of_space::Table;
-use subspace_proof_of_space::chia::ChiaTable;
+use subspace_proof_of_space::chia_v2::ChiaV2Table;
 
-type PosTable = ChiaTable;
+type PosTable = ChiaV2Table;
 
 const MAX_PIECES_IN_SECTOR: u16 = 1000;
 

--- a/crates/subspace-farmer-components/benches/plotting.rs
+++ b/crates/subspace-farmer-components/benches/plotting.rs
@@ -14,9 +14,9 @@ use subspace_farmer_components::plotting::{CpuRecordsEncoder, PlotSectorOptions,
 use subspace_farmer_components::sector::sector_size;
 use subspace_kzg::Kzg;
 use subspace_proof_of_space::Table;
-use subspace_proof_of_space::chia::ChiaTable;
+use subspace_proof_of_space::chia_v2::ChiaV2Table;
 
-type PosTable = ChiaTable;
+type PosTable = ChiaV2Table;
 
 const MAX_PIECES_IN_SECTOR: u16 = 1000;
 

--- a/crates/subspace-farmer-components/benches/proving.rs
+++ b/crates/subspace-farmer-components/benches/proving.rs
@@ -31,10 +31,10 @@ use subspace_farmer_components::sector::{
     SectorContentsMap, SectorMetadata, SectorMetadataChecksummed, sector_size,
 };
 use subspace_kzg::Kzg;
-use subspace_proof_of_space::chia::ChiaTable;
+use subspace_proof_of_space::chia_v2::ChiaV2Table;
 use subspace_proof_of_space::{Table, TableGenerator};
 
-type PosTable = ChiaTable;
+type PosTable = ChiaV2Table;
 
 const MAX_PIECES_IN_SECTOR: u16 = 1000;
 

--- a/crates/subspace-farmer-components/benches/reading.rs
+++ b/crates/subspace-farmer-components/benches/reading.rs
@@ -25,9 +25,9 @@ use subspace_farmer_components::sector::{
 use subspace_farmer_components::{FarmerProtocolInfo, ReadAt, ReadAtSync};
 use subspace_kzg::Kzg;
 use subspace_proof_of_space::Table;
-use subspace_proof_of_space::chia::ChiaTable;
+use subspace_proof_of_space::chia_v2::ChiaV2Table;
 
-type PosTable = ChiaTable;
+type PosTable = ChiaV2Table;
 
 const MAX_PIECES_IN_SECTOR: u16 = 1000;
 

--- a/crates/subspace-farmer-components/src/proving.rs
+++ b/crates/subspace-farmer-components/src/proving.rs
@@ -17,6 +17,7 @@ use std::io;
 use subspace_core_primitives::pieces::{PieceOffset, Record};
 use subspace_core_primitives::pos::PosSeed;
 use subspace_core_primitives::sectors::{SBucket, SectorId};
+use subspace_core_primitives::segments::HistorySize;
 use subspace_core_primitives::solutions::{ChunkWitness, Solution, SolutionRange};
 use subspace_core_primitives::{PublicKey, ScalarBytes};
 use subspace_erasure_coding::ErasureCoding;
@@ -157,6 +158,11 @@ where
     /// Returns true if no candidates inside
     pub fn is_empty(&self) -> bool {
         self.chunk_candidates.is_empty()
+    }
+
+    /// History size of the sector these candidates belong to.
+    pub fn history_size(&self) -> HistorySize {
+        self.sector_metadata.history_size
     }
 
     /// Turn solution candidates into actual solutions

--- a/crates/subspace-farmer-components/tests/plot_read_roundtrip.rs
+++ b/crates/subspace-farmer-components/tests/plot_read_roundtrip.rs
@@ -1,0 +1,101 @@
+//! Plot a sector with the abundance-backed table and read a piece back unchanged.
+
+use futures::executor::block_on;
+use rand::prelude::*;
+use std::num::{NonZeroU64, NonZeroUsize};
+use std::slice;
+use subspace_archiving::archiver::Archiver;
+use subspace_core_primitives::PublicKey;
+use subspace_core_primitives::pieces::{PieceOffset, Record};
+use subspace_core_primitives::segments::{HistorySize, RecordedHistorySegment};
+use subspace_data_retrieval::piece_getter::PieceGetter;
+use subspace_erasure_coding::ErasureCoding;
+use subspace_farmer_components::plotting::{CpuRecordsEncoder, PlotSectorOptions, plot_sector};
+use subspace_farmer_components::reading::{ReadSectorRecordChunksMode, read_piece};
+use subspace_farmer_components::{FarmerProtocolInfo, ReadAt};
+use subspace_kzg::Kzg;
+use subspace_proof_of_space::Table;
+use subspace_proof_of_space::chia_v2::ChiaV2Table;
+
+#[test]
+fn abundance_plot_read_roundtrip() {
+    let pieces_in_sector = 10;
+    let sector_index = 0;
+    let public_key = PublicKey::default();
+
+    let mut input = RecordedHistorySegment::new_boxed();
+    StdRng::seed_from_u64(42).fill(AsMut::<[u8]>::as_mut(input.as_mut()));
+    let kzg = Kzg::new();
+    let erasure_coding = ErasureCoding::new(
+        NonZeroUsize::new(Record::NUM_S_BUCKETS.next_power_of_two().ilog2() as usize)
+            .expect("Not zero; qed"),
+    )
+    .unwrap();
+    let mut archiver = Archiver::new(kzg.clone(), erasure_coding.clone());
+    let archived_history_segment = archiver
+        .add_block(
+            AsRef::<[u8]>::as_ref(input.as_ref()).to_vec(),
+            Default::default(),
+            true,
+        )
+        .archived_segments
+        .into_iter()
+        .next()
+        .unwrap();
+
+    let farmer_protocol_info = FarmerProtocolInfo {
+        history_size: HistorySize::from(NonZeroU64::new(1).unwrap()),
+        max_pieces_in_sector: pieces_in_sector,
+        recent_segments: HistorySize::from(NonZeroU64::new(5).unwrap()),
+        recent_history_fraction: (
+            HistorySize::from(NonZeroU64::new(1).unwrap()),
+            HistorySize::from(NonZeroU64::new(10).unwrap()),
+        ),
+        min_sector_lifetime: HistorySize::from(NonZeroU64::new(4).unwrap()),
+    };
+
+    let mut table_generator = ChiaV2Table::generator();
+    let mut sector = Vec::new();
+    let plotted_sector = block_on(plot_sector(PlotSectorOptions {
+        public_key: &public_key,
+        sector_index,
+        piece_getter: &archived_history_segment,
+        farmer_protocol_info,
+        kzg: &kzg,
+        erasure_coding: &erasure_coding,
+        pieces_in_sector,
+        sector_output: &mut sector,
+        downloading_semaphore: None,
+        encoding_semaphore: None,
+        records_encoder: &mut CpuRecordsEncoder::<ChiaV2Table>::new(
+            slice::from_mut(&mut table_generator),
+            &erasure_coding,
+            &Default::default(),
+        ),
+        abort_early: &Default::default(),
+    }))
+    .unwrap();
+
+    let piece_offset = PieceOffset::ZERO;
+    let piece_index = plotted_sector.piece_indexes[usize::from(piece_offset)];
+    let expected = block_on(archived_history_segment.get_piece(piece_index))
+        .unwrap()
+        .unwrap();
+
+    let read = block_on(read_piece::<ChiaV2Table, _, _>(
+        piece_offset,
+        &plotted_sector.sector_id,
+        &plotted_sector.sector_metadata,
+        &ReadAt::from_sync(sector.as_slice()),
+        &erasure_coding,
+        ReadSectorRecordChunksMode::ConcurrentChunks,
+        &mut table_generator,
+    ))
+    .unwrap();
+
+    assert_eq!(
+        read.record(),
+        expected.record(),
+        "record read back from an abundance-plotted sector must match the original"
+    );
+}

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/benchmark.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/benchmark.rs
@@ -2,7 +2,6 @@ use crate::PosTable;
 use anyhow::anyhow;
 use clap::{Parser, Subcommand};
 use criterion::{BatchSize, Criterion, Throughput};
-use parking_lot::Mutex;
 use rayon::{ThreadPool, ThreadPoolBuildError, ThreadPoolBuilder};
 use std::collections::HashSet;
 use std::fs::OpenOptions;
@@ -162,9 +161,7 @@ where
             .expect("Not zero; qed"),
     )
     .map_err(|error| anyhow!("Failed to instantiate erasure coding: {error}"))?;
-    let table_generator = Mutex::new(PosTable::generator());
-
-    let sectors_metadata = SingleDiskFarm::read_all_sectors_metadata(&disk_farm)
+    let (cutover, sectors_metadata) = SingleDiskFarm::read_all_sectors_metadata(&disk_farm)
         .map_err(|error| anyhow::anyhow!("Failed to read sectors metadata: {error}"))?;
 
     let mut criterion = Criterion::default().sample_size(sample_size);
@@ -187,7 +184,7 @@ where
                 b.iter_batched(
                     rand::random::<[u8; 32]>,
                     |global_challenge| {
-                        let options = PlotAuditOptions::<PosTable> {
+                        let options = PlotAuditOptions {
                             public_key: single_disk_farm_info.public_key(),
                             reward_address: single_disk_farm_info.public_key(),
                             slot_info: SlotInfo {
@@ -204,10 +201,10 @@ where
                             sectors_being_modified: &HashSet::default(),
                             read_sector_record_chunks_mode:
                                 ReadSectorRecordChunksMode::ConcurrentChunks,
-                            table_generator: &table_generator,
+                            cutover,
                         };
 
-                        black_box(plot_audit.audit(black_box(options)))
+                        black_box(plot_audit.audit::<PosTable>(black_box(options)))
                     },
                     BatchSize::SmallInput,
                 )
@@ -224,7 +221,7 @@ where
                 b.iter_batched(
                     rand::random::<[u8; 32]>,
                     |global_challenge| {
-                        let options = PlotAuditOptions::<PosTable> {
+                        let options = PlotAuditOptions {
                             public_key: single_disk_farm_info.public_key(),
                             reward_address: single_disk_farm_info.public_key(),
                             slot_info: SlotInfo {
@@ -241,10 +238,10 @@ where
                             sectors_being_modified: &HashSet::default(),
                             read_sector_record_chunks_mode:
                                 ReadSectorRecordChunksMode::ConcurrentChunks,
-                            table_generator: &table_generator,
+                            cutover,
                         };
 
-                        black_box(plot_audit.audit(black_box(options)))
+                        black_box(plot_audit.audit::<PosTable>(black_box(options)))
                     },
                     BatchSize::SmallInput,
                 )
@@ -259,7 +256,7 @@ where
                 b.iter_batched(
                     rand::random::<[u8; 32]>,
                     |global_challenge| {
-                        let options = PlotAuditOptions::<PosTable> {
+                        let options = PlotAuditOptions {
                             public_key: single_disk_farm_info.public_key(),
                             reward_address: single_disk_farm_info.public_key(),
                             slot_info: SlotInfo {
@@ -276,10 +273,10 @@ where
                             sectors_being_modified: &HashSet::default(),
                             read_sector_record_chunks_mode:
                                 ReadSectorRecordChunksMode::ConcurrentChunks,
-                            table_generator: &table_generator,
+                            cutover,
                         };
 
-                        black_box(plot_audit.audit(black_box(options)))
+                        black_box(plot_audit.audit::<PosTable>(black_box(options)))
                     },
                     BatchSize::SmallInput,
                 )
@@ -342,9 +339,7 @@ where
             .expect("Not zero; qed"),
     )
     .map_err(|error| anyhow!("Failed to instantiate erasure coding: {error}"))?;
-    let table_generator = Mutex::new(PosTable::generator());
-
-    let mut sectors_metadata = SingleDiskFarm::read_all_sectors_metadata(&disk_farm)
+    let (cutover, mut sectors_metadata) = SingleDiskFarm::read_all_sectors_metadata(&disk_farm)
         .map_err(|error| anyhow::anyhow!("Failed to read sectors metadata: {error}"))?;
     if let Some(limit_sector_count) = limit_sector_count {
         sectors_metadata.truncate(limit_sector_count);
@@ -362,7 +357,7 @@ where
                 .open(disk_farm.join(SingleDiskFarm::PLOT_FILE))
                 .map_err(|error| anyhow::anyhow!("Failed to open plot: {error}"))?;
             let plot_audit = PlotAudit::new(&plot);
-            let mut options = PlotAuditOptions::<PosTable> {
+            let mut options = PlotAuditOptions {
                 public_key: single_disk_farm_info.public_key(),
                 reward_address: single_disk_farm_info.public_key(),
                 slot_info: SlotInfo {
@@ -378,10 +373,10 @@ where
                 erasure_coding: &erasure_coding,
                 sectors_being_modified: &HashSet::default(),
                 read_sector_record_chunks_mode: ReadSectorRecordChunksMode::ConcurrentChunks,
-                table_generator: &table_generator,
+                cutover,
             };
 
-            let mut audit_results = plot_audit.audit(options).unwrap();
+            let mut audit_results = plot_audit.audit::<PosTable>(options).unwrap();
 
             group.bench_function("plot/single/concurrent-chunks", |b| {
                 b.iter_batched(
@@ -392,7 +387,7 @@ where
 
                         options.slot_info.global_challenge =
                             Blake3Hash::from(rand::random::<[u8; 32]>());
-                        audit_results = plot_audit.audit(options).unwrap();
+                        audit_results = plot_audit.audit::<PosTable>(options).unwrap();
 
                         audit_results.pop().unwrap()
                     },
@@ -406,7 +401,7 @@ where
             });
 
             options.read_sector_record_chunks_mode = ReadSectorRecordChunksMode::WholeSector;
-            let mut audit_results = plot_audit.audit(options).unwrap();
+            let mut audit_results = plot_audit.audit::<PosTable>(options).unwrap();
 
             group.bench_function("plot/single/whole-sector", |b| {
                 b.iter_batched(
@@ -417,7 +412,7 @@ where
 
                         options.slot_info.global_challenge =
                             Blake3Hash::from(rand::random::<[u8; 32]>());
-                        audit_results = plot_audit.audit(options).unwrap();
+                        audit_results = plot_audit.audit::<PosTable>(options).unwrap();
 
                         audit_results.pop().unwrap()
                     },
@@ -436,7 +431,7 @@ where
             })
             .map_err(|error| anyhow::anyhow!("Failed to open plot: {error}"))?;
             let plot_audit = PlotAudit::new(&plot);
-            let mut options = PlotAuditOptions::<PosTable> {
+            let mut options = PlotAuditOptions {
                 public_key: single_disk_farm_info.public_key(),
                 reward_address: single_disk_farm_info.public_key(),
                 slot_info: SlotInfo {
@@ -452,10 +447,10 @@ where
                 erasure_coding: &erasure_coding,
                 sectors_being_modified: &HashSet::default(),
                 read_sector_record_chunks_mode: ReadSectorRecordChunksMode::ConcurrentChunks,
-                table_generator: &table_generator,
+                cutover,
             };
 
-            let mut audit_results = plot_audit.audit(options).unwrap();
+            let mut audit_results = plot_audit.audit::<PosTable>(options).unwrap();
 
             group.bench_function("plot/rayon/unbuffered/concurrent-chunks", |b| {
                 b.iter_batched(
@@ -466,7 +461,7 @@ where
 
                         options.slot_info.global_challenge =
                             Blake3Hash::from(rand::random::<[u8; 32]>());
-                        audit_results = plot_audit.audit(options).unwrap();
+                        audit_results = plot_audit.audit::<PosTable>(options).unwrap();
 
                         audit_results.pop().unwrap()
                     },
@@ -480,7 +475,7 @@ where
             });
 
             options.read_sector_record_chunks_mode = ReadSectorRecordChunksMode::WholeSector;
-            let mut audit_results = plot_audit.audit(options).unwrap();
+            let mut audit_results = plot_audit.audit::<PosTable>(options).unwrap();
 
             group.bench_function("plot/rayon/unbuffered/whole-sector", |b| {
                 b.iter_batched(
@@ -491,7 +486,7 @@ where
 
                         options.slot_info.global_challenge =
                             Blake3Hash::from(rand::random::<[u8; 32]>());
-                        audit_results = plot_audit.audit(options).unwrap();
+                        audit_results = plot_audit.audit::<PosTable>(options).unwrap();
 
                         audit_results.pop().unwrap()
                     },
@@ -508,7 +503,7 @@ where
             let plot = RayonFiles::open(disk_farm.join(SingleDiskFarm::PLOT_FILE))
                 .map_err(|error| anyhow::anyhow!("Failed to open plot: {error}"))?;
             let plot_audit = PlotAudit::new(&plot);
-            let mut options = PlotAuditOptions::<PosTable> {
+            let mut options = PlotAuditOptions {
                 public_key: single_disk_farm_info.public_key(),
                 reward_address: single_disk_farm_info.public_key(),
                 slot_info: SlotInfo {
@@ -524,10 +519,10 @@ where
                 erasure_coding: &erasure_coding,
                 sectors_being_modified: &HashSet::default(),
                 read_sector_record_chunks_mode: ReadSectorRecordChunksMode::ConcurrentChunks,
-                table_generator: &table_generator,
+                cutover,
             };
 
-            let mut audit_results = plot_audit.audit(options).unwrap();
+            let mut audit_results = plot_audit.audit::<PosTable>(options).unwrap();
 
             group.bench_function("plot/rayon/regular/concurrent-chunks", |b| {
                 b.iter_batched(
@@ -538,7 +533,7 @@ where
 
                         options.slot_info.global_challenge =
                             Blake3Hash::from(rand::random::<[u8; 32]>());
-                        audit_results = plot_audit.audit(options).unwrap();
+                        audit_results = plot_audit.audit::<PosTable>(options).unwrap();
 
                         audit_results.pop().unwrap()
                     },
@@ -552,7 +547,7 @@ where
             });
 
             options.read_sector_record_chunks_mode = ReadSectorRecordChunksMode::WholeSector;
-            let mut audit_results = plot_audit.audit(options).unwrap();
+            let mut audit_results = plot_audit.audit::<PosTable>(options).unwrap();
 
             group.bench_function("plot/rayon/regular/whole-sector", |b| {
                 b.iter_batched(
@@ -563,7 +558,7 @@ where
 
                         options.slot_info.global_challenge =
                             Blake3Hash::from(rand::random::<[u8; 32]>());
-                        audit_results = plot_audit.audit(options).unwrap();
+                        audit_results = plot_audit.audit::<PosTable>(options).unwrap();
 
                         audit_results.pop().unwrap()
                     },

--- a/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
@@ -5,13 +5,12 @@ use std::fs;
 use std::path::PathBuf;
 use subspace_farmer::single_disk_farm::{ScrubTarget, SingleDiskFarm};
 use subspace_process::{init_logger, raise_fd_limit, set_exit_on_panic};
-use subspace_proof_of_space::chia::ChiaTable;
 use tracing::info;
 
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
-type PosTable = ChiaTable;
+type PosTable = subspace_proof_of_space::PosTable;
 
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, Parser)]

--- a/crates/subspace-farmer/src/single_disk_farm.rs
+++ b/crates/subspace-farmer/src/single_disk_farm.rs
@@ -255,21 +255,67 @@ pub enum SingleDiskFarmSummary {
     },
 }
 
-#[derive(Debug, Encode, Decode)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Encode, Decode)]
+enum PlotMetadataVersion {
+    /// Original layout, before the proof-of-space cutover.
+    #[codec(index = 0)]
+    V0,
+    /// Adds the proof-of-space `cutover`.
+    #[codec(index = 1)]
+    V1,
+}
+
+impl PlotMetadataVersion {
+    /// Latest version this implementation writes.
+    const LATEST: Self = Self::V1;
+}
+
+#[derive(Debug, Encode)]
 struct PlotMetadataHeader {
-    version: u8,
+    version: PlotMetadataVersion,
     plotted_sector_count: SectorIndex,
+    /// History size of the newest sector plotted before the proof-of-space cutover, or `None` for
+    /// a farm with no pre-cutover sectors. Sectors with `history_size <= cutover` use the old
+    /// proof-of-space, newer ones the new one. Present only in version 1 and later.
+    cutover: Option<HistorySize>,
 }
 
 impl PlotMetadataHeader {
     #[inline]
     fn encoded_size() -> usize {
         let default = PlotMetadataHeader {
-            version: 0,
+            version: PlotMetadataVersion::LATEST,
             plotted_sector_count: 0,
+            // `Some` is the larger encoding; size the header buffer for it so a version 1 header
+            // with a recorded cutover always fits.
+            cutover: Some(HistorySize::from(SegmentIndex::ZERO)),
         };
 
         default.encoded_size()
+    }
+}
+
+// TODO(ved): Drop this manual `Decode` and return to `#[derive(Decode)]` once the `cutover` field
+//  is removed after the proof-of-space migration completes. It exists only to decode version 0
+//  headers that predate the `cutover` field.
+impl Decode for PlotMetadataHeader {
+    fn decode<I: parity_scale_codec::Input>(
+        input: &mut I,
+    ) -> Result<Self, parity_scale_codec::Error> {
+        // Rejects unknown (future) versions — this is the old-binary lockout.
+        let version = PlotMetadataVersion::decode(input)?;
+        let plotted_sector_count = SectorIndex::decode(input)?;
+        // `cutover` was added in version 1; version 0 headers do not carry it.
+        let cutover = match version {
+            PlotMetadataVersion::V0 => None,
+            PlotMetadataVersion::V1 => Option::<HistorySize>::decode(input)?,
+        };
+
+        Ok(Self {
+            version,
+            plotted_sector_count,
+            cutover,
+        })
     }
 }
 
@@ -388,9 +434,6 @@ pub enum SingleDiskFarmError {
     /// Failed to decode metadata header
     #[error("Failed to decode metadata header: {0}")]
     FailedToDecodeMetadataHeader(parity_scale_codec::Error),
-    /// Unexpected metadata version
-    #[error("Unexpected metadata version {0}")]
-    UnexpectedMetadataVersion(u8),
     /// Allocated space is not enough for one sector
     #[error(
         "Allocated space is not enough for one sector. \
@@ -528,9 +571,6 @@ pub enum SingleDiskFarmScrubError {
     /// Failed to decode metadata header
     #[error("Failed to decode metadata header: {0}")]
     FailedToDecodeMetadataHeader(parity_scale_codec::Error),
-    /// Unexpected metadata version
-    #[error("Unexpected metadata version {0}")]
-    UnexpectedMetadataVersion(u8),
     /// Cache can't be opened
     #[error("Cache at {file} can't be opened: {error}")]
     CacheCantBeOpened {
@@ -821,7 +861,6 @@ impl SingleDiskFarm {
     pub const PLOT_FILE: &'static str = "plot.bin";
     /// Name of the metadata file
     pub const METADATA_FILE: &'static str = "metadata.bin";
-    const SUPPORTED_PLOT_VERSION: u8 = 0;
 
     /// Create new single disk farm instance
     pub async fn new<NC, PosTable>(
@@ -1350,10 +1389,11 @@ impl SingleDiskFarm {
         // Align plot file size for disk sector size
         let expected_metadata_size =
             expected_metadata_size.div_ceil(DISK_SECTOR_SIZE as u64) * DISK_SECTOR_SIZE as u64;
-        let metadata_header = if metadata_size == 0 {
+        let mut metadata_header = if metadata_size == 0 {
             let metadata_header = PlotMetadataHeader {
-                version: SingleDiskFarm::SUPPORTED_PLOT_VERSION,
+                version: PlotMetadataVersion::LATEST,
                 plotted_sector_count: 0,
+                cutover: None,
             };
 
             metadata_file
@@ -1379,12 +1419,6 @@ impl SingleDiskFarm {
             let mut metadata_header =
                 PlotMetadataHeader::decode(&mut metadata_header_bytes.as_ref())
                     .map_err(SingleDiskFarmError::FailedToDecodeMetadataHeader)?;
-
-            if metadata_header.version != SingleDiskFarm::SUPPORTED_PLOT_VERSION {
-                return Err(SingleDiskFarmError::UnexpectedMetadataVersion(
-                    metadata_header.version,
-                ));
-            }
 
             if metadata_header.plotted_sector_count > target_sector_count {
                 metadata_header.plotted_sector_count = target_sector_count;
@@ -1428,6 +1462,14 @@ impl SingleDiskFarm {
                         }
                     };
                 sectors_metadata.push(sector_metadata);
+            }
+
+            // Upgrade a version-0 plot in place: its sectors predate the new proof-of-space, so set
+            // the cutover from their max history size (not node history, which can trail on sync).
+            if metadata_header.version < PlotMetadataVersion::LATEST {
+                metadata_header.cutover = sectors_metadata.iter().map(|m| m.history_size).max();
+                metadata_header.version = PlotMetadataVersion::LATEST;
+                metadata_file.write_all_at(&metadata_header.encode(), 0)?;
             }
 
             Arc::new(AsyncRwLock::new(sectors_metadata))
@@ -1588,13 +1630,6 @@ impl SingleDiskFarm {
             .map_err(|error| {
                 io::Error::other(format!("Failed to decode metadata header: {error}"))
             })?;
-
-        if metadata_header.version != SingleDiskFarm::SUPPORTED_PLOT_VERSION {
-            return Err(io::Error::other(format!(
-                "Unsupported metadata version {}",
-                metadata_header.version
-            )));
-        }
 
         let mut sectors_metadata = Vec::<SectorMetadataChecksummed>::with_capacity(
             ((metadata_size - RESERVED_PLOT_METADATA) / sector_metadata_size as u64) as usize,
@@ -1862,12 +1897,6 @@ impl SingleDiskFarm {
                     PlotMetadataHeader::decode(&mut reserved_metadata.as_slice())
                         .map_err(SingleDiskFarmScrubError::FailedToDecodeMetadataHeader)?
                 };
-
-                if metadata_header.version != SingleDiskFarm::SUPPORTED_PLOT_VERSION {
-                    return Err(SingleDiskFarmScrubError::UnexpectedMetadataVersion(
-                        metadata_header.version,
-                    ));
-                }
 
                 let plotted_sector_count = metadata_header.plotted_sector_count;
 

--- a/crates/subspace-farmer/src/single_disk_farm.rs
+++ b/crates/subspace-farmer/src/single_disk_farm.rs
@@ -319,6 +319,11 @@ impl Decode for PlotMetadataHeader {
     }
 }
 
+/// With no cutover (a fresh farm) every sector is post-cutover.
+fn is_post_cutover(cutover: Option<HistorySize>, history_size: HistorySize) -> bool {
+    cutover.is_none_or(|cutover| history_size > cutover)
+}
+
 /// Options used to open single disk farm
 #[derive(Debug)]
 pub struct SingleDiskFarmOptions<'a, NC>
@@ -1009,6 +1014,9 @@ impl SingleDiskFarm {
         let (farming_plot, farming_thread_pool) =
             AsyncJoinOnDrop::new(farming_plot_fut, false).await??;
 
+        // The plot's cutover decides which proof-of-space each sector reads and proves with.
+        let cutover = metadata_header.cutover;
+
         let plotting_join_handle = task::spawn_blocking({
             let sectors_metadata = Arc::clone(&sectors_metadata);
             let handlers = Arc::clone(&handlers);
@@ -1155,6 +1163,7 @@ impl SingleDiskFarm {
                         read_sector_record_chunks_mode,
                         global_mutex,
                         metrics,
+                        cutover,
                     };
                     farming::<PosTable, _, _>(farming_options).await
                 };
@@ -1198,6 +1207,7 @@ impl SingleDiskFarm {
             erasure_coding,
             sectors_being_modified,
             read_sector_record_chunks_mode,
+            cutover,
             global_mutex,
         );
 
@@ -1614,10 +1624,10 @@ impl SingleDiskFarm {
         Ok(effective_disk_usage)
     }
 
-    /// Read all sectors metadata
+    /// Read the proof-of-space cutover and all sectors metadata
     pub fn read_all_sectors_metadata(
         directory: &Path,
-    ) -> io::Result<Vec<SectorMetadataChecksummed>> {
+    ) -> io::Result<(Option<HistorySize>, Vec<SectorMetadataChecksummed>)> {
         let metadata_file = DirectIoFile::open(directory.join(Self::METADATA_FILE))?;
 
         let metadata_size = metadata_file.size()?;
@@ -1648,7 +1658,14 @@ impl SingleDiskFarm {
             );
         }
 
-        Ok(sectors_metadata)
+        // A version-0 plot has no stored cutover; derive it from its sectors, like the upgrade.
+        let cutover = if metadata_header.version < PlotMetadataVersion::LATEST {
+            sectors_metadata.iter().map(|m| m.history_size).max()
+        } else {
+            metadata_header.cutover
+        };
+
+        Ok((cutover, sectors_metadata))
     }
 
     /// ID of this farm

--- a/crates/subspace-farmer/src/single_disk_farm.rs
+++ b/crates/subspace-farmer/src/single_disk_farm.rs
@@ -2407,3 +2407,52 @@ fn write_dummy_sector_metadata(
             error,
         })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plot_metadata_header_version_upgrade() {
+        // A version 0 header carries no cutover field yet must still decode, with cutover = None.
+        #[derive(Encode)]
+        struct V0Header {
+            version: u8,
+            plotted_sector_count: SectorIndex,
+        }
+        let v0_bytes = V0Header {
+            version: 0,
+            plotted_sector_count: 42,
+        }
+        .encode();
+        let decoded =
+            PlotMetadataHeader::decode(&mut v0_bytes.as_slice()).expect("version 0 header decodes");
+        assert_eq!(decoded.version, PlotMetadataVersion::V0);
+        assert_eq!(decoded.plotted_sector_count, 42);
+        assert_eq!(decoded.cutover, None);
+
+        // A current header round-trips with its cutover intact.
+        let cutover = Some(HistorySize::from(SegmentIndex::ZERO));
+        let header = PlotMetadataHeader {
+            version: PlotMetadataVersion::LATEST,
+            plotted_sector_count: 7,
+            cutover,
+        };
+        let decoded = PlotMetadataHeader::decode(&mut header.encode().as_slice())
+            .expect("current header round-trips");
+        assert_eq!(decoded.version, PlotMetadataVersion::LATEST);
+        assert_eq!(decoded.plotted_sector_count, 7);
+        assert_eq!(decoded.cutover, cutover);
+    }
+
+    #[test]
+    fn is_post_cutover_boundary() {
+        let h = |n: u64| HistorySize::from(SegmentIndex::from(n));
+        // No cutover: a fresh farm plots everything with the new proof-of-space.
+        assert!(is_post_cutover(None, h(1)));
+        // At or below the cutover stays old; strictly above moves to the new proof-of-space.
+        assert!(!is_post_cutover(Some(h(10)), h(9)));
+        assert!(!is_post_cutover(Some(h(10)), h(10)));
+        assert!(is_post_cutover(Some(h(10)), h(11)));
+    }
+}

--- a/crates/subspace-farmer/src/single_disk_farm/farming.rs
+++ b/crates/subspace-farmer/src/single_disk_farm/farming.rs
@@ -14,7 +14,6 @@ use crate::single_disk_farm::metrics::SingleDiskFarmMetrics;
 use async_lock::{Mutex as AsyncMutex, RwLock as AsyncRwLock};
 use futures::StreamExt;
 use futures::channel::mpsc;
-use parking_lot::Mutex;
 use rayon::ThreadPool;
 use std::collections::HashSet;
 use std::sync::Arc;
@@ -73,11 +72,8 @@ where
 }
 
 /// Plot audit options
-#[derive(Debug)]
-pub struct PlotAuditOptions<'a, 'b, PosTable>
-where
-    PosTable: Table,
-{
+#[derive(Debug, Clone, Copy)]
+pub struct PlotAuditOptions<'a, 'b> {
     /// Public key of the farm
     pub public_key: &'a PublicKey,
     /// Reward address to use for solutions
@@ -95,21 +91,10 @@ where
     pub sectors_being_modified: &'b HashSet<SectorIndex>,
     /// Mode of reading chunks during proving
     pub read_sector_record_chunks_mode: ReadSectorRecordChunksMode,
-    /// Proof of space table generator
-    pub table_generator: &'a Mutex<PosTable::Generator>,
+    /// Proof-of-space cutover: sectors with a history size above this use the new implementation,
+    /// `None` on a farm with no pre-cutover sectors.
+    pub cutover: Option<HistorySize>,
 }
-
-impl<PosTable> Clone for PlotAuditOptions<'_, '_, PosTable>
-where
-    PosTable: Table,
-{
-    #[inline]
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-
-impl<PosTable> Copy for PlotAuditOptions<'_, '_, PosTable> where PosTable: Table {}
 
 /// Plot auditing implementation
 #[derive(Debug)]
@@ -130,7 +115,7 @@ where
     #[allow(clippy::type_complexity)]
     pub fn audit<'b, PosTable>(
         &'a self,
-        options: PlotAuditOptions<'a, 'b, PosTable>,
+        options: PlotAuditOptions<'a, 'b>,
     ) -> Result<
         Vec<(
             SectorIndex,
@@ -151,7 +136,7 @@ where
             erasure_coding,
             sectors_being_modified,
             read_sector_record_chunks_mode: mode,
-            table_generator,
+            cutover,
         } = options;
 
         let audit_results = audit_plot_sync(
@@ -168,12 +153,17 @@ where
             .filter_map(|audit_results| {
                 let sector_index = audit_results.sector_index;
 
-                let sector_solutions = audit_results.solution_candidates.into_solutions(
+                let solution_candidates = audit_results.solution_candidates;
+                let is_post_cutover =
+                    super::is_post_cutover(cutover, solution_candidates.history_size());
+                let table_generator = PosTable::generator_for(is_post_cutover);
+
+                let sector_solutions = solution_candidates.into_solutions(
                     reward_address,
                     kzg,
                     erasure_coding,
                     mode,
-                    |seed: &PosSeed| table_generator.lock().generate_parallel(seed),
+                    move |seed: &PosSeed| table_generator.generate_parallel(seed),
                 );
 
                 let sector_solutions = match sector_solutions {
@@ -214,6 +204,7 @@ pub(super) struct FarmingOptions<NC, PlotAudit> {
     pub(super) read_sector_record_chunks_mode: ReadSectorRecordChunksMode,
     pub(super) global_mutex: Arc<AsyncMutex<()>>,
     pub(super) metrics: Option<Arc<SingleDiskFarmMetrics>>,
+    pub(super) cutover: Option<HistorySize>,
 }
 
 /// Starts farming process.
@@ -243,6 +234,7 @@ where
         read_sector_record_chunks_mode,
         global_mutex,
         metrics,
+        cutover,
     } = farming_options;
 
     let farmer_app_info = node_client
@@ -253,7 +245,6 @@ where
     // We assume that each slot is one second
     let farming_timeout = farmer_app_info.farming_timeout;
 
-    let table_generator = Arc::new(Mutex::new(PosTable::generator()));
     let span = Span::current();
 
     let mut non_fatal_errors = 0;
@@ -278,7 +269,7 @@ where
                     .install(|| {
                         let _span_guard = span.enter();
 
-                        plot_audit.audit(PlotAuditOptions::<PosTable> {
+                        plot_audit.audit::<PosTable>(PlotAuditOptions {
                             public_key: &public_key,
                             reward_address: &reward_address,
                             slot_info,
@@ -287,7 +278,7 @@ where
                             erasure_coding: &erasure_coding,
                             sectors_being_modified,
                             read_sector_record_chunks_mode,
-                            table_generator: &table_generator,
+                            cutover,
                         })
                     })
                     .map_err(FarmingError::LowLevelAuditing)?

--- a/crates/subspace-farmer/src/single_disk_farm/piece_reader.rs
+++ b/crates/subspace-farmer/src/single_disk_farm/piece_reader.rs
@@ -12,6 +12,7 @@ use std::sync::Arc;
 use subspace_core_primitives::PublicKey;
 use subspace_core_primitives::pieces::{Piece, PieceOffset};
 use subspace_core_primitives::sectors::{SectorId, SectorIndex};
+use subspace_core_primitives::segments::HistorySize;
 use subspace_erasure_coding::ErasureCoding;
 use subspace_farmer_components::reading::ReadSectorRecordChunksMode;
 use subspace_farmer_components::sector::{SectorMetadataChecksummed, sector_size};
@@ -58,6 +59,7 @@ impl DiskPieceReader {
         erasure_coding: ErasureCoding,
         sectors_being_modified: Arc<AsyncRwLock<HashSet<SectorIndex>>>,
         read_sector_record_chunks_mode: ReadSectorRecordChunksMode,
+        cutover: Option<HistorySize>,
         global_mutex: Arc<AsyncMutex<()>>,
     ) -> (Self, impl Future<Output = ()>)
     where
@@ -75,6 +77,7 @@ impl DiskPieceReader {
                 sectors_being_modified,
                 read_piece_receiver,
                 read_sector_record_chunks_mode,
+                cutover,
                 global_mutex,
             )
             .await
@@ -118,12 +121,16 @@ async fn read_pieces<PosTable, S>(
     sectors_being_modified: Arc<AsyncRwLock<HashSet<SectorIndex>>>,
     mut read_piece_receiver: mpsc::Receiver<ReadPieceRequest>,
     mode: ReadSectorRecordChunksMode,
+    cutover: Option<HistorySize>,
     global_mutex: Arc<AsyncMutex<()>>,
 ) where
     PosTable: Table,
     S: ReadAtSync,
 {
-    let mut table_generator = PosTable::generator();
+    // Keep a warm generator for each proof-of-space so old and new sectors can be read without
+    // re-allocating table caches per request.
+    let mut table_generator_old = PosTable::generator_for(false);
+    let mut table_generator_new = PosTable::generator_for(true);
 
     while let Some(read_piece_request) = read_piece_receiver.next().await {
         let ReadPieceRequest {
@@ -194,6 +201,13 @@ async fn read_pieces<PosTable, S>(
         // Take mutex briefly to make sure piece reading is allowed right now
         global_mutex.lock().await;
 
+        let is_post_cutover = super::is_post_cutover(cutover, sector_metadata.history_size);
+        let table_generator = if is_post_cutover {
+            &mut table_generator_new
+        } else {
+            &mut table_generator_old
+        };
+
         let maybe_piece = read_piece::<PosTable, _, _>(
             &public_key,
             piece_offset,
@@ -202,7 +216,7 @@ async fn read_pieces<PosTable, S>(
             &ReadAt::from_sync(&sector),
             &erasure_coding,
             mode,
-            &mut table_generator,
+            table_generator,
         )
         .await;
 

--- a/crates/subspace-farmer/src/single_disk_farm/plotting.rs
+++ b/crates/subspace-farmer/src/single_disk_farm/plotting.rs
@@ -125,6 +125,7 @@ where
     } = plotting_options;
 
     let sector_plotting_options = &sector_plotting_options;
+    let cutover = metadata_header.cutover;
     let plotting_semaphore = Semaphore::new(max_plotting_sectors_per_farm.get());
     let mut sectors_being_plotted = FuturesOrdered::new();
     // Channel size is intentionally unbounded for easier analysis, but it is bounded by plotting
@@ -165,6 +166,7 @@ where
                     sectors_metadata,
                     sectors_being_modified,
                     &plotting_semaphore,
+                    cutover,
                 )
                     .instrument(info_span!("", %sector_index))
                     .fuse();
@@ -287,6 +289,7 @@ async fn plot_single_sector<'a, NC>(
     sectors_metadata: &'a AsyncRwLock<Vec<SectorMetadataChecksummed>>,
     sectors_being_modified: &'a AsyncRwLock<HashSet<SectorIndex>>,
     plotting_semaphore: &'a Semaphore,
+    cutover: Option<HistorySize>,
 ) -> PlotSingleSectorResult<
     impl Future<Output = Result<SectorPlottingResult<'a>, PlottingError>> + 'a,
 >
@@ -382,6 +385,20 @@ where
                 );
                 return PlotSingleSectorResult::Skipped;
             }
+        }
+
+        // Wait for history to pass the cutover before plotting, so a new sector isn't stamped at or
+        // below it and later read back with the old proof-of-space.
+        if let Some(cutover) = cutover
+            && farmer_app_info.protocol_info.history_size <= cutover
+        {
+            debug!(
+                current_history_size = %farmer_app_info.protocol_info.history_size,
+                %cutover,
+                "History size has not advanced past the proof-of-space cutover yet, waiting"
+            );
+            tokio::time::sleep(FARMER_APP_INFO_RETRY_INTERVAL).await;
+            continue;
         }
 
         break farmer_app_info;

--- a/crates/subspace-proof-of-space/Cargo.toml
+++ b/crates/subspace-proof-of-space/Cargo.toml
@@ -19,6 +19,7 @@ bench = false
 
 [dependencies]
 ab-chacha8.workspace = true
+ab-proof-of-space = { workspace = true, optional = true }
 blake3 = { workspace = true, default-features = false }
 chacha20 = { workspace = true, features = ["cipher"], optional = true }
 derive_more = { workspace = true, features = ["full"] }
@@ -44,6 +45,9 @@ default = []
 alloc = [
     "dep:chacha20",
     "dep:seq-macro",
+    "dep:ab-proof-of-space",
+    "ab-proof-of-space/alloc",
+    "ab-proof-of-space/full-chiapos",
 ]
 # Enabling this feature exposes quality search on `chiapos` module as well as enables support for K=15..=25 (by default
 # only K=20 is exposed)
@@ -53,4 +57,5 @@ full-chiapos = [
 parallel = [
     "alloc",
     "dep:rayon",
+    "ab-proof-of-space/parallel",
 ]

--- a/crates/subspace-proof-of-space/benches/pos.rs
+++ b/crates/subspace-proof-of-space/benches/pos.rs
@@ -250,13 +250,14 @@ fn pos_bench<PosTable>(
 }
 
 pub fn criterion_benchmark(c: &mut Criterion) {
+    #[cfg(feature = "alloc")]
     {
         // This challenge index with above seed is known to not have a solution
-        let challenge_index_without_solution = 1232460437;
+        let challenge_index_without_solution = 0;
         // This challenge index with above seed is known to have a solution
-        let challenge_index_with_solution = 600426542;
+        let challenge_index_with_solution = 3;
 
-        pos_bench::<subspace_proof_of_space::chia::ChiaTable>(
+        pos_bench::<subspace_proof_of_space::chia_v2::ChiaV2Table>(
             c,
             "chia",
             challenge_index_without_solution,

--- a/crates/subspace-proof-of-space/src/chia_v2.rs
+++ b/crates/subspace-proof-of-space/src/chia_v2.rs
@@ -63,3 +63,6 @@ impl Table for ChiaV2Table {
         <Self as SolutionPotVerifier>::is_proof_valid(seed, challenge_index, proof)
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/crates/subspace-proof-of-space/src/chia_v2.rs
+++ b/crates/subspace-proof-of-space/src/chia_v2.rs
@@ -1,0 +1,65 @@
+//! Chia proof of space backed by abundance's `ab-proof-of-space`.
+//!
+//! Proofs are looked up under Subspace's s-bucket convention, so they verify under the existing
+//! [`ChiaTable`] verifier.
+
+use crate::chia::ChiaTable;
+use crate::{PosTableType, Table, TableGenerator};
+use ab_proof_of_space::chiapos::{Tables, TablesCache};
+use subspace_core_primitives::pos::{PosProof, PosSeed};
+use subspace_core_primitives::solutions::SolutionPotVerifier;
+
+const K: u8 = PosProof::K;
+
+/// Proof of space table generator.
+///
+/// Chia implementation.
+#[derive(Debug, Default, Clone)]
+pub struct ChiaV2TableGenerator {
+    tables_cache: TablesCache,
+}
+
+impl TableGenerator<ChiaV2Table> for ChiaV2TableGenerator {
+    fn generate(&self, seed: &PosSeed) -> ChiaV2Table {
+        ChiaV2Table {
+            tables: Tables::<K>::create((*seed).into(), &self.tables_cache),
+        }
+    }
+
+    #[cfg(feature = "parallel")]
+    fn generate_parallel(&self, seed: &PosSeed) -> ChiaV2Table {
+        ChiaV2Table {
+            tables: Tables::<K>::create_parallel((*seed).into(), &self.tables_cache),
+        }
+    }
+}
+
+/// Proof of space table.
+///
+/// Chia implementation.
+#[derive(Debug)]
+pub struct ChiaV2Table {
+    tables: Tables<K>,
+}
+
+impl SolutionPotVerifier for ChiaV2Table {
+    fn is_proof_valid(seed: &PosSeed, challenge_index: u32, proof: &PosProof) -> bool {
+        <ChiaTable as SolutionPotVerifier>::is_proof_valid(seed, challenge_index, proof)
+    }
+}
+
+impl Table for ChiaV2Table {
+    const TABLE_TYPE: PosTableType = PosTableType::Chia;
+    type Generator = ChiaV2TableGenerator;
+
+    fn find_proof(&self, challenge_index: u32) -> Option<PosProof> {
+        self.tables
+            .find_proof(challenge_index.to_le_bytes())
+            .next()
+            .map(PosProof::from)
+    }
+
+    fn is_proof_valid(seed: &PosSeed, challenge_index: u32, proof: &PosProof) -> bool {
+        <Self as SolutionPotVerifier>::is_proof_valid(seed, challenge_index, proof)
+    }
+}

--- a/crates/subspace-proof-of-space/src/chia_v2/tests.rs
+++ b/crates/subspace-proof-of-space/src/chia_v2/tests.rs
@@ -1,0 +1,29 @@
+use crate::chia::ChiaTable;
+use crate::chia_v2::ChiaV2TableGenerator;
+use crate::{Table, TableGenerator};
+use subspace_core_primitives::pos::PosSeed;
+use subspace_core_primitives::sectors::SBucket;
+
+// Every abundance-backed proof must verify under ChiaTable::is_proof_valid.
+#[test]
+fn proofs_verify_under_consensus() {
+    let generator = ChiaV2TableGenerator::default();
+
+    for seed_byte in 0..3u8 {
+        let seed = PosSeed::from([seed_byte; 32]);
+        let table = generator.generate(&seed);
+
+        let mut verified = 0u32;
+        for s_bucket in u16::from(SBucket::ZERO)..=u16::from(SBucket::MAX) {
+            if let Some(proof) = table.find_proof(u32::from(s_bucket)) {
+                assert!(
+                    ChiaTable::is_proof_valid(&seed, u32::from(s_bucket), &proof),
+                    "seed {seed_byte}: proof for s-bucket {s_bucket} rejected by the consensus \
+                     verifier"
+                );
+                verified += 1;
+            }
+        }
+        assert!(verified > 0, "seed {seed_byte}: no proofs produced");
+    }
+}

--- a/crates/subspace-proof-of-space/src/lib.rs
+++ b/crates/subspace-proof-of-space/src/lib.rs
@@ -8,6 +8,8 @@
 #![cfg_attr(feature = "parallel", feature(exact_size_is_empty, sync_unsafe_cell))]
 
 pub mod chia;
+#[cfg(feature = "alloc")]
+pub mod chia_v2;
 pub mod chiapos;
 pub mod shim;
 

--- a/crates/subspace-proof-of-space/src/lib.rs
+++ b/crates/subspace-proof-of-space/src/lib.rs
@@ -11,7 +11,12 @@ pub mod chia;
 #[cfg(feature = "alloc")]
 pub mod chia_v2;
 pub mod chiapos;
+#[cfg(feature = "alloc")]
+pub mod pos_table;
 pub mod shim;
+
+#[cfg(feature = "alloc")]
+pub use pos_table::{PosTable, PosTableGenerator};
 
 #[cfg(feature = "alloc")]
 extern crate alloc;
@@ -71,5 +76,12 @@ pub trait Table: SolutionPotVerifier + Sized + Send + Sync + 'static {
     #[cfg(feature = "alloc")]
     fn generator() -> Self::Generator {
         Self::Generator::default()
+    }
+
+    /// Table generator for a sector, given whether it was plotted after the cutover. Single-impl
+    /// tables ignore the argument.
+    #[cfg(feature = "alloc")]
+    fn generator_for(_is_post_cutover: bool) -> Self::Generator {
+        Self::generator()
     }
 }

--- a/crates/subspace-proof-of-space/src/pos_table.rs
+++ b/crates/subspace-proof-of-space/src/pos_table.rs
@@ -1,0 +1,90 @@
+//! Proof of space that dispatches per sector between the old [`ChiaTable`] and the new
+//! [`ChiaV2Table`], so one farm can mix them across the migration cutover.
+
+use crate::chia::ChiaTable;
+use crate::chia_v2::ChiaV2Table;
+use crate::{PosTableType, Table, TableGenerator};
+use subspace_core_primitives::pos::{PosProof, PosSeed};
+use subspace_core_primitives::solutions::SolutionPotVerifier;
+
+/// Proof of space table generator dispatching between the old and new Chia implementations.
+#[derive(Debug, Clone)]
+pub enum PosTableGenerator {
+    /// Old (pre-cutover) implementation.
+    V1(<ChiaTable as Table>::Generator),
+    /// New (post-cutover) implementation.
+    V2(<ChiaV2Table as Table>::Generator),
+}
+
+impl Default for PosTableGenerator {
+    #[inline]
+    fn default() -> Self {
+        Self::V2(ChiaV2Table::generator())
+    }
+}
+
+impl PosTableGenerator {
+    /// Generator for a sector: the new implementation for post-cutover sectors, the old one
+    /// otherwise.
+    #[inline]
+    pub fn new(is_post_cutover: bool) -> Self {
+        if is_post_cutover {
+            Self::V2(ChiaV2Table::generator())
+        } else {
+            Self::V1(ChiaTable::generator())
+        }
+    }
+}
+
+impl TableGenerator<PosTable> for PosTableGenerator {
+    fn generate(&self, seed: &PosSeed) -> PosTable {
+        match self {
+            Self::V1(generator) => PosTable::V1(generator.generate(seed)),
+            Self::V2(generator) => PosTable::V2(generator.generate(seed)),
+        }
+    }
+
+    #[cfg(feature = "parallel")]
+    fn generate_parallel(&self, seed: &PosSeed) -> PosTable {
+        match self {
+            Self::V1(generator) => PosTable::V1(generator.generate_parallel(seed)),
+            Self::V2(generator) => PosTable::V2(generator.generate_parallel(seed)),
+        }
+    }
+}
+
+/// Proof of space table dispatching between the old and new Chia implementations.
+#[derive(Debug)]
+pub enum PosTable {
+    /// Old (pre-cutover) implementation.
+    V1(ChiaTable),
+    /// New (post-cutover) implementation.
+    V2(ChiaV2Table),
+}
+
+impl SolutionPotVerifier for PosTable {
+    fn is_proof_valid(seed: &PosSeed, challenge_index: u32, proof: &PosProof) -> bool {
+        // Both V1 and V2 proofs verify under ChiaTable.
+        <ChiaTable as SolutionPotVerifier>::is_proof_valid(seed, challenge_index, proof)
+    }
+}
+
+impl Table for PosTable {
+    const TABLE_TYPE: PosTableType = PosTableType::Chia;
+    type Generator = PosTableGenerator;
+
+    fn generator_for(is_post_cutover: bool) -> Self::Generator {
+        PosTableGenerator::new(is_post_cutover)
+    }
+
+    fn find_proof(&self, challenge_index: u32) -> Option<PosProof> {
+        match self {
+            Self::V1(table) => table.find_proof(challenge_index),
+            Self::V2(table) => table.find_proof(challenge_index),
+        }
+    }
+
+    fn is_proof_valid(seed: &PosSeed, challenge_index: u32, proof: &PosProof) -> bool {
+        <Self as SolutionPotVerifier>::is_proof_valid(seed, challenge_index, proof)
+    }
+}

--- a/crates/subspace-proof-of-space/src/pos_table.rs
+++ b/crates/subspace-proof-of-space/src/pos_table.rs
@@ -88,3 +88,6 @@ impl Table for PosTable {
         <Self as SolutionPotVerifier>::is_proof_valid(seed, challenge_index, proof)
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/crates/subspace-proof-of-space/src/pos_table/tests.rs
+++ b/crates/subspace-proof-of-space/src/pos_table/tests.rs
@@ -1,0 +1,18 @@
+use crate::pos_table::PosTableGenerator;
+
+// New sectors get the abundance-backed table; sectors at or below the cutover keep the old one.
+#[test]
+fn dispatch_selects_by_cutover() {
+    assert!(matches!(
+        PosTableGenerator::new(true),
+        PosTableGenerator::V2(_)
+    ));
+    assert!(matches!(
+        PosTableGenerator::new(false),
+        PosTableGenerator::V1(_)
+    ));
+    assert!(matches!(
+        PosTableGenerator::default(),
+        PosTableGenerator::V2(_)
+    ));
+}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2026-04-11"
+channel = "nightly-2026-05-03"
 components = ["rust-src"]
 targets = ["wasm32v1-none"]
 profile = "default"


### PR DESCRIPTION
This pulls abundance's proof-of-space into the farmer and makes it the default for anything newly plotted. It's just the CPU side of the wgpu plotter work - the GPU backend is on its own branch and I'll land the two together, so this one's a draft and shouldn't merge alone. Splitting it out lets the CPU part get reviewed separately.

The wrapper uses the seed and looks proofs up the way we already do (our s-bucket convention), so they verify under the existing `ChiaTable` verifier with a test to verify the same.

Old and new plots live side by side using a cutover point I store in the plot metadata header: anything at or below it still reads and proves with the old proof-of-space, anything newer uses the new one. New plotting waits until history moves past the cutover so no sector straddles it. A fresh farm has no cutover, so it's all new from the start.

Probably easiest to review commit by commit:
- `add abundance-backed proof of space` - the git dep, the `chia_v2` wrapper, and the Cargo wiring.
- `add farm cutover point with in-place v0 upgrade` - the header version enum, the cutover field, the version-aware decode and in-place upgrade, and the plotting pause.
- `dispatch proof-of-space per sector by history size` - the `PosTable` dispatch enum wired into read/prove/audit.
- `add tests and benches for the abundance proof of space` - cross-verify, a plot/read round-trip, the dispatch-selection tests, and the benches pointed at the new table. Kept last so you can skip it on a first pass.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
