### PR TITLE
Bump client versions to 0.1.12 and h2 to 0.4.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5335,9 +5335,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14532,7 +14532,7 @@ dependencies = [
 
 [[package]]
 name = "subspace-bootstrap-node"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "clap",
  "futures",
@@ -14630,7 +14630,7 @@ dependencies = [
 
 [[package]]
 name = "subspace-farmer"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "anyhow",
  "async-lock",
@@ -14742,7 +14742,7 @@ dependencies = [
 
 [[package]]
 name = "subspace-gateway"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -14912,7 +14912,7 @@ dependencies = [
 
 [[package]]
 name = "subspace-node"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "auto-id-domain-runtime",
  "bip39",

--- a/crates/subspace-bootstrap-node/Cargo.toml
+++ b/crates/subspace-bootstrap-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subspace-bootstrap-node"
-version = "0.1.11"
+version = "0.1.12"
 authors = [
     "Nazar Mokrynskyi <nazar@mokrynskyi.com>",
     "Shamil Gadelshin <shamilgadelshin@gmail.com>"

--- a/crates/subspace-farmer/Cargo.toml
+++ b/crates/subspace-farmer/Cargo.toml
@@ -2,7 +2,7 @@
 name = "subspace-farmer"
 description = "Farmer for the Subspace Network Blockchain"
 license = "0BSD"
-version = "0.1.11"
+version = "0.1.12"
 authors = ["Nazar Mokrynskyi <nazar@mokrynskyi.com>"]
 edition.workspace = true
 include = [

--- a/crates/subspace-gateway/Cargo.toml
+++ b/crates/subspace-gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subspace-gateway"
-version = "0.1.11"
+version = "0.1.12"
 authors = [
     "Teor <teor@riseup.net>",
     "Shamil Gadelshin <shamilgadelshin@gmail.com>"

--- a/crates/subspace-node/Cargo.toml
+++ b/crates/subspace-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subspace-node"
-version = "0.1.11"
+version = "0.1.12"
 authors = ["Subspace Labs <https://subspace.network>"]
 description = "A Subspace Network Blockchain node."
 edition.workspace = true


### PR DESCRIPTION
Bumping the client version ahead of the chronos release, and h2 to clear RUSTSEC-2026-0258.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
