### PR TITLE
Bump prometheus-client to 0.25 through libp2p

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -356,7 +356,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -367,7 +367,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1204,7 +1204,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 [[package]]
 name = "binary-merkle-tree"
 version = "16.1.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "hash-db",
  "log",
@@ -2403,7 +2403,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-parachain-inherent"
 version = "0.22.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2414,7 +2414,7 @@ dependencies = [
  "sc-client-api",
  "sc-consensus-babe",
  "sc-network-types",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610)",
  "sp-inherents",
  "sp-runtime",
  "sp-state-machine",
@@ -2425,7 +2425,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system"
 version = "0.25.1"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "array-bytes",
  "bytes",
@@ -2463,7 +2463,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system-proc-macro"
 version = "0.7.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
@@ -2474,7 +2474,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-core"
 version = "0.23.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "parity-scale-codec",
  "polkadot-core-primitives",
@@ -2491,7 +2491,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-parachain-inherent"
 version = "0.23.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2505,7 +2505,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-proof-size-hostfunction"
 version = "0.16.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "sp-externalities",
  "sp-runtime-interface",
@@ -2515,7 +2515,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-storage-weight-reclaim"
 version = "16.0.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-proof-size-hostfunction",
@@ -2532,7 +2532,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-interface"
 version = "0.28.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2552,7 +2552,7 @@ dependencies = [
 [[package]]
 name = "cumulus-test-relay-sproof-builder"
 version = "0.24.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
@@ -2758,7 +2758,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3682,7 +3682,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4138,7 +4138,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610)",
 ]
 
 [[package]]
@@ -4282,7 +4282,7 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 [[package]]
 name = "fork-tree"
 version = "13.0.1"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -4409,7 +4409,7 @@ checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 [[package]]
 name = "frame-benchmarking"
 version = "45.0.3"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -4433,7 +4433,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "53.0.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "Inflector",
  "array-bytes",
@@ -4512,7 +4512,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-solution-type"
 version = "16.1.1"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
@@ -4523,7 +4523,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-support"
 version = "45.0.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "frame-election-provider-solution-type",
  "frame-support",
@@ -4540,7 +4540,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "45.0.1"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "aquamarine",
  "frame-support",
@@ -4570,7 +4570,7 @@ dependencies = [
 [[package]]
 name = "frame-storage-access-test-runtime"
 version = "0.6.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "parity-scale-codec",
@@ -4584,7 +4584,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "45.1.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "aquamarine",
  "array-bytes",
@@ -4625,7 +4625,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "36.0.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -4638,14 +4638,14 @@ dependencies = [
  "proc-macro-warning",
  "proc-macro2",
  "quote",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610)",
  "syn 2.0.117",
 ]
 
 [[package]]
 name = "frame-support-procedural-tools"
 version = "13.0.1"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate 3.5.0",
@@ -4657,7 +4657,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "12.0.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4667,7 +4667,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "45.0.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "cfg-if",
  "docify",
@@ -4686,7 +4686,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "45.0.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4700,7 +4700,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "40.0.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "docify",
  "parity-scale-codec",
@@ -4710,7 +4710,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.51.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -5955,7 +5955,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6442,7 +6442,7 @@ dependencies = [
 [[package]]
 name = "libp2p"
 version = "0.57.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
+source = "git+https://github.com/autonomys/rust-libp2p?rev=5be7c854f715da73189a7e7847428bb2af71ccc3#5be7c854f715da73189a7e7847428bb2af71ccc3"
 dependencies = [
  "bytes",
  "either",
@@ -6479,7 +6479,7 @@ dependencies = [
 [[package]]
 name = "libp2p-allow-block-list"
 version = "0.7.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
+source = "git+https://github.com/autonomys/rust-libp2p?rev=5be7c854f715da73189a7e7847428bb2af71ccc3#5be7c854f715da73189a7e7847428bb2af71ccc3"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
@@ -6489,7 +6489,7 @@ dependencies = [
 [[package]]
 name = "libp2p-autonat"
 version = "0.16.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
+source = "git+https://github.com/autonomys/rust-libp2p?rev=5be7c854f715da73189a7e7847428bb2af71ccc3#5be7c854f715da73189a7e7847428bb2af71ccc3"
 dependencies = [
  "asynchronous-codec 0.7.0",
  "either",
@@ -6512,7 +6512,7 @@ dependencies = [
 [[package]]
 name = "libp2p-connection-limits"
 version = "0.7.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
+source = "git+https://github.com/autonomys/rust-libp2p?rev=5be7c854f715da73189a7e7847428bb2af71ccc3#5be7c854f715da73189a7e7847428bb2af71ccc3"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
@@ -6522,7 +6522,7 @@ dependencies = [
 [[package]]
 name = "libp2p-core"
 version = "0.44.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
+source = "git+https://github.com/autonomys/rust-libp2p?rev=5be7c854f715da73189a7e7847428bb2af71ccc3#5be7c854f715da73189a7e7847428bb2af71ccc3"
 dependencies = [
  "either",
  "fnv",
@@ -6546,7 +6546,7 @@ dependencies = [
 [[package]]
 name = "libp2p-dns"
 version = "0.45.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
+source = "git+https://github.com/autonomys/rust-libp2p?rev=5be7c854f715da73189a7e7847428bb2af71ccc3#5be7c854f715da73189a7e7847428bb2af71ccc3"
 dependencies = [
  "futures",
  "hickory-resolver 0.26.1",
@@ -6560,7 +6560,7 @@ dependencies = [
 [[package]]
 name = "libp2p-gossipsub"
 version = "0.50.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
+source = "git+https://github.com/autonomys/rust-libp2p?rev=5be7c854f715da73189a7e7847428bb2af71ccc3#5be7c854f715da73189a7e7847428bb2af71ccc3"
 dependencies = [
  "async-channel 2.5.0",
  "asynchronous-codec 0.7.0",
@@ -6591,7 +6591,7 @@ dependencies = [
 [[package]]
 name = "libp2p-identify"
 version = "0.48.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
+source = "git+https://github.com/autonomys/rust-libp2p?rev=5be7c854f715da73189a7e7847428bb2af71ccc3#5be7c854f715da73189a7e7847428bb2af71ccc3"
 dependencies = [
  "asynchronous-codec 0.7.0",
  "either",
@@ -6611,7 +6611,7 @@ dependencies = [
 [[package]]
 name = "libp2p-identity"
 version = "0.2.14"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
+source = "git+https://github.com/autonomys/rust-libp2p?rev=5be7c854f715da73189a7e7847428bb2af71ccc3#5be7c854f715da73189a7e7847428bb2af71ccc3"
 dependencies = [
  "bs58",
  "ed25519-dalek",
@@ -6629,7 +6629,7 @@ dependencies = [
 [[package]]
 name = "libp2p-kad"
 version = "0.49.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
+source = "git+https://github.com/autonomys/rust-libp2p?rev=5be7c854f715da73189a7e7847428bb2af71ccc3#5be7c854f715da73189a7e7847428bb2af71ccc3"
 dependencies = [
  "asynchronous-codec 0.7.0",
  "bytes",
@@ -6656,7 +6656,7 @@ dependencies = [
 [[package]]
 name = "libp2p-mdns"
 version = "0.49.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
+source = "git+https://github.com/autonomys/rust-libp2p?rev=5be7c854f715da73189a7e7847428bb2af71ccc3#5be7c854f715da73189a7e7847428bb2af71ccc3"
 dependencies = [
  "futures",
  "hickory-proto 0.26.1",
@@ -6674,7 +6674,7 @@ dependencies = [
 [[package]]
 name = "libp2p-metrics"
 version = "0.18.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
+source = "git+https://github.com/autonomys/rust-libp2p?rev=5be7c854f715da73189a7e7847428bb2af71ccc3#5be7c854f715da73189a7e7847428bb2af71ccc3"
 dependencies = [
  "futures",
  "libp2p-core",
@@ -6692,7 +6692,7 @@ dependencies = [
 [[package]]
 name = "libp2p-noise"
 version = "0.47.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
+source = "git+https://github.com/autonomys/rust-libp2p?rev=5be7c854f715da73189a7e7847428bb2af71ccc3#5be7c854f715da73189a7e7847428bb2af71ccc3"
 dependencies = [
  "asynchronous-codec 0.7.0",
  "bytes",
@@ -6714,7 +6714,7 @@ dependencies = [
 [[package]]
 name = "libp2p-ping"
 version = "0.48.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
+source = "git+https://github.com/autonomys/rust-libp2p?rev=5be7c854f715da73189a7e7847428bb2af71ccc3#5be7c854f715da73189a7e7847428bb2af71ccc3"
 dependencies = [
  "futures",
  "futures-timer",
@@ -6729,7 +6729,7 @@ dependencies = [
 [[package]]
 name = "libp2p-plaintext"
 version = "0.44.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
+source = "git+https://github.com/autonomys/rust-libp2p?rev=5be7c854f715da73189a7e7847428bb2af71ccc3#5be7c854f715da73189a7e7847428bb2af71ccc3"
 dependencies = [
  "asynchronous-codec 0.7.0",
  "bytes",
@@ -6744,7 +6744,7 @@ dependencies = [
 [[package]]
 name = "libp2p-quic"
 version = "0.14.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
+source = "git+https://github.com/autonomys/rust-libp2p?rev=5be7c854f715da73189a7e7847428bb2af71ccc3#5be7c854f715da73189a7e7847428bb2af71ccc3"
 dependencies = [
  "futures",
  "futures-timer",
@@ -6765,7 +6765,7 @@ dependencies = [
 [[package]]
 name = "libp2p-request-response"
 version = "0.30.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
+source = "git+https://github.com/autonomys/rust-libp2p?rev=5be7c854f715da73189a7e7847428bb2af71ccc3#5be7c854f715da73189a7e7847428bb2af71ccc3"
 dependencies = [
  "futures",
  "futures-bounded",
@@ -6780,7 +6780,7 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm"
 version = "0.48.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
+source = "git+https://github.com/autonomys/rust-libp2p?rev=5be7c854f715da73189a7e7847428bb2af71ccc3#5be7c854f715da73189a7e7847428bb2af71ccc3"
 dependencies = [
  "either",
  "fnv",
@@ -6803,7 +6803,7 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm-derive"
 version = "0.36.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
+source = "git+https://github.com/autonomys/rust-libp2p?rev=5be7c854f715da73189a7e7847428bb2af71ccc3#5be7c854f715da73189a7e7847428bb2af71ccc3"
 dependencies = [
  "heck 0.5.0",
  "quote",
@@ -6813,7 +6813,7 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm-test"
 version = "0.7.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
+source = "git+https://github.com/autonomys/rust-libp2p?rev=5be7c854f715da73189a7e7847428bb2af71ccc3#5be7c854f715da73189a7e7847428bb2af71ccc3"
 dependencies = [
  "async-trait",
  "futures",
@@ -6830,7 +6830,7 @@ dependencies = [
 [[package]]
 name = "libp2p-tcp"
 version = "0.45.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
+source = "git+https://github.com/autonomys/rust-libp2p?rev=5be7c854f715da73189a7e7847428bb2af71ccc3#5be7c854f715da73189a7e7847428bb2af71ccc3"
 dependencies = [
  "futures",
  "futures-timer",
@@ -6845,7 +6845,7 @@ dependencies = [
 [[package]]
 name = "libp2p-tls"
 version = "0.7.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
+source = "git+https://github.com/autonomys/rust-libp2p?rev=5be7c854f715da73189a7e7847428bb2af71ccc3#5be7c854f715da73189a7e7847428bb2af71ccc3"
 dependencies = [
  "futures",
  "futures-rustls",
@@ -6863,7 +6863,7 @@ dependencies = [
 [[package]]
 name = "libp2p-upnp"
 version = "0.7.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
+source = "git+https://github.com/autonomys/rust-libp2p?rev=5be7c854f715da73189a7e7847428bb2af71ccc3#5be7c854f715da73189a7e7847428bb2af71ccc3"
 dependencies = [
  "futures",
  "futures-timer",
@@ -6877,7 +6877,7 @@ dependencies = [
 [[package]]
 name = "libp2p-websocket"
 version = "0.46.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
+source = "git+https://github.com/autonomys/rust-libp2p?rev=5be7c854f715da73189a7e7847428bb2af71ccc3#5be7c854f715da73189a7e7847428bb2af71ccc3"
 dependencies = [
  "either",
  "futures",
@@ -6897,7 +6897,7 @@ dependencies = [
 [[package]]
 name = "libp2p-yamux"
 version = "0.48.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
+source = "git+https://github.com/autonomys/rust-libp2p?rev=5be7c854f715da73189a7e7847428bb2af71ccc3#5be7c854f715da73189a7e7847428bb2af71ccc3"
 dependencies = [
  "either",
  "futures",
@@ -7359,7 +7359,7 @@ dependencies = [
 [[package]]
 name = "mmr-gadget"
 version = "50.0.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "futures",
  "log",
@@ -7378,7 +7378,7 @@ dependencies = [
 [[package]]
 name = "mmr-rpc"
 version = "44.0.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -7538,7 +7538,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 [[package]]
 name = "multistream-select"
 version = "0.14.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
+source = "git+https://github.com/autonomys/rust-libp2p?rev=5be7c854f715da73189a7e7847428bb2af71ccc3#5be7c854f715da73189a7e7847428bb2af71ccc3"
 dependencies = [
  "bytes",
  "futures",
@@ -7735,7 +7735,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8015,7 +8015,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-conversion"
 version = "27.0.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8033,7 +8033,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "45.0.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8048,7 +8048,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "45.0.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8081,7 +8081,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "45.0.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8104,7 +8104,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "46.0.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8136,7 +8136,7 @@ dependencies = [
 [[package]]
 name = "pallet-broker"
 version = "0.24.1"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -8154,7 +8154,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "45.0.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8171,7 +8171,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "45.0.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8368,7 +8368,7 @@ dependencies = [
 [[package]]
 name = "pallet-message-queue"
 version = "48.0.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -8411,7 +8411,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr"
 version = "45.0.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -8423,7 +8423,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "45.0.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -8434,7 +8434,7 @@ dependencies = [
 [[package]]
 name = "pallet-preimage"
 version = "45.0.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8483,7 +8483,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "46.0.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8500,7 +8500,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "45.2.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8522,7 +8522,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "45.1.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -8603,7 +8603,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "45.0.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8618,7 +8618,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "44.0.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8647,7 +8647,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "45.0.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8663,7 +8663,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "48.0.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -8679,7 +8679,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "45.0.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -8712,7 +8712,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "45.0.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9072,7 +9072,7 @@ dependencies = [
 [[package]]
 name = "polkadot-core-primitives"
 version = "21.0.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9083,7 +9083,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-metrics"
 version = "28.0.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "bs58",
  "futures",
@@ -9100,7 +9100,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-network-protocol"
 version = "28.0.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -9125,7 +9125,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-primitives"
 version = "23.0.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "bitvec",
  "bounded-vec",
@@ -9149,7 +9149,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-types"
 version = "28.0.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "async-trait",
  "derive_more 0.99.20",
@@ -9177,7 +9177,7 @@ dependencies = [
 [[package]]
 name = "polkadot-overseer"
 version = "28.0.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "async-trait",
  "futures",
@@ -9197,7 +9197,7 @@ dependencies = [
 [[package]]
 name = "polkadot-parachain-primitives"
 version = "20.0.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "array-bytes",
  "bounded-collections",
@@ -9214,7 +9214,7 @@ dependencies = [
 [[package]]
 name = "polkadot-primitives"
 version = "22.0.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "bitvec",
  "bounded-collections",
@@ -9243,7 +9243,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-metrics"
 version = "25.0.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "bs58",
  "frame-benchmarking",
@@ -9255,7 +9255,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-parachains"
 version = "24.0.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "bitflags 1.3.2",
  "bitvec",
@@ -9303,7 +9303,7 @@ dependencies = [
 [[package]]
 name = "polkadot-sdk-frame"
 version = "0.14.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9338,7 +9338,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-table"
 version = "23.0.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
@@ -9554,7 +9554,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610)",
  "syn 2.0.117",
 ]
 
@@ -9750,9 +9750,9 @@ dependencies = [
 
 [[package]]
 name = "prometheus-client"
-version = "0.24.1"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cca3d75b4566b9a29fe1ed623587fb058e826eb329a0be4b7c4da1ebb2d7a6ca"
+checksum = "ba70bf887030e45213b4a95c9b08d5a450b157f87c1d63661ed0847a12fa2aad"
 dependencies = [
  "dtoa",
  "itoa",
@@ -9835,7 +9835,7 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -9855,7 +9855,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -9871,7 +9871,7 @@ dependencies = [
 [[package]]
 name = "prost-codec"
 version = "0.4.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
+source = "git+https://github.com/autonomys/rust-libp2p?rev=5be7c854f715da73189a7e7847428bb2af71ccc3#5be7c854f715da73189a7e7847428bb2af71ccc3"
 dependencies = [
  "asynchronous-codec 0.7.0",
  "bytes",
@@ -10569,7 +10569,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10674,7 +10674,7 @@ checksum = "e5ff0cc5e135c8870a775d3320910cd9b564ec036b4dc0b8741629020be63f01"
 [[package]]
 name = "rw-stream-sink"
 version = "0.5.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=676c687c2f7a6e92f8f4f77a6934022aec3ba16c#676c687c2f7a6e92f8f4f77a6934022aec3ba16c"
+source = "git+https://github.com/autonomys/rust-libp2p?rev=5be7c854f715da73189a7e7847428bb2af71ccc3#5be7c854f715da73189a7e7847428bb2af71ccc3"
 dependencies = [
  "futures",
  "pin-project",
@@ -10717,7 +10717,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "35.0.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "log",
  "sp-core",
@@ -10728,7 +10728,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.55.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "async-trait",
  "futures",
@@ -10760,7 +10760,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.53.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "futures",
  "log",
@@ -10782,7 +10782,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.48.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -10797,7 +10797,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "48.0.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "array-bytes",
  "docify",
@@ -10812,7 +10812,7 @@ dependencies = [
  "serde_json",
  "sp-blockchain",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610)",
  "sp-genesis-builder",
  "sp-io",
  "sp-runtime",
@@ -10823,7 +10823,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "12.0.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
@@ -10834,7 +10834,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.57.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "array-bytes",
  "bip39",
@@ -10876,7 +10876,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "44.0.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "fnv",
  "futures",
@@ -10902,7 +10902,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.51.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -10929,7 +10929,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.54.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "async-trait",
  "futures",
@@ -10952,7 +10952,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.55.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -10977,7 +10977,7 @@ dependencies = [
  "sp-consensus-babe",
  "sp-consensus-slots",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610)",
  "sp-inherents",
  "sp-keystore",
  "sp-runtime",
@@ -10989,7 +10989,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.54.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -11002,7 +11002,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.54.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "async-trait",
  "futures",
@@ -11132,7 +11132,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.47.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.5",
@@ -11155,7 +11155,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.43.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "polkavm",
  "sc-allocator",
@@ -11168,7 +11168,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-polkavm"
 version = "0.40.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "log",
  "polkavm",
@@ -11179,7 +11179,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.43.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "anyhow",
  "log",
@@ -11195,7 +11195,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.54.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "console",
  "futures",
@@ -11211,7 +11211,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "39.0.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "array-bytes",
  "parking_lot 0.12.5",
@@ -11225,7 +11225,7 @@ dependencies = [
 [[package]]
 name = "sc-mixnet"
 version = "0.25.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "array-bytes",
  "arrayvec 0.7.6",
@@ -11253,7 +11253,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.55.2"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -11302,7 +11302,7 @@ dependencies = [
 [[package]]
 name = "sc-network-common"
 version = "0.52.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "bitflags 1.3.2",
  "parity-scale-codec",
@@ -11312,7 +11312,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.55.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "ahash 0.8.12",
  "futures",
@@ -11331,7 +11331,7 @@ dependencies = [
 [[package]]
 name = "sc-network-light"
 version = "0.54.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -11352,7 +11352,7 @@ dependencies = [
 [[package]]
 name = "sc-network-sync"
 version = "0.54.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -11387,7 +11387,7 @@ dependencies = [
 [[package]]
 name = "sc-network-transactions"
 version = "0.54.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "array-bytes",
  "futures",
@@ -11406,7 +11406,7 @@ dependencies = [
 [[package]]
 name = "sc-network-types"
 version = "0.20.2"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "bs58",
  "bytes",
@@ -11427,7 +11427,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "50.0.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "bytes",
  "fnv",
@@ -11490,7 +11490,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.20.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -11499,7 +11499,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "50.0.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -11531,7 +11531,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.54.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -11551,7 +11551,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "27.0.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "dyn-clone",
  "forwarded-header-value",
@@ -11575,7 +11575,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-spec-v2"
 version = "0.55.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "array-bytes",
  "futures",
@@ -11608,13 +11608,13 @@ dependencies = [
 [[package]]
 name = "sc-runtime-utilities"
 version = "0.7.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "parity-scale-codec",
  "sc-executor",
  "sc-executor-common",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610)",
  "sp-state-machine",
  "sp-wasm-interface",
  "thiserror 1.0.69",
@@ -11623,7 +11623,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.56.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "async-trait",
  "directories",
@@ -11687,7 +11687,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.41.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -11698,7 +11698,7 @@ dependencies = [
 [[package]]
 name = "sc-storage-monitor"
 version = "0.27.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "clap",
  "fs4 0.7.0",
@@ -11756,7 +11756,7 @@ dependencies = [
 [[package]]
 name = "sc-sysinfo"
 version = "46.0.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "derive_more 0.99.20",
  "futures",
@@ -11769,14 +11769,14 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610)",
  "sp-io",
 ]
 
 [[package]]
 name = "sc-telemetry"
 version = "30.0.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "chrono",
  "futures",
@@ -11795,7 +11795,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "44.0.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "chrono",
  "console",
@@ -11823,7 +11823,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "11.1.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
@@ -11834,7 +11834,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "44.1.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "async-trait",
  "futures",
@@ -11851,7 +11851,7 @@ dependencies = [
  "sp-api",
  "sp-blockchain",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610)",
  "sp-runtime",
  "sp-tracing",
  "sp-transaction-pool",
@@ -11866,7 +11866,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "43.0.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "async-trait",
  "futures",
@@ -11884,7 +11884,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "20.0.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "async-channel 1.9.0",
  "futures",
@@ -12731,7 +12731,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12753,7 +12753,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "40.0.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "docify",
  "hash-db",
@@ -12775,7 +12775,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "26.0.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "Inflector",
  "blake2 0.10.6",
@@ -12789,7 +12789,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "44.0.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12801,7 +12801,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "28.0.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "docify",
  "integer-sqrt",
@@ -12815,7 +12815,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "40.0.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12840,7 +12840,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "40.0.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "sp-api",
  "sp-inherents",
@@ -12861,7 +12861,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "43.0.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -12880,7 +12880,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.46.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "async-trait",
  "futures",
@@ -12894,7 +12894,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.46.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -12910,7 +12910,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.46.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -12928,7 +12928,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-beefy"
 version = "28.0.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12936,7 +12936,7 @@ dependencies = [
  "sp-api",
  "sp-application-crypto",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610)",
  "sp-io",
  "sp-keystore",
  "sp-mmr-primitives",
@@ -12948,7 +12948,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-grandpa"
 version = "27.0.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -12965,7 +12965,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.46.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -13004,7 +13004,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "39.0.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "ark-vrf",
  "array-bytes",
@@ -13035,7 +13035,7 @@ dependencies = [
  "secrecy 0.8.0",
  "serde",
  "sha2 0.10.9",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610)",
  "sp-debug-derive",
  "sp-externalities",
  "sp-std",
@@ -13065,7 +13065,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing"
 version = "0.1.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -13078,17 +13078,17 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "quote",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610)",
  "syn 2.0.117",
 ]
 
 [[package]]
 name = "sp-database"
 version = "10.0.1"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.5",
@@ -13097,7 +13097,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "14.0.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -13250,7 +13250,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.31.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -13260,7 +13260,7 @@ dependencies = [
 [[package]]
 name = "sp-genesis-builder"
 version = "0.21.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -13272,7 +13272,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "40.0.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -13285,7 +13285,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "44.0.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "bytes",
  "docify",
@@ -13297,7 +13297,7 @@ dependencies = [
  "rustversion",
  "secp256k1 0.28.2",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610)",
  "sp-externalities",
  "sp-keystore",
  "sp-runtime-interface",
@@ -13311,7 +13311,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "45.0.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "sp-core",
  "sp-runtime",
@@ -13321,7 +13321,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.45.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.5",
@@ -13332,7 +13332,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "11.1.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "thiserror 1.0.69",
  "zstd 0.12.4",
@@ -13380,7 +13380,7 @@ dependencies = [
 [[package]]
 name = "sp-metadata-ir"
 version = "0.12.1"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "frame-metadata",
  "parity-scale-codec",
@@ -13390,7 +13390,7 @@ dependencies = [
 [[package]]
 name = "sp-mixnet"
 version = "0.18.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -13401,7 +13401,7 @@ dependencies = [
 [[package]]
 name = "sp-mmr-primitives"
 version = "40.0.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -13418,7 +13418,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "40.0.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -13439,7 +13439,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "40.0.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -13449,7 +13449,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "13.0.2"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "backtrace",
  "regex",
@@ -13458,7 +13458,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "37.0.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "rustc-hash 1.1.0",
  "serde",
@@ -13468,7 +13468,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "45.0.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "binary-merkle-tree",
  "bytes",
@@ -13499,7 +13499,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "33.0.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -13517,7 +13517,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "20.0.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "Inflector",
  "expander",
@@ -13530,7 +13530,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "42.0.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -13544,7 +13544,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "42.2.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -13557,7 +13557,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.49.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "hash-db",
  "log",
@@ -13577,7 +13577,7 @@ dependencies = [
 [[package]]
 name = "sp-statement-store"
 version = "24.0.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "aes-gcm",
  "curve25519-dalek",
@@ -13590,7 +13590,7 @@ dependencies = [
  "sp-api",
  "sp-application-crypto",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610)",
  "sp-externalities",
  "sp-runtime",
  "sp-runtime-interface",
@@ -13601,12 +13601,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "14.0.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 
 [[package]]
 name = "sp-storage"
 version = "22.0.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -13636,7 +13636,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "40.0.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -13648,7 +13648,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "19.0.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "parity-scale-codec",
  "regex",
@@ -13660,7 +13660,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "40.0.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -13669,7 +13669,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "40.1.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -13684,7 +13684,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "42.0.1"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "ahash 0.8.12",
  "foldhash 0.1.5",
@@ -13709,7 +13709,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "43.0.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -13726,7 +13726,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "15.0.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "parity-scale-codec",
  "proc-macro-warning",
@@ -13738,7 +13738,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "24.0.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -13750,7 +13750,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "33.2.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "bounded-collections",
  "parity-scale-codec",
@@ -13828,7 +13828,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 [[package]]
 name = "staging-xcm"
 version = "21.0.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "array-bytes",
  "bounded-collections",
@@ -13849,7 +13849,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-builder"
 version = "25.0.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "environmental",
  "frame-support",
@@ -13873,7 +13873,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-executor"
 version = "24.0.1"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -14896,12 +14896,12 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "11.0.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "49.0.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "docify",
  "frame-system-rpc-runtime-api",
@@ -14921,7 +14921,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.17.7"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "http-body-util",
  "hyper",
@@ -14935,7 +14935,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-client"
 version = "2.0.1"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "array-bytes",
  "async-trait",
@@ -14960,7 +14960,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "31.1.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "build-helper",
  "cargo_metadata",
@@ -15323,7 +15323,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -15342,7 +15342,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -15828,7 +15828,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum"
 version = "23.0.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "coarsetime",
  "polkadot-primitives",
@@ -15839,7 +15839,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "expander",
  "proc-macro-crate 3.5.0",
@@ -16904,7 +16904,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -17551,7 +17551,7 @@ dependencies = [
 [[package]]
 name = "xcm-procedural"
 version = "11.0.2"
-source = "git+https://github.com/autonomys/polkadot-sdk?rev=8304f8852018c9b2d69071449e988d6e63e4122c#8304f8852018c9b2d69071449e988d6e63e4122c"
+source = "git+https://github.com/autonomys/polkadot-sdk?rev=962a09e060d0d07dacadca5cd3a2864fb456d610#962a09e060d0d07dacadca5cd3a2864fb456d610"
 dependencies = [
  "Inflector",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ core_affinity = "0.8.1"
 cpufeatures = "0.3.0"
 criterion = { version = "0.8.2", default-features = false }
 cross-domain-message-gossip = { version = "0.1.0", path = "domains/client/cross-domain-message-gossip" }
-cumulus-primitives-proof-size-hostfunction = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
+cumulus-primitives-proof-size-hostfunction = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610", default-features = false }
 derive_more = { version = "2.1.1", default-features = false }
 domain-block-builder = { version = "0.1.0", path = "domains/client/block-builder", default-features = false }
 domain-block-preprocessor = { version = "0.1.0", path = "domains/client/block-preprocessor", default-features = false }
@@ -90,13 +90,13 @@ fp-account = { version = "1.0.0-dev", git = "https://github.com/polkadot-evm/fro
 fp-evm = { version = "3.0.0-dev", git = "https://github.com/polkadot-evm/frontier", rev = "9d49e36ed5bac38241594f8ba055fdb94991483a", default-features = false }
 fp-rpc = { version = "3.0.0-dev", git = "https://github.com/polkadot-evm/frontier", rev = "9d49e36ed5bac38241594f8ba055fdb94991483a", default-features = false }
 fp-self-contained = { version = "1.0.0-dev", git = "https://github.com/polkadot-evm/frontier", rev = "9d49e36ed5bac38241594f8ba055fdb94991483a", default-features = false }
-frame-benchmarking = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
-frame-benchmarking-cli = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
-frame-executive = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
-frame-support = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
-frame-system = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
-frame-system-benchmarking = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
-frame-system-rpc-runtime-api = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
+frame-benchmarking = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610", default-features = false }
+frame-benchmarking-cli = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610", default-features = false }
+frame-executive = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610", default-features = false }
+frame-support = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610", default-features = false }
+frame-system = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610", default-features = false }
+frame-system-benchmarking = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610", default-features = false }
+frame-system-rpc-runtime-api = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610", default-features = false }
 fs2 = "0.4.3"
 fs4 = "1.1.0"
 futures = "0.3.31"
@@ -108,15 +108,15 @@ hwlocality = "1.0.0-alpha.12"
 jsonrpsee = "0.24.10"
 kzg = { git = "https://github.com/grandinetech/rust-kzg", rev = "8f5f1a0f73b3c529c77cb880ff8d265830c7d7ac", default-features = false }
 libc = "0.2.186"
-libp2p = { version = "0.57.0", git = "https://github.com/autonomys/rust-libp2p", rev = "676c687c2f7a6e92f8f4f77a6934022aec3ba16c", default-features = false }
-libp2p-swarm-test = { version = "0.7.0", git = "https://github.com/autonomys/rust-libp2p", rev = "676c687c2f7a6e92f8f4f77a6934022aec3ba16c" }
+libp2p = { version = "0.57.0", git = "https://github.com/autonomys/rust-libp2p", rev = "5be7c854f715da73189a7e7847428bb2af71ccc3", default-features = false }
+libp2p-swarm-test = { version = "0.7.0", git = "https://github.com/autonomys/rust-libp2p", rev = "5be7c854f715da73189a7e7847428bb2af71ccc3" }
 libsecp256k1 = "0.7.1"
 log = { version = "0.4.22", default-features = false }
 memmap2 = "0.9.5"
 memory-db = { version = "0.34.0", default-features = false }
 mimalloc = "0.1.50"
-mmr-gadget = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
-mmr-rpc = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
+mmr-gadget = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610" }
+mmr-rpc = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610" }
 multihash = "0.19.5"
 nohash-hasher = "0.2.0"
 num-traits = { version = "0.2.18", default-features = false }
@@ -124,10 +124,10 @@ num_cpus = "1.16.0"
 num_enum = { version = "0.7.6", default-features = false }
 ouroboros = "0.18.4"
 pallet-auto-id = { version = "0.1.0", path = "domains/pallets/auto-id", default-features = false }
-pallet-balances = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
+pallet-balances = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610", default-features = false }
 pallet-block-fees = { version = "0.1.0", path = "domains/pallets/block-fees", default-features = false }
-pallet-collective = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
-pallet-democracy = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
+pallet-collective = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610", default-features = false }
+pallet-democracy = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610", default-features = false }
 pallet-domain-id = { version = "0.1.0", path = "domains/pallets/domain-id", default-features = false }
 pallet-domain-sudo = { version = "0.1.0", path = "domains/pallets/domain-sudo", default-features = false }
 pallet-domains = { version = "0.1.0", path = "crates/pallet-domains", default-features = false }
@@ -139,30 +139,30 @@ pallet-evm-precompile-sha3fips = { version = "2.0.0-dev", git = "https://github.
 pallet-evm-precompile-simple = { version = "2.0.0-dev", git = "https://github.com/polkadot-evm/frontier", rev = "9d49e36ed5bac38241594f8ba055fdb94991483a", default-features = false }
 pallet-evm-tracker = { version = "0.1.0", path = "domains/pallets/evm-tracker", default-features = false }
 pallet-messenger = { version = "0.1.0", path = "domains/pallets/messenger", default-features = false }
-pallet-mmr = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
-pallet-multisig = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
-pallet-preimage = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
+pallet-mmr = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610", default-features = false }
+pallet-multisig = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610", default-features = false }
+pallet-preimage = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610", default-features = false }
 pallet-rewards = { version = "0.1.0", path = "crates/pallet-rewards", default-features = false }
 pallet-runtime-configs = { version = "0.1.0", path = "crates/pallet-runtime-configs", default-features = false }
-pallet-scheduler = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
+pallet-scheduler = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610", default-features = false }
 pallet-storage-overlay-checks = { version = "0.1.0", path = "domains/test/pallets/storage_overlay_checks", default-features = false }
 pallet-subspace = { version = "0.1.0", path = "crates/pallet-subspace", default-features = false }
 pallet-subspace-mmr = { version = "0.1.0", path = "crates/pallet-subspace-mmr", default-features = false }
-pallet-sudo = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
-pallet-timestamp = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
+pallet-sudo = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610", default-features = false }
+pallet-timestamp = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610", default-features = false }
 pallet-transaction-fees = { version = "0.1.0", path = "crates/pallet-transaction-fees", default-features = false }
-pallet-transaction-payment = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
-pallet-transaction-payment-rpc = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
-pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
+pallet-transaction-payment = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610", default-features = false }
+pallet-transaction-payment-rpc = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610" }
+pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610", default-features = false }
 pallet-transporter = { version = "0.1.0", path = "domains/pallets/transporter", default-features = false }
-pallet-utility = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
+pallet-utility = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610", default-features = false }
 parity-scale-codec = { version = "3.7.5", default-features = false }
 parking_lot = "0.12.2"
 pem = "3.0.4"
 pin-project = "1.1.13"
 precompile-utils = { version = "0.1.0", git = "https://github.com/polkadot-evm/frontier", rev = "9d49e36ed5bac38241594f8ba055fdb94991483a", default-features = false }
 prometheus = { version = "0.13.4", default-features = false }
-prometheus-client = "0.24.1"
+prometheus-client = "0.25.0"
 prop-test = "0.1.1"
 rand = { version = "0.8.5", default-features = false }
 rand_chacha = { version = "0.3.1", default-features = false }
@@ -173,42 +173,42 @@ ring = "0.17.8"
 rlp = "0.6"
 rs_merkle = { version = "1.4.2", default-features = false }
 rust-kzg-blst = { git = "https://github.com/grandinetech/rust-kzg", rev = "8f5f1a0f73b3c529c77cb880ff8d265830c7d7ac", default-features = false }
-sc-basic-authorship = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
-sc-block-builder = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
-sc-chain-spec = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
-sc-cli = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
-sc-client-api = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
-sc-client-db = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
-sc-consensus = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
-sc-consensus-slots = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
+sc-basic-authorship = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610" }
+sc-block-builder = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610" }
+sc-chain-spec = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610" }
+sc-cli = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610", default-features = false }
+sc-client-api = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610" }
+sc-client-db = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610" }
+sc-consensus = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610" }
+sc-consensus-slots = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610" }
 sc-consensus-subspace = { version = "0.1.0", path = "crates/sc-consensus-subspace" }
 sc-consensus-subspace-rpc = { version = "0.1.0", path = "crates/sc-consensus-subspace-rpc" }
 sc-domains = { version = "0.1.0", path = "crates/sc-domains" }
-sc-executor = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
-sc-informant = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
-sc-keystore = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
-sc-network = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
-sc-network-common = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
-sc-network-gossip = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
-sc-network-sync = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
-sc-network-transactions = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
-sc-offchain = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
+sc-executor = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610", default-features = false }
+sc-informant = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610" }
+sc-keystore = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610" }
+sc-network = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610" }
+sc-network-common = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610" }
+sc-network-gossip = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610" }
+sc-network-sync = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610", default-features = false }
+sc-network-transactions = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610" }
+sc-offchain = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610" }
 sc-proof-of-time = { version = "0.1.0", path = "crates/sc-proof-of-time" }
-sc-rpc = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
-sc-rpc-api = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
-sc-rpc-server = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
-sc-service = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
-sc-state-db = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
-sc-storage-monitor = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
+sc-rpc = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610" }
+sc-rpc-api = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610" }
+sc-rpc-server = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610" }
+sc-service = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610", default-features = false }
+sc-state-db = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610" }
+sc-storage-monitor = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610", default-features = false }
 sc-subspace-block-relay = { version = "0.1.0", path = "crates/sc-subspace-block-relay" }
 sc-subspace-chain-specs = { version = "0.1.0", path = "crates/sc-subspace-chain-specs" }
 sc-subspace-sync-common = { version = "0.1.0", path = "shared/sc-subspace-sync-common", default-features = false }
-sc-sysinfo = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
-sc-telemetry = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
-sc-tracing = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
-sc-transaction-pool = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
-sc-transaction-pool-api = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
-sc-utils = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
+sc-sysinfo = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610", default-features = false }
+sc-telemetry = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610" }
+sc-tracing = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610" }
+sc-transaction-pool = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610" }
+sc-transaction-pool-api = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610" }
+sc-utils = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610" }
 scale-info = { version = "2.11.6", default-features = false }
 schnellru = "0.2.4"
 schnorrkel = { version = "0.11.4", default-features = false }
@@ -217,48 +217,48 @@ serde = { version = "1.0.216", default-features = false }
 serde-big-array = "0.5.1"
 serde_json = "1.0.133"
 sha2 = { version = "0.11.0", default-features = false }
-sp-api = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
-sp-application-crypto = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
-sp-arithmetic = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
+sp-api = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610", default-features = false }
+sp-application-crypto = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610", default-features = false }
+sp-arithmetic = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610", default-features = false }
 sp-auto-id = { version = "0.1.0", path = "domains/primitives/auto-id", default-features = false }
-sp-block-builder = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
+sp-block-builder = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610", default-features = false }
 sp-block-fees = { version = "0.1.0", path = "domains/primitives/block-fees", default-features = false }
-sp-blockchain = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
-sp-consensus = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
-sp-consensus-slots = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
+sp-blockchain = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610", default-features = false }
+sp-consensus = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610" }
+sp-consensus-slots = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610", default-features = false }
 sp-consensus-subspace = { version = "0.1.0", path = "crates/sp-consensus-subspace", default-features = false }
-sp-core = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
+sp-core = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610", default-features = false }
 sp-domain-digests = { version = "0.1.0", path = "domains/primitives/digests", default-features = false }
 sp-domain-sudo = { version = "0.1.0", path = "domains/primitives/domain-sudo", default-features = false }
 sp-domains = { version = "0.1.0", path = "crates/sp-domains", default-features = false }
 sp-domains-fraud-proof = { version = "0.1.0", path = "crates/sp-domains-fraud-proof", default-features = false }
 sp-evm-tracker = { version = "0.1.0", path = "domains/primitives/evm-tracker", default-features = false }
 sp-executive = { version = "0.1.0", path = "domains/primitives/executive", default-features = false }
-sp-externalities = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
+sp-externalities = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610", default-features = false }
 sp-evm-precompiles = { version = "0.1.0", path = "domains/primitives/evm-precompiles", default-features = false }
-sp-genesis-builder = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
-sp-inherents = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
-sp-io = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
-sp-keyring = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
-sp-keystore = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
+sp-genesis-builder = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610", default-features = false }
+sp-inherents = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610", default-features = false }
+sp-io = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610", default-features = false }
+sp-keyring = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610" }
+sp-keystore = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610" }
 sp-messenger = { version = "0.1.0", path = "domains/primitives/messenger", default-features = false }
 sp-messenger-host-functions = { version = "0.1.0", path = "domains/primitives/messenger-host-functions", default-features = false }
-sp-mmr-primitives = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
+sp-mmr-primitives = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610", default-features = false }
 sp-objects = { version = "0.1.0", path = "crates/sp-objects", default-features = false }
-sp-offchain = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
-sp-runtime = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
-sp-runtime-interface = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
-sp-session = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
-sp-state-machine = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
-sp-std = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
-sp-storage = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
+sp-offchain = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610", default-features = false }
+sp-runtime = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610", default-features = false }
+sp-runtime-interface = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610", default-features = false }
+sp-session = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610", default-features = false }
+sp-state-machine = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610", default-features = false }
+sp-std = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610", default-features = false }
+sp-storage = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610", default-features = false }
 sp-subspace-mmr = { version = "0.1.0", path = "crates/sp-subspace-mmr", default-features = false }
-sp-timestamp = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
-sp-tracing = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
-sp-transaction-pool = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
-sp-trie = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
-sp-version = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
-sp-weights = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
+sp-timestamp = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610", default-features = false }
+sp-tracing = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610", default-features = false }
+sp-transaction-pool = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610", default-features = false }
+sp-trie = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610", default-features = false }
+sp-version = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610", default-features = false }
+sp-weights = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610", default-features = false }
 spin = "0.12.0"
 sppark = { version = "0.1.8", git = "https://github.com/autonomys/sppark", rev = "b2a181eb99c8200f1a604f04122551ea39fbf63f" }
 ss58-registry = "1.51.0"
@@ -287,11 +287,11 @@ subspace-test-runtime = { version = "0.1.0", path = "test/subspace-test-runtime"
 subspace-test-service = { version = "0.1.0", path = "test/subspace-test-service" }
 subspace-verification = { version = "0.1.0", path = "crates/subspace-verification", default-features = false }
 substrate-bip39 = "=0.6.0"
-substrate-build-script-utils = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
-substrate-frame-rpc-system = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
-substrate-prometheus-endpoint = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
-substrate-test-client = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
-substrate-wasm-builder = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
+substrate-build-script-utils = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610" }
+substrate-frame-rpc-system = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610" }
+substrate-prometheus-endpoint = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610" }
+substrate-test-client = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610" }
+substrate-wasm-builder = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610" }
 supports-color = "3.0.1"
 tempfile = "3.13.0"
 thiserror = { version = "2.0.0", default-features = false }
@@ -390,51 +390,51 @@ lto = "fat"
 # Reason: We need to patch substrate dependency of frontier to our fork
 # TODO: Remove if/when we are using upstream substrate instead of fork
 [patch."https://github.com/paritytech/polkadot-sdk.git"]
-cumulus-primitives-storage-weight-reclaim = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
-frame-benchmarking = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
-frame-support = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
-frame-system = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
-sc-block-builder = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
-sc-client-db = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
-sc-consensus = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
-sc-consensus-slots = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
-sc-client-api = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
-sc-network = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
-sc-network-common = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
-sc-network-sync = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
-sc-rpc = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
-sc-service = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
-sc-telemetry = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
-sc-transaction-pool = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
-sc-transaction-pool-api = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
-sc-utils = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
-sp-api = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
-sp-application-crypto = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
-sp-arithmetic = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
-sp-block-builder = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
-sp-blockchain = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
-sp-consensus = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
-sp-consensus-slots = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
-sp-core = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
-sp-crypto-hashing = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
-sp-database = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
-sp-debug-derive = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
-sp-externalities = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
-sp-inherents = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
-sp-io = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
-sp-keystore = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
-sp-runtime = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
-sp-runtime-interface = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
-sp-state-machine = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
-sp-std = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
-sp-storage = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
-sp-timestamp = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
-sp-trie = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
-sp-version = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
-sp-weights = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
-staging-xcm = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
-substrate-prometheus-endpoint = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
-xcm-procedural = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c" }
+cumulus-primitives-storage-weight-reclaim = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610" }
+frame-benchmarking = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610" }
+frame-support = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610" }
+frame-system = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610" }
+sc-block-builder = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610" }
+sc-client-db = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610" }
+sc-consensus = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610" }
+sc-consensus-slots = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610" }
+sc-client-api = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610" }
+sc-network = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610" }
+sc-network-common = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610" }
+sc-network-sync = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610" }
+sc-rpc = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610" }
+sc-service = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610" }
+sc-telemetry = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610" }
+sc-transaction-pool = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610" }
+sc-transaction-pool-api = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610" }
+sc-utils = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610" }
+sp-api = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610" }
+sp-application-crypto = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610" }
+sp-arithmetic = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610" }
+sp-block-builder = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610" }
+sp-blockchain = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610" }
+sp-consensus = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610" }
+sp-consensus-slots = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610" }
+sp-core = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610" }
+sp-crypto-hashing = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610" }
+sp-database = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610" }
+sp-debug-derive = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610" }
+sp-externalities = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610" }
+sp-inherents = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610" }
+sp-io = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610" }
+sp-keystore = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610" }
+sp-runtime = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610" }
+sp-runtime-interface = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610" }
+sp-state-machine = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610" }
+sp-std = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610" }
+sp-storage = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610" }
+sp-timestamp = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610" }
+sp-trie = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610" }
+sp-version = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610" }
+sp-weights = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610" }
+staging-xcm = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610" }
+substrate-prometheus-endpoint = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610" }
+xcm-procedural = { git = "https://github.com/autonomys/polkadot-sdk", rev = "962a09e060d0d07dacadca5cd3a2864fb456d610" }
 
 [patch."https://github.com/autonomys/polkadot-sdk.git"]
 # De-duplicate extra copy that comes from Substrate repo
@@ -442,5 +442,5 @@ substrate-bip39 = "=0.6.0"
 
 [patch.crates-io]
 # Patch away `libp2p-identity` in our dependency tree with the git version.
-# For details see: https://github.com/autonomys/rust-libp2p/blob/676c687c2f7a6e92f8f4f77a6934022aec3ba16c/Cargo.toml#L140-L145
-libp2p-identity = { git = "https://github.com/autonomys/rust-libp2p", rev = "676c687c2f7a6e92f8f4f77a6934022aec3ba16c" }
+# For details see: https://github.com/autonomys/rust-libp2p/blob/5be7c854f715da73189a7e7847428bb2af71ccc3/Cargo.toml#L140-L145
+libp2p-identity = { git = "https://github.com/autonomys/rust-libp2p", rev = "5be7c854f715da73189a7e7847428bb2af71ccc3" }


### PR DESCRIPTION
Bumps prometheus-client to 0.25 through libp2p (backport of rust-libp2p#6485).

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
