### PR TITLE
Bump consensus runtime spec_version to 11

### DIFF
--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -131,7 +131,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: Cow::Borrowed("subspace"),
     impl_name: Cow::Borrowed("subspace"),
     authoring_version: 0,
-    spec_version: 10,
+    spec_version: 11,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
Bumps consensus spec_version 10 -> 11 for the runtime release.

The only runtime change since runtime-mainnet-2026-jun-23 is #3888, which prices dynamic storage cost off network-wide credit supply and seeds the transporter storage migration. transaction_version stays 1. The domain runtimes are left alone since the transporter migration is a no-op there.

Dynamic cost of storage is on for mainnet, so this steps the per-byte storage fee up roughly 4.9x at the upgrade block. That's the correction #3888 describes rather than a new fee. Chronos has it off.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
